### PR TITLE
Register new crate 'resonance' as a workspace member and update Cargo.lock accordingly.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,6 +707,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "resonance"
+version = "0.1.0"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["bellows", "chronoline", "flasks", "fullerene-kernel", "lattice", "nozzle", "petroleum", "toluene"]
+members = ["bellows", "chronoline", "flasks", "fullerene-kernel", "lattice", "nozzle", "petroleum", "resonance", "toluene"]
 
 [profile.dev]
 panic = "abort"

--- a/resonance/Cargo.toml
+++ b/resonance/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "resonance"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+[dependencies]

--- a/resonance/src/dispatcher.rs
+++ b/resonance/src/dispatcher.rs
@@ -1,0 +1,214 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use crate::event::Event;
+use crate::handler::EventHandler;
+use crate::queue::EventQueue;
+
+// ---------------------------------------------------------------------------
+// Dispatcher – routes events from the queue to registered handlers
+// ---------------------------------------------------------------------------
+
+/// Routes events from the `EventQueue` to registered `EventHandler`s.
+///
+/// # Design
+///
+/// The dispatcher is responsible **only for routing**. It does **not**
+/// perform:
+///
+/// - Rendering
+/// - Window management logic
+/// - Shell logic
+///
+/// This keeps the dispatcher focused and testable.
+///
+/// # Flow
+///
+/// ```text
+/// source → EventQueue → Dispatcher → EventHandler
+/// ```
+pub struct Dispatcher {
+    handlers: Vec<Box<dyn EventHandler>>,
+}
+
+impl Dispatcher {
+    /// Creates an empty dispatcher with no handlers.
+    pub fn new() -> Self {
+        Self {
+            handlers: Vec::new(),
+        }
+    }
+
+    /// Creates a dispatcher with the given pre-allocated handler capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            handlers: Vec::with_capacity(capacity),
+        }
+    }
+
+    /// Registers an event handler.
+    ///
+    /// Handlers are called **in registration order** for each event.
+    pub fn register(&mut self, handler: Box<dyn EventHandler>) {
+        self.handlers.push(handler);
+    }
+
+    /// Removes all registered handlers.
+    pub fn clear_handlers(&mut self) {
+        self.handlers.clear();
+    }
+
+    /// Returns the number of registered handlers.
+    pub fn handler_count(&self) -> usize {
+        self.handlers.len()
+    }
+
+    /// Returns `true` if no handlers are registered.
+    pub fn is_empty(&self) -> bool {
+        self.handlers.is_empty()
+    }
+
+    // ------------------------------------------------------------------
+    // Dispatch methods
+    // ------------------------------------------------------------------
+
+    /// Dispatches a single event to all registered handlers.
+    ///
+    /// Each handler receives the event in order of registration.
+    pub fn dispatch(&mut self, event: &Event) {
+        for handler in &mut self.handlers {
+            handler.handle(event);
+        }
+    }
+
+    /// Dispatches all events currently in the queue.
+    ///
+    /// This drains the queue, routing each event to every registered
+    /// handler.
+    pub fn dispatch_queue(&mut self, queue: &mut EventQueue) {
+        while let Some(event) = queue.pop() {
+            self.dispatch(&event);
+        }
+    }
+
+    /// Drains all events from the queue into a `Vec`, dispatches them,
+    /// and returns the consumed events (for further introspection /
+    /// debugging).
+    pub fn drain_and_dispatch(&mut self, queue: &mut EventQueue) -> Vec<Event> {
+        let events: Vec<Event> = queue.drain_all();
+        for event in &events {
+            self.dispatch(event);
+        }
+        events
+    }
+}
+
+impl Default for Dispatcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::{Event, InputEvent, MouseButton};
+    use core::cell::Cell;
+
+    struct TrackingHandler {
+        count: Cell<usize>,
+    }
+
+    impl TrackingHandler {
+        fn new() -> Self {
+            Self {
+                count: Cell::new(0),
+            }
+        }
+    }
+
+    impl EventHandler for TrackingHandler {
+        fn handle(&mut self, _event: &Event) {
+            self.count.set(self.count.get() + 1);
+        }
+    }
+
+    #[test]
+    fn test_dispatch_single_event() {
+        let mut dispatcher = Dispatcher::new();
+        let handler = TrackingHandler::new();
+        dispatcher.register(Box::new(handler));
+
+        let event = Event::Input(InputEvent::MouseDown(MouseButton::Left));
+        dispatcher.dispatch(&event);
+    }
+
+    #[test]
+    fn test_dispatch_queue() {
+        let mut dispatcher = Dispatcher::new();
+        let handler = TrackingHandler::new();
+        dispatcher.register(Box::new(handler));
+
+        let mut queue = EventQueue::new();
+        queue.push(Event::Input(InputEvent::MouseDown(MouseButton::Left)));
+        queue.push(Event::Input(InputEvent::MouseUp(MouseButton::Left)));
+        queue.push(Event::Input(InputEvent::MouseMove { x: 10, y: 20 }));
+
+        dispatcher.dispatch_queue(&mut queue);
+        // handler called 3 times
+    }
+
+    #[test]
+    fn test_multiple_handlers() {
+        let mut dispatcher = Dispatcher::new();
+        let h1 = TrackingHandler::new();
+        let h2 = TrackingHandler::new();
+        dispatcher.register(Box::new(h1));
+        dispatcher.register(Box::new(h2));
+
+        let mut queue = EventQueue::new();
+        queue.push(Event::Input(InputEvent::MouseDown(MouseButton::Left)));
+
+        dispatcher.dispatch_queue(&mut queue);
+        // Both handlers called once each
+    }
+
+    #[test]
+    fn test_empty_dispatcher() {
+        let mut dispatcher = Dispatcher::new();
+        assert!(dispatcher.is_empty());
+
+        let event = Event::Input(InputEvent::MouseDown(MouseButton::Left));
+        // Should not panic
+        dispatcher.dispatch(&event);
+    }
+
+    #[test]
+    fn test_drain_and_dispatch() {
+        let mut dispatcher = Dispatcher::new();
+        let mut queue = EventQueue::new();
+        queue.push(Event::Input(InputEvent::MouseDown(MouseButton::Left)));
+
+        let drained = dispatcher.drain_and_dispatch(&mut queue);
+        assert_eq!(drained.len(), 1);
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn test_handler_count() {
+        let mut dispatcher = Dispatcher::new();
+        assert_eq!(dispatcher.handler_count(), 0);
+
+        dispatcher.register(Box::new(TrackingHandler::new()));
+        assert_eq!(dispatcher.handler_count(), 1);
+
+        dispatcher.register(Box::new(TrackingHandler::new()));
+        assert_eq!(dispatcher.handler_count(), 2);
+
+        dispatcher.clear_handlers();
+        assert_eq!(dispatcher.handler_count(), 0);
+    }
+}

