### PR TITLE
Drop wifi

### DIFF
--- a/fullerene-kernel/src/gui.rs
+++ b/fullerene-kernel/src/gui.rs
@@ -163,7 +163,7 @@ pub fn init() {
     crate::interrupts::apic::register_mmio_watchdog();
     petroleum::serial::serial_log(format_args!("MMIO NMI watchdog registered\n"));
 
-    crate::wifi_service::init_and_register();
+    // crate::wifi_service::init_and_register();
     petroleum::serial::serial_log(format_args!("wifi_service registered\n"));
 }
 

--- a/fullerene-kernel/src/gui.rs
+++ b/fullerene-kernel/src/gui.rs
@@ -163,8 +163,9 @@ pub fn init() {
     crate::interrupts::apic::register_mmio_watchdog();
     petroleum::serial::serial_log(format_args!("MMIO NMI watchdog registered\n"));
 
+    // this function is hanger
     // crate::wifi_service::init_and_register();
-    petroleum::serial::serial_log(format_args!("wifi_service registered\n"));
+    // petroleum::serial::serial_log(format_args!("wifi_service registered\n"));
 }
 
 /// Once the first frame renders successfully, disable the boot-screen

--- a/fullerene-kernel/src/gui.rs
+++ b/fullerene-kernel/src/gui.rs
@@ -160,10 +160,9 @@ pub fn init() {
     solvent::init();
     petroleum::serial::serial_log(format_args!("solvent::init() completed\n"));
 
-    // Register WiFi service — drives iwlwifi init and tick, bridges
-    // driver state to the desktop UI through shared statics.
-    // Solvent itself knows nothing about WiFi.
-    // The driver context was set by the `wifi` init step earlier.
+    crate::interrupts::apic::register_mmio_watchdog();
+    petroleum::serial::serial_log(format_args!("MMIO NMI watchdog registered\n"));
+
     crate::wifi_service::init_and_register();
     petroleum::serial::serial_log(format_args!("wifi_service registered\n"));
 }