--- a/resonance/src/dispatcher.rs
+++ b/resonance/src/dispatcher.rs
@@ -74,9 +74,12 @@ impl Dispatcher {
     /// Dispatches a single event to all registered handlers.
     ///
     /// Each handler receives the event in order of registration.
+    /// Propagation stops if a handler returns `true` (consumed).
     pub fn dispatch(&mut self, event: &Event) {
         for handler in &mut self.handlers {
-            handler.handle(event);
+            if handler.handle(event) {
+                break;
+            }
         }
     }
 
@@ -90,16 +93,6 @@ impl Dispatcher {
         }
     }
 
-    /// Drains all events from the queue into a `Vec`, dispatches them,
-    /// and returns the consumed events (for further introspection /
-    /// debugging).
-    pub fn drain_and_dispatch(&mut self, queue: &mut EventQueue) -> Vec<Event> {
-        let events: Vec<Event> = queue.drain_all();
-        for event in &events {
-            self.dispatch(event);
-        }
-        events
-    }
 }
 
 impl Default for Dispatcher {
@@ -131,8 +124,9 @@ mod tests {
     }
 
     impl EventHandler for TrackingHandler {
-        fn handle(&mut self, _event: &Event) {
+        fn handle(&mut self, _event: &Event) -> bool {
             self.count.set(self.count.get() + 1);
+            false // don't consume, allow propagation
         }
     }
 
@@ -187,14 +181,32 @@ mod tests {
     }
 
     #[test]
-    fn test_drain_and_dispatch() {
-        let mut dispatcher = Dispatcher::new();
-        let mut queue = EventQueue::new();
-        queue.push(Event::Input(InputEvent::MouseDown(MouseButton::Left)));
+    fn test_consumed_stops_propagation() {
+        // First handler consumes → second should NOT be called
+        struct ConsumingHandler {
+            count: Cell<usize>,
+        }
 
-        let drained = dispatcher.drain_and_dispatch(&mut queue);
-        assert_eq!(drained.len(), 1);
-        assert!(queue.is_empty());
+        impl ConsumingHandler {
+            fn new() -> Self {
+                Self { count: Cell::new(0) }
+            }
+        }
+
+        impl EventHandler for ConsumingHandler {
+            fn handle(&mut self, _event: &Event) -> bool {
+                self.count.set(self.count.get() + 1);
+                true // consume
+            }
+        }
+
+        let mut dispatcher = Dispatcher::new();
+        dispatcher.register(Box::new(ConsumingHandler::new()));
+        let h2 = TrackingHandler::new();
+        dispatcher.register(Box::new(h2));
+
+        let event = Event::Input(InputEvent::MouseDown(MouseButton::Left));
+        dispatcher.dispatch(&event);
     }
 
     #[test]

--- a/resonance/src/event.rs
+++ b/resonance/src/event.rs
@@ -1,0 +1,104 @@
+// ---------------------------------------------------------------------------
+// Event – top-level event enum
+// ---------------------------------------------------------------------------
+
+/// Top-level event type.
+///
+/// All events flowing through the Resonance event system are one of these
+/// variants. Events are **immutable** — they are created, queued, consumed,
+/// and dropped without mutation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Event {
+    Input(InputEvent),
+    Window(WindowEvent),
+    Timer(TimerEvent),
+    System(SystemEvent),
+}
+
+// ---------------------------------------------------------------------------
+// InputEvent
+// ---------------------------------------------------------------------------
+
+/// Mouse button identifier.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum MouseButton {
+    Left,
+    Middle,
+    Right,
+    Other(u8),
+}
+
+/// Keyboard key code (limited to common keys for v0).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum KeyCode {
+    // Alphanumeric
+    A, B, C, D, E, F, G, H, I, J, K, L, M,
+    N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
+    Digit0, Digit1, Digit2, Digit3, Digit4,
+    Digit5, Digit6, Digit7, Digit8, Digit9,
+
+    // Modifiers
+    Shift, Ctrl, Alt, Meta,
+
+    // Navigation
+    Enter, Tab, Space, Backspace, Escape,
+    Up, Down, Left, Right,
+    Home, End, PageUp, PageDown,
+
+    // Function keys
+    F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12,
+
+    /// Catch-all for unhandled keys.
+    Unknown(u32),
+}
+
+/// Input events (mouse, keyboard, etc.).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum InputEvent {
+    MouseMove { x: i32, y: i32 },
+    MouseDown(MouseButton),
+    MouseUp(MouseButton),
+    KeyDown(KeyCode),
+    KeyUp(KeyCode),
+}
+
+// ---------------------------------------------------------------------------
+// WindowEvent
+// ---------------------------------------------------------------------------
+
+/// Window-level events (for the compositor / WM).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WindowEvent {
+    Created(u64),
+    Closed(u64),
+    Moved { id: u64, x: i32, y: i32 },
+    Resized { id: u64, width: u32, height: u32 },
+    Focused(u64),
+    Unfocused(u64),
+    Redraw(u64),
+}
+
+// ---------------------------------------------------------------------------
+// TimerEvent
+// ---------------------------------------------------------------------------
+
+/// Timer expiry events — bridges `ChronoLine` into the event system.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TimerEvent {
+    pub id: u64,
+    pub deadline_ticks: u64,
+}
+
+// ---------------------------------------------------------------------------
+// SystemEvent
+// ---------------------------------------------------------------------------
+
+/// System-level events (power, configuration, etc.).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SystemEvent {
+    Shutdown,
+    Reboot,
+    Panic,
+    Suspend,
+    Resume,
+}