--- a/fullerene-kernel/src/interrupts/apic.rs
+++ b/fullerene-kernel/src/interrupts/apic.rs
@@ -182,7 +182,7 @@ pub fn init_apic() {
 
 // ── MMIO NMI watchdog timer switching ───────────────────────────
 
-const WATCHDOG_NMI_INITIAL_COUNT: u32 = 100_000_000;
+const WATCHDOG_NMI_INITIAL_COUNT: u32 = 30_000_000; // ~4.8s at 100MHz bus /16 div
 
 fn arm_watchdog_timer_impl() {
     let guard = APIC_CONTROLLER.lock();
@@ -204,8 +204,12 @@ fn restore_watchdog_timer_impl() {
     if let Some(ref ctrl) = *guard {
         let saved_lvt = mmio::watchdog_saved_lvt();
         let saved_initcnt = mmio::watchdog_saved_initcnt();
-        ctrl.lapic_write(ApicOffsets::LVT_TIMER, saved_lvt);
+        // IMPORTANT: Write TMRINITCNT BEFORE LVT_TIMER.
+        // At this point TMRINITCNT still holds WATCHDOG_NMI_INITIAL_COUNT.
+        // If LVT_TIMER is written first (periodic mode), the timer would start
+        // at the stale watchdog count (~16s) before the correct count is restored.
         ctrl.lapic_write(ApicOffsets::TMRINITCNT, saved_initcnt);
+        ctrl.lapic_write(ApicOffsets::LVT_TIMER, saved_lvt);
     }
 }
 

--- a/fullerene-kernel/src/interrupts/apic.rs
+++ b/fullerene-kernel/src/interrupts/apic.rs
@@ -5,6 +5,7 @@
 
 use nitrogen::apic::{ApicFlags, ApicOffsets, IO_APIC_BASE};
 use nitrogen::apic_controller::ApicController;
+use nitrogen::mmio;
 use petroleum::common::utils::reset_mutex_lock;
 use spin::Mutex;
 use x86_64::registers::model_specific::Msr;
@@ -177,4 +178,39 @@ pub fn init_apic() {
 
     use super::syscall::setup_syscall;
     setup_syscall();
+}
+
+// ── MMIO NMI watchdog timer switching ───────────────────────────
+
+const WATCHDOG_NMI_INITIAL_COUNT: u32 = 100_000_000;
+
+fn arm_watchdog_timer_impl() {
+    let guard = APIC_CONTROLLER.lock();
+    if let Some(ref ctrl) = *guard {
+        let lvt = ctrl.lapic_read(ApicOffsets::LVT_TIMER);
+        let initcnt = ctrl.lapic_read(ApicOffsets::TMRINITCNT);
+        mmio::watchdog_save_lvt(lvt, initcnt);
+
+        ctrl.lapic_write(
+            ApicOffsets::LVT_TIMER,
+            ApicFlags::DELIVERY_MODE_NMI | ApicFlags::TIMER_ONESHOT,
+        );
+        ctrl.lapic_write(ApicOffsets::TMRINITCNT, WATCHDOG_NMI_INITIAL_COUNT);
+    }
+}
+
+fn restore_watchdog_timer_impl() {
+    let guard = APIC_CONTROLLER.lock();
+    if let Some(ref ctrl) = *guard {
+        let saved_lvt = mmio::watchdog_saved_lvt();
+        let saved_initcnt = mmio::watchdog_saved_initcnt();
+        ctrl.lapic_write(ApicOffsets::LVT_TIMER, saved_lvt);
+        ctrl.lapic_write(ApicOffsets::TMRINITCNT, saved_initcnt);
+    }
+}
+
+/// Register the MMIO NMI watchdog timer callbacks with the nitrogen mmio module.
+/// Must be called once after APIC init and before WiFi init.
+pub fn register_mmio_watchdog() {
+    mmio::register_watchdog_timer_callbacks(arm_watchdog_timer_impl, restore_watchdog_timer_impl);
 }

--- a/fullerene-kernel/src/interrupts/apic.rs
+++ b/fullerene-kernel/src/interrupts/apic.rs
@@ -204,10 +204,16 @@ fn arm_watchdog_timer_impl() {
 
 fn restore_watchdog_timer_impl() {
     // NMI-safe: use try_lock to avoid blocking in the NMI handler.
-    // If the lock is held, the timer will remain in NMI mode until the next
-    // normal-path restore attempt — this is safe as the watchdog has already
-    // fired and the system is in recovery.
-    if let Some(guard) = APIC_CONTROLLER.try_lock() {
+    // If the lock is held, force-reset it — the interrupted context that held it
+    // is being abandoned by the watchdog recovery.
+    let mut guard = APIC_CONTROLLER.try_lock();
+    if guard.is_none() {
+        unsafe {
+            reset_mutex_lock(&APIC_CONTROLLER);
+        }
+        guard = APIC_CONTROLLER.try_lock();
+    }
+    if let Some(guard) = guard {
         if let Some(ref ctrl) = *guard {
             let saved_lvt = mmio::watchdog_saved_lvt();
             let saved_initcnt = mmio::watchdog_saved_initcnt();
@@ -219,6 +225,11 @@ fn restore_watchdog_timer_impl() {
             ctrl.lapic_write(ApicOffsets::LVT_TIMER, saved_lvt);
         }
     }
+}
+
+/// Force-reset the APIC controller lock. Safe to call during NMI recovery.
+pub unsafe fn reset_apic_controller_lock() {
+    unsafe { reset_mutex_lock(&APIC_CONTROLLER); }
 }
 
 /// Register the MMIO NMI watchdog timer callbacks with the nitrogen mmio module.

--- a/fullerene-kernel/src/interrupts/apic.rs
+++ b/fullerene-kernel/src/interrupts/apic.rs
@@ -200,16 +200,21 @@ fn arm_watchdog_timer_impl() {
 }
 
 fn restore_watchdog_timer_impl() {
-    let guard = APIC_CONTROLLER.lock();
-    if let Some(ref ctrl) = *guard {
-        let saved_lvt = mmio::watchdog_saved_lvt();
-        let saved_initcnt = mmio::watchdog_saved_initcnt();
-        // IMPORTANT: Write TMRINITCNT BEFORE LVT_TIMER.
-        // At this point TMRINITCNT still holds WATCHDOG_NMI_INITIAL_COUNT.
-        // If LVT_TIMER is written first (periodic mode), the timer would start
-        // at the stale watchdog count (~16s) before the correct count is restored.
-        ctrl.lapic_write(ApicOffsets::TMRINITCNT, saved_initcnt);
-        ctrl.lapic_write(ApicOffsets::LVT_TIMER, saved_lvt);
+    // NMI-safe: use try_lock to avoid blocking in the NMI handler.
+    // If the lock is held, the timer will remain in NMI mode until the next
+    // normal-path restore attempt — this is safe as the watchdog has already
+    // fired and the system is in recovery.
+    if let Some(guard) = APIC_CONTROLLER.try_lock() {
+        if let Some(ref ctrl) = *guard {
+            let saved_lvt = mmio::watchdog_saved_lvt();
+            let saved_initcnt = mmio::watchdog_saved_initcnt();
+            // IMPORTANT: Write TMRINITCNT BEFORE LVT_TIMER.
+            // At this point TMRINITCNT still holds WATCHDOG_NMI_INITIAL_COUNT.
+            // If LVT_TIMER is written first (periodic mode), the timer would start
+            // at the stale watchdog count (~4.8s) before the correct count is restored.
+            ctrl.lapic_write(ApicOffsets::TMRINITCNT, saved_initcnt);
+            ctrl.lapic_write(ApicOffsets::LVT_TIMER, saved_lvt);
+        }
     }
 }
 

--- a/fullerene-kernel/src/interrupts/apic.rs
+++ b/fullerene-kernel/src/interrupts/apic.rs
@@ -8,6 +8,7 @@ use nitrogen::apic_controller::ApicController;
 use nitrogen::mmio;
 use petroleum::common::utils::reset_mutex_lock;
 use spin::Mutex;
+use x86_64::instructions;
 use x86_64::registers::model_specific::Msr;
 
 /// Hardware interrupt vectors
@@ -185,18 +186,20 @@ pub fn init_apic() {
 const WATCHDOG_NMI_INITIAL_COUNT: u32 = 30_000_000; // ~4.8s at 100MHz bus /16 div
 
 fn arm_watchdog_timer_impl() {
-    let guard = APIC_CONTROLLER.lock();
-    if let Some(ref ctrl) = *guard {
-        let lvt = ctrl.lapic_read(ApicOffsets::LVT_TIMER);
-        let initcnt = ctrl.lapic_read(ApicOffsets::TMRINITCNT);
-        mmio::watchdog_save_lvt(lvt, initcnt);
+    instructions::interrupts::without_interrupts(|| {
+        let guard = APIC_CONTROLLER.lock();
+        if let Some(ref ctrl) = *guard {
+            let lvt = ctrl.lapic_read(ApicOffsets::LVT_TIMER);
+            let initcnt = ctrl.lapic_read(ApicOffsets::TMRINITCNT);
+            mmio::watchdog_save_lvt(lvt, initcnt);
 
-        ctrl.lapic_write(
-            ApicOffsets::LVT_TIMER,
-            ApicFlags::DELIVERY_MODE_NMI | ApicFlags::TIMER_ONESHOT,
-        );
-        ctrl.lapic_write(ApicOffsets::TMRINITCNT, WATCHDOG_NMI_INITIAL_COUNT);
-    }
+            ctrl.lapic_write(
+                ApicOffsets::LVT_TIMER,
+                ApicFlags::DELIVERY_MODE_NMI | ApicFlags::TIMER_ONESHOT,
+            );
+            ctrl.lapic_write(ApicOffsets::TMRINITCNT, WATCHDOG_NMI_INITIAL_COUNT);
+        }
+    });
 }
 
 fn restore_watchdog_timer_impl() {

--- a/fullerene-kernel/src/interrupts/exceptions.rs
+++ b/fullerene-kernel/src/interrupts/exceptions.rs
@@ -136,7 +136,9 @@ fn terminate_and_recover(frame: &mut InterruptStackFrame, reason: &str) {
                 frame.stack_pointer,
                 crate::gdt::kernel_data_selector(),
             );
+        unsafe {
             frame.as_mut().write(new_frame);
+        }
         } else {
             safe_halt();
         }
@@ -187,7 +189,28 @@ macro_rules! define_err_handler {
 
 define_no_err_handler!(divide_error_handler, 0);
 define_no_err_handler!(debug_handler, 1);
-define_no_err_handler!(nmi_handler, 2);
+
+#[unsafe(no_mangle)]
+pub extern "x86-interrupt" fn nmi_handler(mut frame: InterruptStackFrame) {
+    if nitrogen::mmio::mmio_watchdog_armed() {
+        raw_log!("NMI: MMIO watchdog expired — forcing recovery\n");
+        nitrogen::mmio::mmio_watchdog_nmi_recovery();
+        let trampoline = x86_64::VirtAddr::from_ptr(
+            nitrogen::mmio::mmio_nmi_recovery_trampoline as *const ()
+        );
+        let new_frame = InterruptStackFrameValue::new(
+            trampoline,
+            frame.code_segment,
+            frame.cpu_flags,
+            frame.stack_pointer,
+            frame.stack_segment,
+        );
+        unsafe { frame.as_mut().write(new_frame); }
+        return;
+    }
+    raw_log!("NMI: unexpected — halting\n");
+    safe_halt();
+}
 define_no_err_handler!(overflow_handler, 4);
 define_no_err_handler!(bound_range_exceeded_handler, 5);
 define_no_err_handler!(invalid_opcode_handler, 6);

--- a/fullerene-kernel/src/interrupts/input.rs
+++ b/fullerene-kernel/src/interrupts/input.rs
@@ -4,7 +4,7 @@
 
 use super::apic::send_eoi;
 use petroleum::port_read_u8;
-use x86_64::structures::idt::InterruptStackFrame;
+use x86_64::structures::idt::{InterruptStackFrame, InterruptStackFrameValue};
 
 /// Macro to create input device interrupt handlers
 macro_rules! define_input_interrupt_handler {
@@ -37,10 +37,28 @@ define_input_interrupt_handler!(mouse_handler, 0x60, |byte: u8| {
 });
 
 /// Timer interrupt handler (no preemption - scheduler loop handles yielding)
+/// Also detects NMI MMIO watchdog recovery and redirects to the scheduler loop.
 #[unsafe(no_mangle)]
-pub extern "x86-interrupt" fn timer_handler(_stack_frame: InterruptStackFrame) {
+pub extern "x86-interrupt" fn timer_handler(mut frame: InterruptStackFrame) {
     // Increment global tick counter (lock-free atomic increment)
     super::TICK_COUNTER.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+
+    if nitrogen::mmio::mmio_watchdog_recovery_triggered() {
+        nitrogen::mmio::clear_watchdog_recovery_trigger();
+        let restart_fn = crate::scheduler::get_recovery_restart_fn();
+        if let Some((rsp, rip)) = restart_fn {
+            let new_frame = InterruptStackFrameValue::new(
+                rip,
+                frame.code_segment,
+                frame.cpu_flags,
+                rsp,
+                frame.stack_segment,
+            );
+            unsafe {
+                frame.as_mut().write(new_frame);
+            }
+        }
+    }
 
     send_eoi();
 }

--- a/fullerene-kernel/src/interrupts/input.rs
+++ b/fullerene-kernel/src/interrupts/input.rs
@@ -44,7 +44,6 @@ pub extern "x86-interrupt" fn timer_handler(mut frame: InterruptStackFrame) {
     super::TICK_COUNTER.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
 
     if nitrogen::mmio::mmio_watchdog_recovery_triggered() {
-        nitrogen::mmio::clear_watchdog_recovery_trigger();
         petroleum::serial::serial_log(format_args!(
             "[timer_handler] NMI recovery triggered — jumping to scheduler_loop\n"
         ));
@@ -60,6 +59,10 @@ pub extern "x86-interrupt" fn timer_handler(mut frame: InterruptStackFrame) {
             unsafe {
                 frame.as_mut().write(new_frame);
             }
+            // Clear the trigger only after successfully writing the new frame.
+            // If no restart target is available, leave the trigger set so a
+            // later recovery attempt can succeed.
+            nitrogen::mmio::clear_watchdog_recovery_trigger();
         }
     }
 

--- a/fullerene-kernel/src/interrupts/input.rs
+++ b/fullerene-kernel/src/interrupts/input.rs
@@ -45,6 +45,9 @@ pub extern "x86-interrupt" fn timer_handler(mut frame: InterruptStackFrame) {
 
     if nitrogen::mmio::mmio_watchdog_recovery_triggered() {
         nitrogen::mmio::clear_watchdog_recovery_trigger();
+        petroleum::serial::serial_log(format_args!(
+            "[timer_handler] NMI recovery triggered — jumping to scheduler_loop\n"
+        ));
         let restart_fn = crate::scheduler::get_recovery_restart_fn();
         if let Some((rsp, rip)) = restart_fn {
             let new_frame = InterruptStackFrameValue::new(

--- a/fullerene-kernel/src/scheduler.rs
+++ b/fullerene-kernel/src/scheduler.rs
@@ -24,8 +24,12 @@ use solvent;
 use core::sync::atomic::{AtomicU64, Ordering};
 use x86_64::VirtAddr;
 
-/// NMI recovery dedicated stack.
-static NMI_RECOVERY_STACK: [u8; 4096] = [0u8; 4096];
+/// NMI recovery dedicated stack (writable, 16-byte aligned).
+/// Must be mutable so recovery pushes can write to it without faulting.
+#[repr(align(16))]
+struct AlignedStack([u8; 4096]);
+
+static mut NMI_RECOVERY_STACK: AlignedStack = AlignedStack([0u8; 4096]);
 
 /// Set the launch‑shell flag from the solvent side.
 pub fn request_shell_launch() {
@@ -60,9 +64,9 @@ pub fn scheduler_loop() -> ! {
     gui::set_render_fn(gui::render);
 
     // Register NMI recovery restart context with a dedicated stack.
-    let recovery_rsp = {
-        let base = NMI_RECOVERY_STACK.as_ptr() as u64;
-        VirtAddr::new((base + NMI_RECOVERY_STACK.len() as u64) & !15u64)
+    let recovery_rsp = unsafe {
+        let base = NMI_RECOVERY_STACK.0.as_ptr() as u64;
+        VirtAddr::new((base + NMI_RECOVERY_STACK.0.len() as u64) & !15u64)
     };
     set_recovery_restart(
         recovery_rsp,

--- a/fullerene-kernel/src/scheduler.rs
+++ b/fullerene-kernel/src/scheduler.rs
@@ -21,6 +21,11 @@
 use crate::gui;
 use crate::vdso;
 use solvent;
+use core::sync::atomic::{AtomicU64, Ordering};
+use x86_64::VirtAddr;
+
+/// NMI recovery dedicated stack.
+static NMI_RECOVERY_STACK: [u8; 4096] = [0u8; 4096];
 
 /// Set the launch‑shell flag from the solvent side.
 pub fn request_shell_launch() {
@@ -53,6 +58,16 @@ pub fn scheduler_loop() -> ! {
 
     // Wire kernel renderer into Solvent so runtime ticks can paint the display.
     gui::set_render_fn(gui::render);
+
+    // Register NMI recovery restart context with a dedicated stack.
+    let recovery_rsp = {
+        let base = NMI_RECOVERY_STACK.as_ptr() as u64;
+        VirtAddr::new((base + NMI_RECOVERY_STACK.len() as u64) & !15u64)
+    };
+    set_recovery_restart(
+        recovery_rsp,
+        VirtAddr::from_ptr(mmio_recovery_restart as *const ()),
+    );
 
     // Idle loop: drive runtime ticks without a shell.
     // Shell and other apps are launched via AppGrid or context menu.
@@ -100,4 +115,39 @@ pub extern "C" fn shell_process_main() -> ! {
     crate::shell::shell_main();
     crate::process::terminate_process(crate::process::current_pid().unwrap(), 0);
     petroleum::halt_loop();
+}
+
+// ── NMI recovery restart ───────────────────────────────────────
+
+static RECOVERY_RSP: AtomicU64 = AtomicU64::new(0);
+static RECOVERY_RIP: AtomicU64 = AtomicU64::new(0);
+
+/// Set the recovery RSP and RIP for the timer ISR to use after NMI
+/// MMIO watchdog recovery.
+pub fn set_recovery_restart(rsp: VirtAddr, rip: VirtAddr) {
+    RECOVERY_RSP.store(rsp.as_u64(), Ordering::Release);
+    RECOVERY_RIP.store(rip.as_u64(), Ordering::Release);
+}
+
+/// Get the recovery RSP and RIP for the timer ISR.
+pub fn get_recovery_restart_fn() -> Option<(VirtAddr, VirtAddr)> {
+    let rsp = RECOVERY_RSP.load(Ordering::Acquire);
+    let rip = RECOVERY_RIP.load(Ordering::Acquire);
+    if rsp != 0 && rip != 0 {
+        Some((VirtAddr::new(rsp), VirtAddr::new(rip)))
+    } else {
+        None
+    }
+}
+
+/// Restart the scheduler loop after an NMI watchdog recovery.
+/// Called from the timer ISR on a fresh stack.
+#[unsafe(no_mangle)]
+pub extern "C" fn mmio_recovery_restart() -> ! {
+    petroleum::serial::serial_log(format_args!(
+        "[mmio_recovery_restart] WiFi init hung, restarting scheduler loop\n"
+    ));
+    // Safe: no locks held from the hung context on this fresh stack.
+    nitrogen::iwlwifi::force_init_failed();
+    scheduler_loop()
 }

--- a/fullerene-kernel/src/scheduler.rs
+++ b/fullerene-kernel/src/scheduler.rs
@@ -27,9 +27,9 @@ use x86_64::VirtAddr;
 /// NMI recovery dedicated stack (writable, 16-byte aligned).
 /// Must be mutable so recovery pushes can write to it without faulting.
 #[repr(align(16))]
-struct AlignedStack([u8; 4096]);
+struct AlignedStack([u8; 65536]);
 
-static mut NMI_RECOVERY_STACK: AlignedStack = AlignedStack([0u8; 4096]);
+static mut NMI_RECOVERY_STACK: AlignedStack = AlignedStack([0u8; 65536]);
 
 /// Set the launch‑shell flag from the solvent side.
 pub fn request_shell_launch() {

--- a/fullerene-kernel/src/scheduler.rs
+++ b/fullerene-kernel/src/scheduler.rs
@@ -151,7 +151,10 @@ pub extern "C" fn mmio_recovery_restart() -> ! {
     petroleum::serial::serial_log(format_args!(
         "[mmio_recovery_restart] WiFi init hung, restarting scheduler loop\n"
     ));
-    // Safe: no locks held from the hung context on this fresh stack.
+    // Force-reset the APIC_CONTROLLER lock in case the hung context held it.
+    unsafe {
+        crate::interrupts::apic::reset_apic_controller_lock();
+    }
     nitrogen::iwlwifi::force_init_failed();
     scheduler_loop()
 }

--- a/fullerene-kernel/src/scheduler.rs
+++ b/fullerene-kernel/src/scheduler.rs
@@ -64,9 +64,9 @@ pub fn scheduler_loop() -> ! {
     gui::set_render_fn(gui::render);
 
     // Register NMI recovery restart context with a dedicated stack.
-    let recovery_rsp = unsafe {
-        let base = NMI_RECOVERY_STACK.0.as_ptr() as u64;
-        VirtAddr::new((base + NMI_RECOVERY_STACK.0.len() as u64) & !15u64)
+    let recovery_rsp = {
+        let base = core::ptr::addr_of!(NMI_RECOVERY_STACK) as u64;
+        VirtAddr::new((base + core::mem::size_of::<[u8; 4096]>() as u64) & !15u64)
     };
     set_recovery_restart(
         recovery_rsp,

--- a/nitrogen/src/apic.rs
+++ b/nitrogen/src/apic.rs
@@ -30,6 +30,11 @@ impl ApicFlags {
     pub const TIMER_PERIODIC: u32 = 1 << 17;
     pub const TIMER_ONESHOT: u32 = 0; // Bit 17 = 0 → one-shot mode
     pub const TIMER_MASKED: u32 = 1 << 16;
+
+    // LVT delivery mode bits [10:8]
+    // 000 = Fixed, 010 = SMI, 100 = NMI, 101 = INIT, 111 = ExtINT
+    pub const DELIVERY_MODE_FIXED: u32 = 0 << 8;
+    pub const DELIVERY_MODE_NMI: u32 = 4 << 8;
 }
 
 /// Default IO APIC base address

--- a/nitrogen/src/iwlwifi/state.rs
+++ b/nitrogen/src/iwlwifi/state.rs
@@ -251,11 +251,13 @@ pub fn try_init_wifi_device_step() {
             // endpoint through a fresh PCI reset cycle, ensuring the
             // link and BAR are truly operational before any MMIO read.
             {
-                let ctx = WIFI_INIT_CTX.lock();
-                let bridge_bdf = ctx.health.as_ref().and_then(|h| h.upstream_bridge());
-                let pci_bdf = ctx.pci_dev.as_ref().map(|d| (d.bus, d.device, d.function));
-                if let (Some((bb, bd, bf)), Some((eb, ed, ef))) = (bridge_bdf, pci_bdf) {
-                    drop(ctx);
+                let bdf_info = {
+                    let ctx = WIFI_INIT_CTX.lock();
+                    let bridge_bdf = ctx.health.as_ref().and_then(|h| h.upstream_bridge());
+                    let pci_bdf = ctx.pci_dev.as_ref().map(|d| (d.bus, d.device, d.function));
+                    (bridge_bdf, pci_bdf)
+                };
+                if let (Some((bb, bd, bf)), Some((eb, ed, ef))) = bdf_info {
                     debug::print("iwlwifi", "step: sbr_start");
                     let bc = crate::pci::PciConfigSpace::read_config_word(bb, bd, bf, 0x3E);
                     crate::pci::PciConfigSpace::write_config_word_raw(
@@ -272,8 +274,6 @@ pub fn try_init_wifi_device_step() {
                     );
                     crate::pci_error::configure_completion_timeout(eb, ed, ef);
                     debug::print("iwlwifi", "step: sbr_done");
-                } else {
-                    drop(ctx);
                 }
             }
 

--- a/nitrogen/src/iwlwifi/state.rs
+++ b/nitrogen/src/iwlwifi/state.rs
@@ -59,12 +59,26 @@ pub fn wifi_init_completed() -> bool {
 /// Called by the kernel when the incremental init has been running
 /// too long (PCIe MMIO hangs on real hardware) to prevent the idle
 /// loop from being permanently blocked.
+///
+/// Uses `try_lock` so that it can be called from the NMI watchdog
+/// path without deadlocking (the lock may be held by the hung context).
 pub fn force_init_failed() {
     if WIFI_INIT_COMPLETED.load(core::sync::atomic::Ordering::Relaxed) {
         return;
     }
-    // Clean up any partially-initialised resources.
-    let mut ctx = WIFI_INIT_CTX.lock();
+    // Always mark as failed (lock-free statics) so the tick loop
+    // stops attempting init, even if the Mutex is perma-locked.
+    set_init_phase(WifiInitPhase::Failed);
+    WIFI_INIT_COMPLETED.store(true, core::sync::atomic::Ordering::Release);
+
+    // Try to clean up resources – skip if lock is held by hung context.
+    let mut ctx = match WIFI_INIT_CTX.try_lock() {
+        Some(c) => c,
+        None => {
+            debug::print("iwlwifi", "step: force_init_failed (lock held, skip cleanup)");
+            return;
+        }
+    };
     let _ = ctx.mmio_device.take();
     // Disable PCI bus-mastering before freeing DMA regions
     if let Some(ref pci) = ctx.pci_dev {
@@ -92,9 +106,7 @@ pub fn force_init_failed() {
             ring.free(c);
         }
     }
-    set_init_phase(WifiInitPhase::Failed);
     drop(ctx);
-    WIFI_INIT_COMPLETED.store(true, core::sync::atomic::Ordering::Release);
     debug::print("iwlwifi", "step: force_init_failed (timeout)");
 }
 
@@ -241,6 +253,13 @@ pub fn try_init_wifi_device_step() {
                 set_init_phase(WifiInitPhase::Failed);
                 return;
             }
+            let bdf_info = {
+                let ctx = WIFI_INIT_CTX.lock();
+                pci_bdf_from_ctx(&ctx)
+            };
+            if let Some((pci_bdf, bridge_bdf)) = bdf_info {
+                mmio::arm_mmio_watchdog(0, pci_bdf, bridge_bdf);
+            }
             debug::print("iwlwifi", "step: mmio_reset");
             IwlWifiDevice::reset_device(mmio);
             debug::print("iwlwifi", "step: mmio_clock_req");
@@ -248,6 +267,7 @@ pub fn try_init_wifi_device_step() {
                 core::ptr::write_volatile(mmio.add(CSR_GP_CNTRL as usize), CSR_GP_CNTRL_MAC_ACCESS_REQ);
             }
             mmio::write_barrier();
+            mmio::disarm_mmio_watchdog();
             debug::print("iwlwifi", "step: mmio_check_clock");
             let device_present = {
                 let mut ctx = WIFI_INIT_CTX.lock();
@@ -261,8 +281,6 @@ pub fn try_init_wifi_device_step() {
                 set_init_phase(WifiInitPhase::Failed);
                 return;
             }
-            // Record MAC-clock poll start TSC and transition to
-            // per-tick polling so the event loop is not blocked.
             let now_tsc = unsafe { core::arch::x86_64::_rdtsc() };
             {
                 let mut ctx = WIFI_INIT_CTX.lock();
@@ -278,24 +296,30 @@ pub fn try_init_wifi_device_step() {
                 (ctx.mmio, ctx.alive_start_tsc)
             };
             const TIMEOUT_CYCLES: u64 = 4_000_000_000;
+            let bdf_info = {
+                let ctx = WIFI_INIT_CTX.lock();
+                pci_bdf_from_ctx(&ctx)
+            };
+            if let Some((pci_bdf, bridge_bdf)) = bdf_info {
+                mmio::arm_mmio_watchdog(0, pci_bdf, bridge_bdf);
+            }
             let mac_acquired = {
                 let ctx = WIFI_INIT_CTX.lock();
                 let health = ctx.health.as_ref();
-                // Single checked read per tick — no busy-loop.
                 match mmio::checked_read_u32(
                     unsafe { mmio.add(CSR_GP_CNTRL as usize) } as *const u32,
                     health,
                 ) {
                     mmio::SafeReadResult::Value(v) if v & CSR_GP_CNTRL_MAC_CLOCK_READY != 0 => true,
                     mmio::SafeReadResult::MasterAbort | mmio::SafeReadResult::DeviceGone => {
+                        mmio::disarm_mmio_watchdog();
                         debug::print("iwlwifi", "step: ERR mac_abort_or_gone");
                         set_init_phase(WifiInitPhase::Failed);
                         return;
                     }
                     _ => {
-                        // Not ready yet — check timeout.
+                        mmio::disarm_mmio_watchdog();
                         if unsafe { core::arch::x86_64::_rdtsc() }.wrapping_sub(start_tsc) >= TIMEOUT_CYCLES {
-                            drop(ctx);
                             debug::print("iwlwifi", "step: mmio_force_mac");
                             unsafe {
                                 core::ptr::write_volatile(
@@ -313,8 +337,10 @@ pub fn try_init_wifi_device_step() {
                             if !recovery_ok {
                                 false
                             } else {
-                                // Recovery succeeded — now verify MAC_CLOCK_READY is actually set.
                                 let health = ctx.health.as_ref();
+                                if let Some((pci_bdf, bridge_bdf)) = bdf_info {
+                                    mmio::arm_mmio_watchdog(0, pci_bdf, bridge_bdf);
+                                }
                                 let clock_ready = match mmio::checked_read_u32(
                                     unsafe { mmio.add(CSR_GP_CNTRL as usize) } as *const u32,
                                     health,
@@ -322,11 +348,11 @@ pub fn try_init_wifi_device_step() {
                                     mmio::SafeReadResult::Value(v) if v & CSR_GP_CNTRL_MAC_CLOCK_READY != 0 => true,
                                     _ => false,
                                 };
+                                mmio::disarm_mmio_watchdog();
                                 drop(ctx);
                                 clock_ready
                             }
                         } else {
-                            // Not ready yet, not timed out: try again next tick.
                             return;
                         }
                     }
@@ -339,9 +365,14 @@ pub fn try_init_wifi_device_step() {
             }
             debug::print("iwlwifi", "step: mmio_read_mac");
             let mac = {
+                if let Some((pci_bdf, bridge_bdf)) = bdf_info {
+                    mmio::arm_mmio_watchdog(0, pci_bdf, bridge_bdf);
+                }
                 let ctx = WIFI_INIT_CTX.lock();
                 let health = ctx.health.as_ref();
-                IwlWifiDevice::read_mac(mmio, health)
+                let mac = IwlWifiDevice::read_mac(mmio, health);
+                mmio::disarm_mmio_watchdog();
+                mac
             };
             debug::print("iwlwifi", "step: mmio_mask_ints");
             unsafe {
@@ -486,7 +517,7 @@ pub fn try_init_wifi_device_step() {
             set_init_phase(WifiInitPhase::FwUpload);
         }
         WifiInitPhase::FwUpload => {
-            let (fw_data, fw_name) = {
+            let (fw_data, fw_name, bdf_info) = {
                 let mut ctx = WIFI_INIT_CTX.lock();
                 let _dev = match ctx.mmio_device.as_mut() {
                     Some(d) => d,
@@ -501,23 +532,29 @@ pub fn try_init_wifi_device_step() {
                     return;
                 }
                 let fw = &ctx.fw_candidates[ctx.fw_candidate_idx];
-                (fw.data, fw.name)
+                let bdf = pci_bdf_from_ctx(&ctx);
+                (fw.data, fw.name, bdf)
             };
             log::info!(
                 "iwlwifi: step: trying firmware {} ({} bytes)",
                 fw_name, fw_data.len()
             );
+            if let Some((pci_bdf, bridge_bdf)) = bdf_info {
+                mmio::arm_mmio_watchdog(0, pci_bdf, bridge_bdf);
+            }
             let start_result = {
                 let mut ctx = WIFI_INIT_CTX.lock();
                 let dev = match ctx.mmio_device.as_mut() {
                     Some(d) => d,
                     None => {
+                        mmio::disarm_mmio_watchdog();
                         set_init_phase(WifiInitPhase::Failed);
                         return;
                     }
                 };
                 dev.start_firmware(fw_data)
             };
+            mmio::disarm_mmio_watchdog();
             match start_result {
                 Ok(()) => {
                     log::info!("iwlwifi: step: firmware {} upload complete, waiting for alive", fw_name);
@@ -534,18 +571,26 @@ pub fn try_init_wifi_device_step() {
             }
         }
         WifiInitPhase::FwWaitAlive => {
-            let start_tsc = WIFI_INIT_CTX.lock().alive_start_tsc;
+            let (start_tsc, bdf_info) = {
+                let ctx = WIFI_INIT_CTX.lock();
+                (ctx.alive_start_tsc, pci_bdf_from_ctx(&ctx))
+            };
+            if let Some((pci_bdf, bridge_bdf)) = bdf_info {
+                mmio::arm_mmio_watchdog(0, pci_bdf, bridge_bdf);
+            }
             let alive_result = {
                 let mut ctx = WIFI_INIT_CTX.lock();
                 let dev = match ctx.mmio_device.as_mut() {
                     Some(d) => d,
                     None => {
+                        mmio::disarm_mmio_watchdog();
                         set_init_phase(WifiInitPhase::Failed);
                         return;
                     }
                 };
                 dev.check_alive_nonblocking(start_tsc)
             };
+            mmio::disarm_mmio_watchdog();
             match alive_result {
                 Ok(true) => {
                     debug::print("iwlwifi", "step: fw_alive");
@@ -563,17 +608,26 @@ pub fn try_init_wifi_device_step() {
             }
         }
         WifiInitPhase::FwInitCmds => {
+            let bdf_info = {
+                let ctx = WIFI_INIT_CTX.lock();
+                pci_bdf_from_ctx(&ctx)
+            };
+            if let Some((pci_bdf, bridge_bdf)) = bdf_info {
+                mmio::arm_mmio_watchdog(0, pci_bdf, bridge_bdf);
+            }
             let result = {
                 let mut ctx = WIFI_INIT_CTX.lock();
                 let dev = match ctx.mmio_device.as_mut() {
                     Some(d) => d,
                     None => {
+                        mmio::disarm_mmio_watchdog();
                         set_init_phase(WifiInitPhase::Failed);
                         return;
                     }
                 };
                 dev.send_init_commands()
             };
+            mmio::disarm_mmio_watchdog();
             match result {
                 Ok(()) => {
                     debug::print("iwlwifi", "step: fw_init_cmds_ok");
@@ -620,6 +674,13 @@ pub fn try_init_wifi_device_step() {
 }
 
 // ── High-level API ─────────────────
+
+fn pci_bdf_from_ctx(ctx: &WifiInitContext) -> Option<((u8, u8, u8), Option<(u8, u8, u8)>)> {
+    let pci = ctx.pci_dev.as_ref()?;
+    let bdf = (pci.bus, pci.device, pci.function);
+    let bridge = ctx.health.as_ref().and_then(|h| h.upstream_bridge());
+    Some((bdf, bridge))
+}
 
 pub fn try_init_wifi_device() {
     debug::print("iwlwifi", "try_init_wifi_device: start");

--- a/nitrogen/src/iwlwifi/state.rs
+++ b/nitrogen/src/iwlwifi/state.rs
@@ -240,6 +240,44 @@ pub fn try_init_wifi_device_step() {
         }
         WifiInitPhase::MmioInit => {
             debug::print("iwlwifi", "step: mmio_enter");
+
+            // ── Secondary Bus Reset ──────────────────────────────
+            // Some platforms leave the WiFi endpoint in a state where
+            // PCI config space responds (vendor/device ID, D0, link)
+            // but MMIO BAR reads hang the CPU permanently (phantom
+            // device, ASPM L1 wedge, or platform erratum).
+            //
+            // A secondary bus reset on the upstream bridge forces the
+            // endpoint through a fresh PCI reset cycle, ensuring the
+            // link and BAR are truly operational before any MMIO read.
+            {
+                let ctx = WIFI_INIT_CTX.lock();
+                let bridge_bdf = ctx.health.as_ref().and_then(|h| h.upstream_bridge());
+                let pci_bdf = ctx.pci_dev.as_ref().map(|d| (d.bus, d.device, d.function));
+                if let (Some((bb, bd, bf)), Some((eb, ed, ef))) = (bridge_bdf, pci_bdf) {
+                    drop(ctx);
+                    debug::print("iwlwifi", "step: sbr_start");
+                    let bc = crate::pci::PciConfigSpace::read_config_word(bb, bd, bf, 0x3E);
+                    crate::pci::PciConfigSpace::write_config_word_raw(
+                        bb, bd, bf, 0x3E, bc | (1 << 6),
+                    );
+                    crate::timing::delay_us(100_000);
+                    crate::pci::PciConfigSpace::write_config_word_raw(
+                        bb, bd, bf, 0x3E, bc & !(1 << 6),
+                    );
+                    crate::timing::delay_us(100_000);
+                    // Re-configure endpoint after reset
+                    crate::pci::PciConfigSpace::write_config_word_raw(
+                        eb, ed, ef, 4, 0x06,
+                    );
+                    crate::pci_error::configure_completion_timeout(eb, ed, ef);
+                    debug::print("iwlwifi", "step: sbr_done");
+                } else {
+                    drop(ctx);
+                }
+            }
+
+            // Check device is present after reset
             let mmio = WIFI_INIT_CTX.lock().mmio;
             let device_present = {
                 let mut ctx = WIFI_INIT_CTX.lock();

--- a/nitrogen/src/iwlwifi/state.rs
+++ b/nitrogen/src/iwlwifi/state.rs
@@ -333,6 +333,11 @@ pub fn try_init_wifi_device_step() {
                 let ctx = WIFI_INIT_CTX.lock();
                 (ctx.mmio, ctx.alive_start_tsc)
             };
+            if mmio.is_null() {
+                debug::print("iwlwifi", "step: ERR mmio_null");
+                set_init_phase(WifiInitPhase::Failed);
+                return;
+            }
             const TIMEOUT_CYCLES: u64 = 4_000_000_000;
             let bdf_info = {
                 let ctx = WIFI_INIT_CTX.lock();

--- a/nitrogen/src/mmio.rs
+++ b/nitrogen/src/mmio.rs
@@ -30,6 +30,7 @@
 use crate::DriverContext;
 use crate::pci_health::PciHealth;
 use core::ptr;
+use core::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 
 // ============================================================================
 //  Cache management
@@ -134,14 +135,29 @@ impl<T> SafeReadResult<T> {
 /// *after* the config-space check.  True hang prevention requires platform
 /// mechanisms (e.g. PCIe AER, SMI watchdog, or an external timeout).
 /// These checks catch ~99% of real-world cases encountered during development.
-#[inline]
+#[inline(never)]
 pub fn checked_read_u32(addr: *const u32, health: Option<&PciHealth>) -> SafeReadResult<u32> {
     if let Some(h) = health {
         if !h.is_device_present() {
             return SafeReadResult::DeviceGone;
         }
     }
+
+    if MMIO_WATCHDOG_ARMED.load(Ordering::Relaxed) {
+        arm_watchdog_timer();
+    }
+
     let val = unsafe { core::ptr::read_volatile(addr) };
+
+    if MMIO_WATCHDOG_ARMED.load(Ordering::Relaxed) {
+        disarm_mmio_watchdog();
+    }
+
+    if MMIO_WATCHDOG_HUNG.load(Ordering::Acquire) {
+        MMIO_WATCHDOG_HUNG.store(false, Ordering::Release);
+        return SafeReadResult::MasterAbort;
+    }
+
     if val == 0xFFFF_FFFF {
         return SafeReadResult::MasterAbort;
     }
@@ -447,5 +463,180 @@ impl Drop for DmaRegion {
         } else if self.len != 0 {
             log::warn!("DmaRegion dropped without free()");
         }
+    }
+}
+
+// ============================================================================
+//  MMIO NMI Watchdog — hang recovery for stalled PCIe reads
+// ============================================================================
+
+static MMIO_WATCHDOG_ARMED: AtomicBool = AtomicBool::new(false);
+static MMIO_WATCHDOG_HUNG: AtomicBool = AtomicBool::new(false);
+static MMIO_WATCHDOG_DEADLINE: AtomicU64 = AtomicU64::new(0);
+
+// Packed BDF: bits [7:0]=bus, [15:8]=dev, [23:16]=func
+static MMIO_WATCHDOG_PCI_BDF: AtomicU32 = AtomicU32::new(0);
+static MMIO_WATCHDOG_BRIDGE_BDF: AtomicU32 = AtomicU32::new(0);
+
+// Saved LVT timer value to restore after NMI recovery
+static MMIO_WATCHDOG_SAVED_LVT: AtomicU32 = AtomicU32::new(0);
+static MMIO_WATCHDOG_SAVED_INITCNT: AtomicU32 = AtomicU32::new(0);
+
+/// Extern callback: switch APIC timer to NMI one-shot mode.
+/// Set by the kernel at boot; points to a function that reprograms
+/// the LAPIC LVT_TIMER register for NMI delivery.
+static mut MMIO_WATCHDOG_ARM_TIMER_FN: Option<fn()> = None;
+
+/// Extern callback: restore APIC timer to periodic mode.
+/// Set by the kernel at boot; points to a function that restores
+/// the LAPIC timer to its original periodic configuration.
+static mut MMIO_WATCHDOG_RESTORE_TIMER_FN: Option<fn()> = None;
+
+/// Register kernel-provided APIC timer switch callbacks.
+///
+/// Must be called once during kernel init, before any WiFi MMIO access.
+pub fn register_watchdog_timer_callbacks(arm_fn: fn(), restore_fn: fn()) {
+    unsafe {
+        MMIO_WATCHDOG_ARM_TIMER_FN = Some(arm_fn);
+        MMIO_WATCHDOG_RESTORE_TIMER_FN = Some(restore_fn);
+    }
+}
+
+/// Save the current APIC LVT timer configuration for later restoration.
+/// Called by the kernel's arm callback so the NMI handler can restore it.
+pub fn watchdog_save_lvt(lvt: u32, initcnt: u32) {
+    MMIO_WATCHDOG_SAVED_LVT.store(lvt, Ordering::SeqCst);
+    MMIO_WATCHDOG_SAVED_INITCNT.store(initcnt, Ordering::SeqCst);
+}
+
+/// Return the saved LVT timer value (used by NMI handler to restore timer).
+pub fn watchdog_saved_lvt() -> u32 {
+    MMIO_WATCHDOG_SAVED_LVT.load(Ordering::SeqCst)
+}
+
+/// Return the saved initial count (used by NMI handler to restore timer).
+pub fn watchdog_saved_initcnt() -> u32 {
+    MMIO_WATCHDOG_SAVED_INITCNT.load(Ordering::SeqCst)
+}
+
+/// Arm the MMIO NMI watchdog.
+///
+/// After calling this, the next `checked_read_u32` will reprogram the
+/// APIC timer to deliver an NMI after `deadline_tsc`.  If the MMIO read
+/// stalls, the NMI fires, the PCI device is disabled via port I/O, and
+/// the link is retrained so the stalled `mov` completes with `0xFFFFFFFF`.
+pub fn arm_mmio_watchdog(
+    deadline_tsc: u64,
+    pci_bdf: (u8, u8, u8),
+    bridge_bdf: Option<(u8, u8, u8)>,
+) {
+    MMIO_WATCHDOG_DEADLINE.store(deadline_tsc, Ordering::Release);
+    MMIO_WATCHDOG_PCI_BDF.store(
+        pci_bdf.0 as u32 | ((pci_bdf.1 as u32) << 8) | ((pci_bdf.2 as u32) << 16),
+        Ordering::Release,
+    );
+    if let Some((b, d, f)) = bridge_bdf {
+        MMIO_WATCHDOG_BRIDGE_BDF.store(
+            b as u32 | ((d as u32) << 8) | ((f as u32) << 16),
+            Ordering::Release,
+        );
+    } else {
+        MMIO_WATCHDOG_BRIDGE_BDF.store(0, Ordering::Release);
+    }
+    MMIO_WATCHDOG_HUNG.store(false, Ordering::Release);
+    MMIO_WATCHDOG_ARMED.store(true, Ordering::Release);
+}
+
+/// Disarm the MMIO NMI watchdog and restore the APIC timer.
+pub fn disarm_mmio_watchdog() {
+    MMIO_WATCHDOG_ARMED.store(false, Ordering::Release);
+    if let Some(restore) = unsafe { MMIO_WATCHDOG_RESTORE_TIMER_FN } {
+        restore();
+    }
+}
+
+/// Called internally by `checked_read_u32` when the watchdog is armed.
+/// Switches the APIC timer to NMI one-shot mode.
+fn arm_watchdog_timer() {
+    if let Some(arm) = unsafe { MMIO_WATCHDOG_ARM_TIMER_FN } {
+        arm();
+    }
+}
+
+/// Query whether the NMI watchdog has fired (for use by the NMI handler).
+pub fn mmio_watchdog_armed() -> bool {
+    MMIO_WATCHDOG_ARMED.load(Ordering::Acquire)
+}
+
+/// Check if the NMI fired within the watchdog window (for the NMI handler).
+pub fn mmio_watchdog_expired() -> bool {
+    MMIO_WATCHDOG_ARMED.load(Ordering::Acquire)
+}
+
+// ── NMI recovery trigger flag ─────
+
+static MMIO_NMI_RECOVERY_TRIGGERED: AtomicBool = AtomicBool::new(false);
+
+pub fn mmio_watchdog_recovery_triggered() -> bool {
+    MMIO_NMI_RECOVERY_TRIGGERED.load(Ordering::Acquire)
+}
+
+pub fn clear_watchdog_recovery_trigger() {
+    MMIO_NMI_RECOVERY_TRIGGERED.store(false, Ordering::Release);
+}
+
+/// Called by the NMI handler as the main recovery path:
+/// 1. disable PCI endpoint via port I/O
+/// 2. trigger link retrain
+/// 3. set recovery trigger flag
+pub fn mmio_watchdog_nmi_recovery() {
+    MMIO_WATCHDOG_HUNG.store(true, Ordering::Release);
+
+    let bdf = MMIO_WATCHDOG_PCI_BDF.load(Ordering::Acquire);
+    let (bus, dev, func) = (bdf as u8, (bdf >> 8) as u8, (bdf >> 16) as u8);
+
+    let cmd = crate::pci::PciConfigSpace::read_config_word(bus, dev, func, 4);
+    crate::pci::PciConfigSpace::write_config_word_raw(
+        bus,
+        dev,
+        func,
+        4,
+        cmd & !(0x02 | 0x04),
+    );
+
+    let bridge_bdf = MMIO_WATCHDOG_BRIDGE_BDF.load(Ordering::Acquire);
+    if bridge_bdf != 0 {
+        let (b, d, f) = (bridge_bdf as u8, (bridge_bdf >> 8) as u8, (bridge_bdf >> 16) as u8);
+        if let Some(lnk_off) = crate::pci_error::find_pcie_cap(b, d, f)
+            .and_then(|off| off.checked_add(0x10))
+            .filter(|&off| off <= 0xFC)
+        {
+            let ctl = crate::pci::PciConfigSpace::read_config_word(b, d, f, lnk_off as u8);
+            crate::pci::PciConfigSpace::write_config_word_raw(
+                b,
+                d,
+                f,
+                lnk_off as u8,
+                ctl | (1 << 5),
+            );
+        }
+    }
+
+    MMIO_WATCHDOG_ARMED.store(false, Ordering::Release);
+    if let Some(restore) = unsafe { MMIO_WATCHDOG_RESTORE_TIMER_FN } {
+        restore();
+    }
+
+    MMIO_NMI_RECOVERY_TRIGGERED.store(true, Ordering::Release);
+}
+
+// ── NMI trampoline (halt loop) ────
+
+/// NMI handler redirects iretq here after MMIO watchdog recovery.
+/// This function just halts; the next periodic timer interrupt detects
+/// the recovery trigger flag and jumps to the scheduler loop.
+pub extern "C" fn mmio_nmi_recovery_trampoline() -> ! {
+    loop {
+        x86_64::instructions::hlt();
     }
 }

--- a/nitrogen/src/mmio.rs
+++ b/nitrogen/src/mmio.rs
@@ -160,11 +160,6 @@ pub fn checked_read_u32(addr: *const u32, health: Option<&PciHealth>) -> SafeRea
         disarm_mmio_watchdog();
     }
 
-    if MMIO_WATCHDOG_HUNG.load(Ordering::Acquire) {
-        MMIO_WATCHDOG_HUNG.store(false, Ordering::Release);
-        return SafeReadResult::MasterAbort;
-    }
-
     if val == 0xFFFF_FFFF {
         return SafeReadResult::MasterAbort;
     }
@@ -479,7 +474,6 @@ impl Drop for DmaRegion {
 
 static MMIO_WATCHDOG_ARMED: AtomicBool = AtomicBool::new(false);
 static MMIO_WATCHDOG_ACTIVE: AtomicBool = AtomicBool::new(false);
-static MMIO_WATCHDOG_HUNG: AtomicBool = AtomicBool::new(false);
 static MMIO_WATCHDOG_DEADLINE: AtomicU64 = AtomicU64::new(0);
 
 // Packed BDF: bits [7:0]=bus, [15:8]=dev, [23:16]=func
@@ -551,7 +545,6 @@ pub fn arm_mmio_watchdog(
     } else {
         MMIO_WATCHDOG_BRIDGE_BDF.store(0, Ordering::Release);
     }
-    MMIO_WATCHDOG_HUNG.store(false, Ordering::Release);
     MMIO_WATCHDOG_ACTIVE.store(false, Ordering::Release);
     MMIO_WATCHDOG_ARMED.store(true, Ordering::Release);
 }
@@ -600,8 +593,6 @@ pub fn clear_watchdog_recovery_trigger() {
 /// 2. trigger link retrain
 /// 3. set recovery trigger flag
 pub fn mmio_watchdog_nmi_recovery() {
-    MMIO_WATCHDOG_HUNG.store(true, Ordering::Release);
-
     let bdf = MMIO_WATCHDOG_PCI_BDF.load(Ordering::Acquire);
     let (bus, dev, func) = (bdf as u8, (bdf >> 8) as u8, (bdf >> 16) as u8);
 

--- a/nitrogen/src/mmio.rs
+++ b/nitrogen/src/mmio.rs
@@ -143,13 +143,20 @@ pub fn checked_read_u32(addr: *const u32, health: Option<&PciHealth>) -> SafeRea
         }
     }
 
-    if MMIO_WATCHDOG_ARMED.load(Ordering::Relaxed) {
+    // If watchdog is armed but not yet active, activate it for this read.
+    // If already active, keep it active (multi-read protection).
+    let was_active = MMIO_WATCHDOG_ACTIVE.load(Ordering::Relaxed);
+    if MMIO_WATCHDOG_ARMED.load(Ordering::Relaxed) && !was_active {
+        MMIO_WATCHDOG_ACTIVE.store(true, Ordering::Release);
         arm_watchdog_timer();
     }
 
     let val = unsafe { core::ptr::read_volatile(addr) };
 
-    if MMIO_WATCHDOG_ARMED.load(Ordering::Relaxed) {
+    // Only disarm if we activated it (single-read case).
+    // Multi-read callers must explicitly call disarm_mmio_watchdog().
+    if MMIO_WATCHDOG_ARMED.load(Ordering::Relaxed) && !was_active {
+        MMIO_WATCHDOG_ACTIVE.store(false, Ordering::Release);
         disarm_mmio_watchdog();
     }
 
@@ -471,6 +478,7 @@ impl Drop for DmaRegion {
 // ============================================================================
 
 static MMIO_WATCHDOG_ARMED: AtomicBool = AtomicBool::new(false);
+static MMIO_WATCHDOG_ACTIVE: AtomicBool = AtomicBool::new(false);
 static MMIO_WATCHDOG_HUNG: AtomicBool = AtomicBool::new(false);
 static MMIO_WATCHDOG_DEADLINE: AtomicU64 = AtomicU64::new(0);
 
@@ -544,12 +552,14 @@ pub fn arm_mmio_watchdog(
         MMIO_WATCHDOG_BRIDGE_BDF.store(0, Ordering::Release);
     }
     MMIO_WATCHDOG_HUNG.store(false, Ordering::Release);
+    MMIO_WATCHDOG_ACTIVE.store(false, Ordering::Release);
     MMIO_WATCHDOG_ARMED.store(true, Ordering::Release);
 }
 
 /// Disarm the MMIO NMI watchdog and restore the APIC timer.
 pub fn disarm_mmio_watchdog() {
     MMIO_WATCHDOG_ARMED.store(false, Ordering::Release);
+    MMIO_WATCHDOG_ACTIVE.store(false, Ordering::Release);
     if let Some(restore) = unsafe { MMIO_WATCHDOG_RESTORE_TIMER_FN } {
         restore();
     }
@@ -623,6 +633,7 @@ pub fn mmio_watchdog_nmi_recovery() {
     }
 
     MMIO_WATCHDOG_ARMED.store(false, Ordering::Release);
+    MMIO_WATCHDOG_ACTIVE.store(false, Ordering::Release);
     if let Some(restore) = unsafe { MMIO_WATCHDOG_RESTORE_TIMER_FN } {
         restore();
     }

--- a/nitrogen/src/pci.rs
+++ b/nitrogen/src/pci.rs
@@ -26,12 +26,17 @@ static PCI_CONFIG_LOCK: AtomicBool = AtomicBool::new(false);
 /// Acquire the PCI config space lock (NMI-safe spinlock).
 #[inline]
 fn pci_config_lock_acquire() {
+    let mut retries = 0;
     while PCI_CONFIG_LOCK.compare_exchange_weak(
         false,
         true,
         Ordering::Acquire,
         Ordering::Relaxed,
     ).is_err() {
+        retries += 1;
+        if retries > 10000 {
+            break;
+        }
         core::hint::spin_loop();
     }
 }

--- a/nitrogen/src/pci.rs
+++ b/nitrogen/src/pci.rs
@@ -4,7 +4,7 @@
 //! for unified hardware management. No kernel or boot crate dependencies — only
 //! `x86_64`, `alloc`, and `log`.
 
-use core::sync::atomic::AtomicU64;
+use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use crate::port::PortWriter;
 
@@ -17,6 +17,30 @@ use crate::port::PortWriter;
 //
 // These statics are populated once by the kernel after it parses the
 // MCFG ACPI table.
+
+/// NMI-safe spinlock for PCI config space (CF8/CFC) access.
+/// Protects the address/data pair from interleaving between normal
+/// and NMI recovery paths.
+static PCI_CONFIG_LOCK: AtomicBool = AtomicBool::new(false);
+
+/// Acquire the PCI config space lock (NMI-safe spinlock).
+#[inline]
+fn pci_config_lock_acquire() {
+    while PCI_CONFIG_LOCK.compare_exchange_weak(
+        false,
+        true,
+        Ordering::Acquire,
+        Ordering::Relaxed,
+    ).is_err() {
+        core::hint::spin_loop();
+    }
+}
+
+/// Release the PCI config space lock.
+#[inline]
+fn pci_config_lock_release() {
+    PCI_CONFIG_LOCK.store(false, Ordering::Release);
+}
 
 static ECAM_BASE: AtomicU64 = AtomicU64::new(0);
 static PHYS_OFFSET: AtomicU64 = AtomicU64::new(0);
@@ -236,36 +260,53 @@ impl PciConfigSpace {
         Self::write_config_dword_raw(bus, device, function, offset, value);
     }
 
-    /// Write a raw WORD to PCI configuration space.
+    /// Write a raw DWORD to PCI configuration space (internal, unlocked).
     ///
-    /// Uses the existing dword at the aligned address, modifies only the
-    /// relevant 16-bit half, and writes it back. This avoids corrupting the
-    /// other half of the dword (e.g. the Status register when writing Command).
-    pub fn write_config_word_raw(bus: u8, device: u8, function: u8, offset: u8, value: u16) {
-        let aligned = offset & !3;
-        let shift = if offset % 4 < 2 { 0 } else { 16 };
-        let existing = Self::read_config_dword(bus, device, function, aligned);
-        let masked = existing & !(0xFFFFu32 << shift);
-        Self::write_config_dword_raw(
-            bus,
-            device,
-            function,
-            aligned,
-            masked | ((value as u32) << shift),
-        );
-    }
-
-    /// Write a raw DWORD to PCI configuration space.
-    ///
-    /// This is a low-level mechanism. Use `write_config_dword` on `PciConfigSpace`
-    /// when you need to update the cached header fields as well.
-    pub fn write_config_dword_raw(bus: u8, device: u8, function: u8, offset: u8, value: u32) {
+    /// Caller must hold PCI_CONFIG_LOCK.
+    fn write_config_dword_unlocked(bus: u8, device: u8, function: u8, offset: u8, value: u32) {
         let address = Self::build_config_address(bus, device, function, offset);
         let mut addr_writer = PortWriter::new(crate::port::HardwarePorts::PCI_CONFIG_ADDRESS);
         let mut data_writer = PortWriter::new(crate::port::HardwarePorts::PCI_CONFIG_DATA);
 
         addr_writer.write_safe(address);
         data_writer.write_safe(value);
+    }
+
+    /// Write a raw WORD to PCI configuration space.
+    ///
+    /// Uses the existing dword at the aligned address, modifies only the
+    /// relevant 16-bit half, and writes it back. This avoids corrupting the
+    /// other half of the dword (e.g. the Status register when writing Command).
+    ///
+    /// NMI-safe: serializes CF8/CFC access to prevent interleaving with
+    /// MMIO NMI recovery path.
+    pub fn write_config_word_raw(bus: u8, device: u8, function: u8, offset: u8, value: u16) {
+        pci_config_lock_acquire();
+        let aligned = offset & !3;
+        let shift = if offset % 4 < 2 { 0 } else { 16 };
+        let existing = Self::read_config_dword(bus, device, function, aligned);
+        let masked = existing & !(0xFFFFu32 << shift);
+        Self::write_config_dword_unlocked(
+            bus,
+            device,
+            function,
+            aligned,
+            masked | ((value as u32) << shift),
+        );
+        pci_config_lock_release();
+    }
+
+    /// Write a raw DWORD to PCI configuration space.
+    ///
+    /// This is a low-level mechanism. Use `write_config_dword` on `PciConfigSpace`
+    /// when you need to update the cached header fields as well.
+    ///
+    /// NMI-safe: serializes CF8/CFC access to prevent interleaving with
+    /// MMIO NMI recovery path.
+    pub fn write_config_dword_raw(bus: u8, device: u8, function: u8, offset: u8, value: u32) {
+        pci_config_lock_acquire();
+        Self::write_config_dword_unlocked(bus, device, function, offset, value);
+        pci_config_lock_release();
     }
 }
 

--- a/nitrogen/src/pci_health.rs
+++ b/nitrogen/src/pci_health.rs
@@ -85,6 +85,10 @@ impl PciHealth {
         self
     }
 
+    pub fn upstream_bridge(&self) -> Option<(u8, u8, u8)> {
+        self.upstream_bridge
+    }
+
     /// Quick check: is the device still visible on the PCI bus?
     /// This is a single config read — safe and fast.
     pub fn is_device_present(&self) -> bool {

--- a/nitrogen/src/wifi.rs
+++ b/nitrogen/src/wifi.rs
@@ -271,22 +271,12 @@ pub fn probe_pci_only(ctx: &'static dyn DriverContext) -> Option<RawPciProbeResu
     let (entry, info) = WifiRegistry::probe()?;
     crate::debug::print("wifi", "probe_ok");
 
-    // PCI config-space setup (NEVER hangs)
+    // PCI config-space setup (NEVER hangs).
+    // Order is critical: configure the upstream bridge BEFORE touching
+    // the endpoint to avoid ASPM state mismatch on the PCIe link.
     let pci_dev = crate::pci::PciDevice::new(info.bus, info.device, info.function)?;
-    crate::debug::print("wifi", "ensure_d0");
-    pci_dev.ensure_d0();
-    crate::debug::print("wifi", "disable_aspm");
-    pci_dev.disable_pcie_aspm();
-    crate::debug::print("wifi", "enable_mem");
-    pci_dev.enable_memory_access();
 
-    // ── Find upstream PCIe bridge (once, used for error reporting + ASPM) ──
-    // The upstream bridge controls ASPM and error routing for the endpoint.
-    // We find it via a single PCI scan and then:
-    //   1. Disable standard ASPM on the bridge
-    //   2. Disable L1 PM Substates on the bridge to prevent endpoint hangs
-    //   3. Configure Completion Timeout on the endpoint
-    //   4. Set up AER / Root Control error reporting on the bridge
+    // ── Find upstream PCIe bridge and disable its ASPM first ──
     crate::debug::print("wifi", "scan_bridge");
     let upstream_bridge: Option<(u8, u8, u8)> = {
         let mut scanner = PciScanner::new();
@@ -300,23 +290,23 @@ pub fn probe_pci_only(ctx: &'static dyn DriverContext) -> Option<RawPciProbeResu
         });
         if let Some(up) = upstream {
             log::info!(
-                "WiFi: disabling ASPM on upstream bridge {:02x}:{:02x}.{}",
+                "WiFi: found upstream bridge {:02x}:{:02x}.{}",
                 up.bus, up.device, up.function
             );
-            up.disable_pcie_aspm();
-            // Disable L1 PM Substates on the bridge via ECAM MMIO.
-            // Bridge-side ECAM is safe (bridges are never in L1).
-            crate::pci::PciDevice::disable_l1_substates(up.bus, up.device, up.function);
-            // ── PCIe error recovery: Completion Timeout on endpoint + Root Port AER ──
-            crate::pci_error::configure_completion_timeout(info.bus, info.device, info.function);
-            crate::pci_error::configure_root_port_error_reporting(up.bus, up.device, up.function);
             Some((up.bus, up.device, up.function))
         } else {
-            // No upstream bridge found — still configure endpoint timeout
-            crate::pci_error::configure_completion_timeout(info.bus, info.device, info.function);
             None
         }
     };
+
+    // ── Minimal endpoint configuration ─────────────────────
+    // Linux' iwlwifi calls only pci_enable_device() (which sets
+    // the Memory Space + Bus Master bits in the Command register)
+    // before accessing BAR0 MMIO.  Any additional config writes
+    // (ASPM disable, D0 re-assertion, CTO) can cause the PCIe
+    // link to enter an inconsistent state on this platform.
+    crate::debug::print("wifi", "enable_mem");
+    pci_dev.enable_memory_access();
 
     // Read HW revision from PCI config space (port I/O, NEVER hangs)
     crate::debug::print("wifi", "read_hw_rev_pci");
@@ -331,9 +321,9 @@ pub fn probe_pci_only(ctx: &'static dyn DriverContext) -> Option<RawPciProbeResu
     if ctx.map_mmio_region(info.bar0_phys as usize, mmio_virt, info.bar0_size).is_err() {
         return None;
     }
+    let mmio_base = mmio_virt as *mut u32;
 
     // Sanity-check: verify the device is still present before any MMIO
-    let mmio_base = mmio_virt as *mut u32;
     crate::debug::print("wifi", "check_device_present");
     {
         let vendor = crate::pci::PciConfigSpace::read_config_word(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an MMIO NMI watchdog to detect and recover from stalled hardware access.
  - Improved WiFi initialization recovery, including PCIe reset and link-retraining support.
  - Added automatic scheduler restart after watchdog-based recovery.

- **Bug Fixes**
  - Prevented potential deadlocks during emergency WiFi recovery.
  - Improved handling of failed or unavailable hardware initialization.
  - Added safer MMIO access checks and recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->