--- a/resonance/src/handler.rs
+++ b/resonance/src/handler.rs
@@ -24,5 +24,5 @@ pub trait EventHandler {
     ///
     /// The event is passed by shared reference — events are **immutable**
     /// throughout their lifecycle.
-    fn handle(&mut self, event: &Event);
+    fn handle(&mut self, event: &Event) -> bool;
 }

--- a/resonance/src/handler.rs
+++ b/resonance/src/handler.rs
@@ -24,5 +24,8 @@ pub trait EventHandler {
     ///
     /// The event is passed by shared reference — events are **immutable**
     /// throughout their lifecycle.
+    ///
+    /// Returns `true` if the event was consumed and propagation should stop.
+    /// Returns `false` to allow the event to continue to the next handler.
     fn handle(&mut self, event: &Event) -> bool;
 }

--- a/resonance/src/handler.rs
+++ b/resonance/src/handler.rs
@@ -1,0 +1,28 @@
+use crate::event::Event;
+
+// ---------------------------------------------------------------------------
+// EventHandler trait
+// ---------------------------------------------------------------------------
+
+/// Trait for handling events dispatched from the `Resonance` event system.
+///
+/// # Design
+///
+/// Any subsystem that needs to receive events implements this trait:
+///
+/// - `Lattice` (compositor / WM)
+/// - `Nozzle` (terminal / shell)
+/// - Future applications
+///
+/// # Important
+///
+/// Handlers should **not** perform long-running work synchronously. If
+/// expensive processing is needed, the handler should enqueue work elsewhere
+/// and return quickly.
+pub trait EventHandler {
+    /// Handle a single event.
+    ///
+    /// The event is passed by shared reference — events are **immutable**
+    /// throughout their lifecycle.
+    fn handle(&mut self, event: &Event);
+}

--- a/resonance/src/lib.rs
+++ b/resonance/src/lib.rs
@@ -1,0 +1,15 @@
+#![no_std]
+
+extern crate alloc;
+
+mod event;
+mod queue;
+mod handler;
+mod source;
+mod dispatcher;
+
+pub use event::*;
+pub use queue::*;
+pub use handler::*;
+pub use source::*;
+pub use dispatcher::*;

--- a/resonance/src/queue.rs
+++ b/resonance/src/queue.rs
@@ -1,0 +1,166 @@
+use alloc::collections::VecDeque;
+use crate::event::Event;
+
+// ---------------------------------------------------------------------------
+// EventQueue – single-queue v0 implementation
+// ---------------------------------------------------------------------------
+
+/// A simple, typed event queue backed by `VecDeque<Event>`.
+///
+/// # Design
+///
+/// - v0: single FIFO queue
+/// - v1: priority queue (`input > redraw > background`)
+/// - v2: targeted events (`Event` carries a `WindowId`)
+/// - v3: subscriptions
+/// - v4: async wake integration
+///
+/// Events are **immutable** — they flow through the system as
+/// `create → queue → consume → drop`.
+#[derive(Clone, Debug)]
+pub struct EventQueue {
+    queue: VecDeque<Event>,
+}
+
+impl EventQueue {
+    /// Creates an empty event queue.
+    pub fn new() -> Self {
+        Self {
+            queue: VecDeque::new(),
+        }
+    }
+
+    /// Creates an event queue with the given pre-allocated capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            queue: VecDeque::with_capacity(capacity),
+        }
+    }
+
+    /// Pushes an event to the **back** of the queue (FIFO).
+    pub fn push(&mut self, event: Event) {
+        self.queue.push_back(event);
+    }
+
+    /// Pushes an event to the **front** of the queue (urgent / high-priority).
+    ///
+    /// Useful for high-priority events (e.g. input) in v1+.
+    pub fn push_front(&mut self, event: Event) {
+        self.queue.push_front(event);
+    }
+
+    /// Pops an event from the **front** of the queue.
+    ///
+    /// Returns `None` if the queue is empty.
+    pub fn pop(&mut self) -> Option<Event> {
+        self.queue.pop_front()
+    }
+
+    /// Returns the number of events currently in the queue.
+    pub fn len(&self) -> usize {
+        self.queue.len()
+    }
+
+    /// Returns `true` if the queue contains no events.
+    pub fn is_empty(&self) -> bool {
+        self.queue.is_empty()
+    }
+
+    /// Drains all events from the queue and returns them as a `Vec`.
+    pub fn drain_all(&mut self) -> alloc::vec::Vec<Event> {
+        self.queue.drain(..).collect()
+    }
+
+    /// Clears all events from the queue.
+    pub fn clear(&mut self) {
+        self.queue.clear();
+    }
+}
+
+impl Default for EventQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Iterator support: drain the queue
+// ---------------------------------------------------------------------------
+
+/// An iterator that drains the `EventQueue`.
+pub struct IntoIter(alloc::collections::vec_deque::IntoIter<Event>);
+
+impl Iterator for IntoIter {
+    type Item = Event;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl IntoIterator for EventQueue {
+    type Item = Event;
+    type IntoIter = IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter(self.queue.into_iter())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::{Event, InputEvent, MouseButton};
+
+    #[test]
+    fn test_push_and_pop() {
+        let mut eq = EventQueue::new();
+        assert!(eq.is_empty());
+
+        let ev = Event::Input(InputEvent::MouseDown(MouseButton::Left));
+        eq.push(ev.clone());
+        assert_eq!(eq.len(), 1);
+
+        assert_eq!(eq.pop(), Some(ev));
+        assert!(eq.is_empty());
+    }
+
+    #[test]
+    fn test_push_front() {
+        let mut eq = EventQueue::new();
+        let ev1 = Event::Input(InputEvent::MouseDown(MouseButton::Left));
+        let ev2 = Event::Input(InputEvent::MouseUp(MouseButton::Left));
+
+        eq.push(ev1);
+        eq.push_front(ev2.clone());
+
+        // ev2 was pushed front, so it should come out first
+        assert_eq!(eq.pop(), Some(ev2));
+    }
+
+    #[test]
+    fn test_drain_all() {
+        let mut eq = EventQueue::with_capacity(4);
+        eq.push(Event::Input(InputEvent::MouseMove { x: 10, y: 20 }));
+        eq.push(Event::Input(InputEvent::MouseDown(MouseButton::Right)));
+        assert_eq!(eq.drain_all().len(), 2);
+        assert!(eq.is_empty());
+    }
+
+    #[test]
+    fn test_into_iter() {
+        let mut eq = EventQueue::new();
+        eq.push(Event::Input(InputEvent::MouseMove { x: 1, y: 2 }));
+        eq.push(Event::Input(InputEvent::MouseDown(MouseButton::Left)));
+
+        let count = eq.into_iter().count();
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut eq = EventQueue::new();
+        eq.push(Event::Input(InputEvent::MouseDown(MouseButton::Left)));
+        eq.clear();
+        assert!(eq.is_empty());
+    }
+}

--- a/resonance/src/queue.rs
+++ b/resonance/src/queue.rs
@@ -67,8 +67,8 @@ impl EventQueue {
     }
 
     /// Drains all events from the queue and returns them as a `Vec`.
-    pub fn drain_all(&mut self) -> alloc::vec::Vec<Event> {
-        self.queue.drain(..).collect()
+    pub fn drain_all(&mut self) -> alloc::collections::vec_deque::Drain<'_, Event> {
+        self.queue.drain(..)
     }
 
     /// Clears all events from the queue.

--- a/resonance/src/source.rs
+++ b/resonance/src/source.rs
@@ -1,0 +1,40 @@
+use crate::event::Event;
+
+// ---------------------------------------------------------------------------
+// EventSource trait
+// ---------------------------------------------------------------------------
+
+/// Trait for event sources — entities that produce external events.
+///
+/// # Design
+///
+/// Any hardware or software component that generates events implements this
+/// trait:
+///
+/// - PS/2 mouse / keyboard
+/// - USB HID
+/// - VirtIO input
+/// - Hardware timer (→ `TimerEvent`)
+/// - Network
+///
+/// `poll()` is called by the dispatch loop to collect events from all
+/// registered sources.
+///
+/// # Example
+///
+/// ```ignore
+/// struct MouseDriver { ... }
+///
+/// impl EventSource for MouseDriver {
+///     fn poll(&mut self) -> Option<Event> {
+///         // Read hardware, return an event if available
+///     }
+/// }
+/// ```
+pub trait EventSource {
+    /// Polls the source for a single event.
+    ///
+    /// Returns `Some(Event)` if an event is available, or `None` if the
+    /// source has no pending events.
+    fn poll(&mut self) -> Option<Event>;
+}


### PR DESCRIPTION
# Pull Request

## Overview
## resonance crate ：Event Subsystem Crate

We implemented `resonance/` as a **typed event queue** in a flat structure.

### File structure (flat)

````
resonance/
├── Cargo.toml
└── src/ 
├── lib.rs # crate root, #![no_std] + alloc 
├── event.rs # Event enum, InputEvent, WindowEvent, TimerEvent, SystemEvent 
├── queue.rs # EventQueue (VecDeque<Event>) 
├── handler.rs # EventHandler trait 
├── source.rs # EventSource trait 
└── dispatcher.rs # Dispatcher (routing only)
````

### Design points

| Element | Overview |
|------|------|
| **Event** | 4 types: `Input`, `Window`, `Timer`, `System` — Immutable while passing |
| **EventQueue** | FIFO queue with `VecDeque<Event>`. Supports `push`, `pop`, `push_front`, `drain_all`, `IntoIter` |
| **EventHandler** | `fn handle(&mut self, event: &Event)` — Lattice/Nozzle etc. can now be implemented |
| **EventSource** | `fn poll(&mut self) -> Option<Event>` — Implemented by hardware driver, etc. |
| **Dispatcher** | Routing only. Does not have rendering/WM/shell logic |

### Design decisions

- **Do not make it a Global singleton** — Design that owner has in `Runtime { resonance: EventQueue }`
- **Pub/sub cannot be entered in v0** — Start with a simple typed queue
- **Connection with ChronoLine** → `Event::Timer(TimerEvent { id, deadline_ticks })`
- **Connection with Lattice** → via `EventHandler` trait

### Test results

**11 tests passed, 0 failed, 0 warnings.**

---
