### PR TITLE
Defer USB controller activation until first poll

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -405,6 +405,11 @@ released, the kernel integration layer performs FAT probing and mounts through
 Genome. This lock boundary must be preserved: recursively borrowing a
 `USBContext` from a mount callback is prohibited.
 
+USB controller service registration is boot-safe and does not activate BAR
+MMIO. Solvent-triggered polling or explicit re-enumeration activates the
+Nitrogen controller state machine; device discovery and `/dev` registration
+remain separate from filesystem mount policy.
+
 The kernel device registry preserves `/dev/<name>` identity while transferring
 exclusive block-device ownership to a mounted filesystem. An available entry
 contains a device lease; a present entry without a lease means mounted or in

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -20,10 +20,21 @@ companion at `00:1d.0`. Before the first xHCI BAR0 load, Fullerene now:
    routes the firmware-declared USB2 ports (`XUSB2PR`, config `0xd0`) to xHCI;
 3. disables standard ASPM and enables PCI memory decoding/bus mastering;
 4. maps BAR0 uncached and reads the capability header as a 32-bit register;
-5. performs the xHCI BIOS/OS ownership handoff and disables legacy SMIs.
+5. performs the xHCI BIOS/OS ownership handoff, disables legacy SMIs, and
+   waits for `USBSTS.CNR` to clear before operational-register access.
 
-The USB subsystem owns this sequence once per boot, rather than once for every
-USB PCI function. EHCI is initialized once and is not restarted by each poll.
+Boot registers the USB service without touching either controller BAR. The
+sequence above starts on the first service poll or explicit re-enumeration, so
+an uncompleted PCIe read cannot block the boot-critical path. xHCI is
+initialized before its companion; after Intel routing is confirmed and xHCI is
+active, Fullerene does not access the unsupported EHCI companion. EHCI-only
+systems still use the EHCI path, which is initialized once and never restarted
+by polling.
+
+The runtime interrupter register set begins at `RTSOFF + 0x20` (after
+`MFINDEX`); using `RTSOFF` directly writes the wrong registers. Capability,
+operational, runtime, doorbell, and extended-capability offsets are rejected if
+they exceed the mapped BAR window.
 
 `core::ptr::read_volatile`, an MMIO wrapper, inline assembly, and an external
 xHCI crate all ultimately issue the same non-posted CPU load. None can impose a

--- a/fullerene-kernel/src/drivers/registry.rs
+++ b/fullerene-kernel/src/drivers/registry.rs
@@ -12,16 +12,24 @@
 //!
 //! No other kernel file needs to change.
 
+#[cfg(any(not(nitrogen_no_usb), not(nitrogen_no_storage)))]
 use alloc::boxed::Box;
 #[cfg(any(not(nitrogen_no_usb), not(nitrogen_no_storage)))]
 use core::sync::atomic::{AtomicBool, Ordering};
 #[cfg(not(nitrogen_no_usb))]
 use core::sync::atomic::AtomicUsize;
+#[cfg(not(nitrogen_no_usb))]
 use spin::Mutex;
 
+#[cfg(any(not(nitrogen_no_usb), not(nitrogen_no_storage)))]
 use genome::block::BlockDevice;
-use nitrogen::driver_api::{Driver, DriverBox, UsbHostDriver};
+#[cfg(any(not(nitrogen_no_usb), not(nitrogen_no_storage)))]
+use nitrogen::driver_api::{Driver, DriverBox};
+#[cfg(not(nitrogen_no_usb))]
+use nitrogen::driver_api::UsbHostDriver;
+#[cfg(any(not(nitrogen_no_usb), not(nitrogen_no_storage)))]
 use nitrogen::pci::PciDevice;
+#[cfg(any(not(nitrogen_no_usb), not(nitrogen_no_storage)))]
 use nitrogen::DriverContext;
 
 // ────────────────────────────────────────────────────────────
@@ -47,9 +55,16 @@ pub fn with_ctx<F, R>(f: F) -> R
 where
     F: FnOnce(&mut nitrogen::usb::context::USBContext) -> R,
 {
-    let mut guard = USB_CTX.lock();
-    let ctx = guard.as_mut().expect("USB context not initialized");
-    f(ctx)
+    try_with_ctx(f).expect("USB context not initialized")
+}
+
+/// Access the USB controller context when a host driver was discovered.
+#[cfg(not(nitrogen_no_usb))]
+pub fn try_with_ctx<F, R>(f: F) -> Option<R>
+where
+    F: FnOnce(&mut nitrogen::usb::context::USBContext) -> R,
+{
+    USB_CTX.lock().as_mut().map(f)
 }
 
 #[cfg(nitrogen_no_usb)]
@@ -58,6 +73,10 @@ pub struct DummyUsbContext;
 
 #[cfg(nitrogen_no_usb)]
 impl DummyUsbContext {
+    pub fn is_enabled(&self) -> bool {
+        false
+    }
+
     pub fn disks(&self) -> &[DummyUsbDisk] {
         &[]
     }
@@ -79,6 +98,14 @@ where
     F: FnOnce(&mut DummyUsbContext) -> R,
 {
     panic!("USB support not compiled in");
+}
+
+#[cfg(nitrogen_no_usb)]
+pub fn try_with_ctx<F, R>(_f: F) -> Option<R>
+where
+    F: FnOnce(&mut DummyUsbContext) -> R,
+{
+    None
 }
 
 // ── SD card state (formerly drivers/sd_card.rs) ────────────
@@ -194,19 +221,11 @@ struct UsbHostCtl;
 #[cfg(not(nitrogen_no_usb))]
 impl UsbHostDriver for UsbHostCtl {
     fn init(&mut self) -> Result<(), &'static str> {
-        crate::boot_stage::draw_boot_label(b"USB STORAGE");
         nitrogen::debug::set_hint_callback(crate::boot_stage::draw_step_hint);
-
-        let mut ctx = nitrogen::usb::context::USBContext::new(
+        init_usb_ctx(nitrogen::usb::context::USBContext::new(
             &crate::driver_context_impl::KernelDriverContext,
-        );
-        if let Err(e) = ctx.enable() {
-            log::warn!("USB: enable failed: {:?}", e);
-        }
-        crate::drivers::registry::init_usb_ctx(ctx);
-        crate::boot_stage::draw_step_hint(b"usb_pol");
-        crate::drivers::registry::usb_poll_and_register();
-        crate::boot_stage::draw_step_hint(b"usb_reg");
+        ));
+        log::info!("USB: service registered; controller activation deferred");
         Ok(())
     }
     fn poll(&self) {
@@ -266,7 +285,9 @@ impl StorageDriver for SdCardStorageCtl {
 
 /// Populate the `DriverRegistry` with every available driver.
 pub fn build_registry() -> DriverRegistry {
-    let mut reg = DriverRegistry::new();
+    let reg = DriverRegistry::new();
+    #[cfg(any(not(nitrogen_no_usb), not(nitrogen_no_storage)))]
+    let mut reg = reg;
     #[cfg(not(nitrogen_no_storage))]
     {
         reg.register("ahci", Box::new(AhciDriver));
@@ -337,6 +358,14 @@ pub fn poll_usb() -> bool {
     {
         let mut guard = with_ctx_inner();
         if let Some(ctx) = guard.as_mut() {
+            if !ctx.is_enabled() {
+                crate::boot_stage::draw_step_hint(b"usb_init");
+                if let Err(e) = ctx.enable() {
+                    log::warn!("USB: enable failed: {:?}", e);
+                    return false;
+                }
+            }
+            crate::boot_stage::draw_step_hint(b"usb_poll");
             ctx.poll();
         }
     }
@@ -357,29 +386,13 @@ pub fn poll_usb() -> bool {
 #[cfg(not(nitrogen_no_usb))]
 fn usb_poll_and_register() {
     for i in 0..8 {
-        {
-            let mut guard = with_ctx_inner();
-            if let Some(ctx) = guard.as_mut() {
-                let disk_count_before = ctx.disks().len();
-                log::info!(
-                    "USB: poll #{}, disks before: {}",
-                    i + 1, disk_count_before
-                );
-                ctx.poll();
-                let disk_count_after = ctx.disks().len();
-                log::info!(
-                    "USB: poll #{}, disks after: {}",
-                    i + 1, disk_count_after
-                );
-                if !ctx.disks().is_empty() {
-                    log::info!("USB: device detected after {} retries", i + 1);
-                    break;
-                }
-            }
+        log::info!("USB: poll #{}", i + 1);
+        if poll_usb() || LAST_REGISTERED_USB_COUNT.load(Ordering::Relaxed) > 0 {
+            log::info!("USB: device detected after {} polls", i + 1);
+            break;
         }
         nitrogen::timing::delay_ms(250);
     }
-    register_pending_usb();
 }
 
 /// Full USB re-enumeration (clear + re-scan).  Does NOT mount.
@@ -402,12 +415,9 @@ pub fn poll_usb_all() -> bool {
     }
     LAST_REGISTERED_USB_COUNT.store(0, Ordering::Relaxed);
 
-    use crate::driver_context_impl::KernelDriverContext;
-    let mut ctx = nitrogen::usb::context::USBContext::new(&KernelDriverContext);
-    if let Err(e) = ctx.enable() {
-        log::warn!("USB: enable failed during re-enumeration: {:?}", e);
-    }
-    init_usb_ctx(ctx);
+    init_usb_ctx(nitrogen::usb::context::USBContext::new(
+        &crate::driver_context_impl::KernelDriverContext,
+    ));
     usb_poll_and_register();
     let registered = LAST_REGISTERED_USB_COUNT.load(Ordering::Relaxed) > 0;
     let _ = crate::klog::flush_to_vfs();
@@ -559,10 +569,8 @@ impl BlockDevice for SdBlockDev {
 /// Call from a background timer tick.  Returns `true` if any
 /// driver reported a state change.
 pub fn poll_all(_registry: &DriverRegistry) -> bool {
-    let mut changed = false;
     #[cfg(not(nitrogen_no_usb))]
-    {
-        changed |= poll_usb();
-    }
-    changed
+    return poll_usb();
+    #[cfg(nitrogen_no_usb)]
+    false
 }

--- a/fullerene-kernel/src/init.rs
+++ b/fullerene-kernel/src/init.rs
@@ -219,12 +219,9 @@ pub fn init_common(_physical_memory_offset: x86_64::VirtAddr) {
             let mut scanner = nitrogen::pci::PciScanner::new();
             let _ = scanner.scan_all_buses();
 
-            // Pre-process: establish safe PCI state for every device before
-            // any driver is probed.  This ensures bridges have memory decoding
-            // enabled and all endpoints are in D0 with ASPM disabled, so the
-            // first MMIO access by any driver never hits a device in L1 or
-            // behind a bridge with memory decoding off.
-            let mut healthy_devices = alloc::vec::Vec::new();
+            // Keep discovery read-only.  Each Nitrogen driver owns the power,
+            // decode and link-state transition immediately before its MMIO.
+            let mut present_devices = alloc::vec::Vec::new();
             for dev in scanner.get_devices() {
                 // Log each device so we can identify where real hardware hangs.
                 {
@@ -242,20 +239,16 @@ pub fn init_common(_physical_memory_offset: x86_64::VirtAddr) {
                     hex_char(dev.function >> 4), hex_char(dev.function & 0xF),
                 ];
                 crate::boot_stage::draw_step_hint(&hint_bcd);
-                dev.disable_pcie_aspm();
-                dev.enable_memory_access();
-                dev.ensure_d0();
-                // Quick MMIO-safety check
                 let vid = nitrogen::pci::PciConfigSpace::read_config_word(
                     dev.bus, dev.device, dev.function, 0,
                 );
                 if vid == 0xFFFF || vid == 0x0000 { continue; }
-                healthy_devices.push(dev.clone());
+                present_devices.push(dev.clone());
             }
 
             // DriverManager orchestrates probe → priority → attach → registration
             let mgr = DRIVER_MGR.call_once(crate::hardware::driver_manager::DriverManager::new);
-            mgr.discover_and_attach(&registry, ctx, &healthy_devices);
+            mgr.discover_and_attach(&registry, ctx, &present_devices);
 
             petroleum::write_serial_bytes(0x3F8, 0x3FD, b"[init] Device probe step done\n");
             Ok(())
@@ -331,15 +324,6 @@ pub fn init_common(_physical_memory_offset: x86_64::VirtAddr) {
                 .map_err(|_| "Failed to initialize device manager")?;
             petroleum::serial::serial_log(format_args!("Device manager initialised\n"));
             petroleum::write_serial_bytes(0x3F8, 0x3FD, b"[step] device_mgr done\n");
-            Ok(())
-        }),
-        petroleum::init_step!("usb_storage", || {
-            petroleum::write_serial_bytes(0x3F8, 0x3FD, b"[step] usb_storage start\n");
-            crate::boot_stage::draw_boot_label(b"USB STORAGE");
-            crate::boot_stage::draw_step_hint(b"pre_log"); // drawn BEFORE serial_log
-            petroleum::serial::serial_log(format_args!("USB storage subsystem initialised\n"));
-            crate::boot_stage::draw_step_hint(b"usb_ok ");
-            petroleum::write_serial_bytes(0x3F8, 0x3FD, b"[step] usb_storage done\n");
             Ok(())
         }),
         petroleum::init_step!("sd_card", || {

--- a/fullerene-kernel/src/shell.rs
+++ b/fullerene-kernel/src/shell.rs
@@ -530,14 +530,17 @@ fn register_nozzle_hooks() {
             for name in crate::devfs::list_block_device_names() {
                 tline!(ctx.terminal, "  /dev/{}", name);
             }
-            // Also show full USB context status
-            registry::with_ctx(|ctx_usb| {
+            // Also show full USB context status without assuming a controller exists.
+            if registry::try_with_ctx(|ctx_usb| {
+                tline!(ctx.terminal, "USB controller: {}", if ctx_usb.is_enabled() { "active" } else { "deferred" });
                 tline!(ctx.terminal, "USBContext: {} disk(s) enumerated", ctx_usb.disks().len());
                 for disk in ctx_usb.disks() {
                     tline!(ctx.terminal, "  ctrl={} dev_addr={} ep_out=0x{:02x} ep_in=0x{:02x} blk_size={} total_blocks={}",
                         disk.ctrl_type, disk.dev_addr, disk.ep_out, disk.ep_in, disk.block_size, disk.total_blocks);
                 }
-            });
+            }).is_none() {
+                tline!(ctx.terminal, "USB controller: unavailable");
+            }
         }
         "pci" => {
             use alloc::format;

--- a/nitrogen/src/usb/context.rs
+++ b/nitrogen/src/usb/context.rs
@@ -1,8 +1,8 @@
 //! USBContext — top-level USB subsystem.
 //!
 //! Owns all controllers, port managers, device drivers, and storage
-//! devices.  The kernel calls [`USBContext::enable`] once at boot,
-//! then [`USBContext::poll`] periodically for hotplug.
+//! devices.  The service may be registered during boot and activated on
+//! demand with [`USBContext::enable`], then polled for hotplug.
 //!
 //! # Usage
 //!
@@ -35,7 +35,7 @@ struct ControllerManager {
 }
 
 impl ControllerManager {
-    fn route_intel_ports_to_xhci(devices: &[crate::pci::PciDevice]) {
+    fn route_intel_ports_to_xhci(devices: &[crate::pci::PciDevice]) -> bool {
         use crate::pci::PciConfigSpace;
 
         let has_intel_ehci = devices.iter().any(|dev| {
@@ -45,9 +45,10 @@ impl ControllerManager {
                 && dev.prog_if == 0x20
         });
         if !has_intel_ehci {
-            return;
+            return false;
         }
 
+        let mut routed = false;
         for dev in devices.iter().filter(|dev| {
             dev.vendor_id == 0x8086
                 && dev.class_code == 0x0C
@@ -85,14 +86,18 @@ impl ControllerManager {
                 XUSB2PR,
                 usb2,
             );
+            let usb2_active = read(XUSB2PR);
+            let usb3_active = read(USB3_PSSEN);
+            routed |= usb2 != 0 && usb2_active == usb2;
             log::info!(
                 "USB: Intel routing USB2={:#x}/{:#x} USB3={:#x}/{:#x}",
-                read(XUSB2PR),
+                usb2_active,
                 usb2,
-                read(USB3_PSSEN),
+                usb3_active,
                 usb3,
             );
         }
+        routed
     }
 
     /// Scan the PCI bus and initialise every USB controller found.
@@ -105,13 +110,30 @@ impl ControllerManager {
             log::info!("USB: PCI scan failed: {:?}", e);
             return;
         }
-        Self::route_intel_ports_to_xhci(scanner.get_devices());
-        let mut found_any = false;
-        for dev in scanner.get_devices() {
-            if dev.class_code != 0x0C || dev.subclass != 0x03 {
+        let intel_ports_routed = Self::route_intel_ports_to_xhci(scanner.get_devices());
+        let mut controllers: Vec<_> = scanner
+            .get_devices()
+            .iter()
+            .filter(|dev| dev.class_code == 0x0C && dev.subclass == 0x03)
+            .collect();
+        // Initialise xHCI before its EHCI companion regardless of PCI scan order.
+        controllers.sort_by_key(|dev| dev.prog_if != 0x30);
+        let found_any = !controllers.is_empty();
+        let mut intel_xhci_active = false;
+        for dev in controllers {
+            if dev.prog_if == 0x20
+                && dev.vendor_id == 0x8086
+                && intel_ports_routed
+                && intel_xhci_active
+            {
+                log::info!(
+                    "USB: skipping routed Intel EHCI companion at {:02x}:{:02x}.{}",
+                    dev.bus,
+                    dev.device,
+                    dev.function
+                );
                 continue;
             }
-            found_any = true;
             log::info!(
                 "USB: found controller at {:02x}:{:02x}.{} (vendor={:#06x} device={:#06x})",
                 dev.bus, dev.device, dev.function, dev.vendor_id, dev.device_id
@@ -128,8 +150,7 @@ impl ControllerManager {
             // Avoid destructive BAR-size probing while firmware or a previous
             // controller instance may still be active. Mapping extra pages is
             // harmless; no transaction occurs until a register is accessed.
-            const USB_BAR_MAP_SIZE: usize = 0x1_0000;
-            let bar_size = USB_BAR_MAP_SIZE;
+            let bar_size = super::HOST_CONTROLLER_BAR_SIZE;
 
             let mmio_virt = ctx.phys_to_virt(mmio_base) as *mut u8;
             if mmio_virt.is_null() {
@@ -237,6 +258,7 @@ impl ControllerManager {
                         if hc.init().is_ok() {
                             log::info!("USB: xHCI init OK, {} ports", hc.n_ports());
                             self.xhci.push(Box::new(hc));
+                            intel_xhci_active |= dev.vendor_id == 0x8086;
                         } else {
                             log::info!("USB: xHCI init failed for {:02x}:{:02x}.{}",
                                 dev.bus, dev.device, dev.function);
@@ -268,7 +290,6 @@ impl ControllerManager {
         let mut xhci_devices: Vec<(usize, usize)> = Vec::new();
 
         for (idx, ehci) in self.ehci.iter_mut().enumerate() {
-            let _ = ehci.start();
             let old = ehci.devices().len();
             let new = ehci.poll_ports();
             if new > 0 {
@@ -295,51 +316,6 @@ impl ControllerManager {
         }
     }
 
-    fn debug_dump(&self) {
-        log::info!("=== USB DEBUG ===");
-        for (i, ehci) in self.ehci.iter().enumerate() {
-            log::info!("EHCI[{}]: {} ports", i, ehci.n_ports());
-            for p in 0..(ehci.n_ports().min(4)) {
-                let ps = ehci.read_portsc(p);
-                log::info!(
-                    "  PORTSC[{}]=0x{:08X} CCS={} PE={}",
-                    p,
-                    ps,
-                    ps & 1,
-                    (ps >> 2) & 1
-                );
-            }
-        }
-        for (i, xhci) in self.xhci.iter().enumerate() {
-            log::info!(
-                "xHCI[{}] ppc={} n_ports={} max_slots={} ports_done={:#x} legacy={}",
-                i,
-                xhci.ppc_enabled(),
-                xhci.n_ports(),
-                xhci.max_slots(),
-                xhci.ports_done_mask(),
-                xhci.legacy_handoff_done()
-            );
-            for p in 0..xhci.n_ports() {
-                let ps = xhci.read_portsc(p);
-                if ps == 0xFFFF_FFFF {
-                    continue;
-                }
-                log::info!(
-                    "xHCI PORTSC[{}]={:#x} CCS={} PED={} PLS={} PP={} PR={} speed={}",
-                    p,
-                    ps,
-                    ps & 1,
-                    (ps >> 1) & 1,
-                    (ps >> 5) & 0xF,
-                    (ps >> 9) & 1,
-                    (ps >> 4) & 1,
-                    (ps >> 10) & 0xF
-                );
-            }
-        }
-        log::info!("=== USB END ===");
-    }
 }
 
 /// Events from a single poll cycle.
@@ -354,12 +330,13 @@ struct ControllerEvent {
 
 /// Top-level USB subsystem handle.
 ///
-/// Call [`enable`](Self::enable) once at boot; call [`poll`](Self::poll)
-/// from a background timer to handle hotplug.
+/// Call [`enable`](Self::enable) before the first poll, then call
+/// [`poll`](Self::poll) from the service scheduler to handle hotplug.
 pub struct USBContext {
     controllers: ControllerManager,
     storage: StorageManager,
     driver_ctx: &'static dyn DriverContext,
+    enabled: bool,
 }
 
 impl USBContext {
@@ -369,16 +346,22 @@ impl USBContext {
             controllers: ControllerManager::default(),
             storage: StorageManager::new(),
             driver_ctx,
+            enabled: false,
         }
     }
 
-    /// Enable USB: scan PCI, initialise controllers, poll once, and discover
-    /// mass-storage devices without invoking filesystem policy.
+    /// Enable USB hardware without invoking polling or filesystem policy.
     pub fn enable(&mut self) -> Result<(), &'static str> {
+        if self.enabled {
+            return Ok(());
+        }
         self.controllers.init_controllers(self.driver_ctx);
-        self.controllers.debug_dump();
-        self.poll();
+        self.enabled = true;
         Ok(())
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
     }
 
     /// Poll all controllers for hotplug events and register new storage.

--- a/nitrogen/src/usb/mod.rs
+++ b/nitrogen/src/usb/mod.rs
@@ -34,6 +34,9 @@ pub mod msd;
 pub mod scsi;
 pub mod usb_bus;
 
+/// MMIO window mapped for a USB host-controller BAR.
+pub(crate) const HOST_CONTROLLER_BAR_SIZE: usize = 0x1_0000;
+
 /// USB device speed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UsbSpeed {

--- a/nitrogen/src/usb/xhci/context.rs
+++ b/nitrogen/src/usb/xhci/context.rs
@@ -96,14 +96,15 @@ impl XhciContext {
         crate::timing::delay_us(100);
 
         // ── Step 1: Read capability registers ─────────────────
+        crate::debug::hint(b"xh_cap");
         let Some(cap_regs) = (unsafe { CapabilityRegisters::read(mmio_base) }) else {
             log::warn!("xHCI: invalid or inaccessible capability header");
             return None;
         };
-        let caplength = cap_regs.caplength;
-        let op_off = caplength;
-        let rt_off = cap_regs.rt_offset;
-        let db_off = cap_regs.db_offset;
+        crate::debug::hint(b"xh_capok");
+        let op_off = cap_regs.caplength as usize;
+        let rt_off = cap_regs.rt_offset as usize;
+        let db_off = cap_regs.db_offset as usize;
 
         let hcs1 = cap_regs.hcs_params1();
         let hcc1 = cap_regs.hcc_params1();
@@ -119,6 +120,25 @@ impl XhciContext {
             || cap_regs.rt_offset == 0
         {
             log::warn!("xHCI: invalid or inaccessible capability registers");
+            return None;
+        }
+
+        let bar_size = crate::usb::HOST_CONTROLLER_BAR_SIZE;
+        let in_bar = |offset: usize, len: usize| {
+            offset
+                .checked_add(len)
+                .is_some_and(|end| end <= bar_size)
+        };
+        let op_len = OP_PORTSC_BASE
+            .checked_add(n_ports as usize * OP_PORTSC_STRIDE)
+            .and_then(|len| len.checked_add(4));
+        let rt_len = RT_INTERRUPTER_STRIDE * 2;
+        let db_len = (max_slots as usize + 1) * 4;
+        if op_len.is_none_or(|len| !in_bar(op_off, len))
+            || !in_bar(rt_off, rt_len)
+            || !in_bar(db_off, db_len)
+        {
+            log::warn!("xHCI: capability offsets exceed mapped BAR window");
             return None;
         }
 
@@ -140,12 +160,12 @@ impl XhciContext {
         );
         log::info!("xHCI: HCIVERSION=0x{:04X}", cap_regs.hci_version,);
 
-        // ── Step 2: Dump extended capabilities ────────────────
-        if hcc1.ext_cap_ptr != 0 {
-            dump_extended_capabilities(mmio_base, hcc1.ext_cap_ptr);
-        }
+        // ── Step 2: Extended capabilities ─────────────────────
+        // Consumers below traverse them as needed; a diagnostic dump would
+        // duplicate every risky MMIO read.
 
         // ── Step 3: Legacy handoff ────────────────────────────
+        crate::debug::hint(b"xh_leg");
         let legacy_ok = match try_legacy_handoff(mmio_base, hcc1.ext_cap_ptr) {
             Ok(true) => true,  // OS already owns
             Ok(false) => true, // handoff succeeded
@@ -154,11 +174,13 @@ impl XhciContext {
                 return None;
             }
         };
+        crate::debug::hint(b"xh_legok");
 
         // ── Step 4: Create sub-contexts ───────────────────────
-        let op_base = unsafe { mmio_base.add(op_off as usize) };
-        let rt_base = unsafe { mmio_base.add(rt_off as usize) };
-        let db_base = unsafe { mmio_base.add(db_off as usize) };
+        let op_base = unsafe { mmio_base.add(op_off) };
+        // Runtime interrupter set 0 starts 0x20 bytes after MFINDEX.
+        let rt_base = unsafe { mmio_base.add(rt_off + RT_INTERRUPTER_STRIDE) };
+        let db_base = unsafe { mmio_base.add(db_off) };
 
         let registers = RegisterContext {
             mmio_base,
@@ -168,13 +190,14 @@ impl XhciContext {
             doorbell: unsafe { DoorbellRegisters::new(db_base) },
         };
 
+        crate::debug::hint(b"xh_dma");
         let rings = RingContext::alloc(ctx, 256, 256)?;
         let device = DeviceContextSet::new(ctx, max_slots, scratchpad_bufs)?;
         let port_protocols = parse_port_protocols(mmio_base, hcc1.ext_cap_ptr, n_ports);
         let ports = PortContext::new(n_ports, ppc, Some(&port_protocols));
         let interrupts = InterruptContext::new();
 
-        Some(Self {
+        let controller = Self {
             registers,
             rings,
             device,
@@ -186,7 +209,9 @@ impl XhciContext {
             legacy_handoff_done: legacy_ok,
             erst_phys: None,
             deferred_free_list: Vec::new(),
-        })
+        };
+        crate::debug::hint(b"xh_newok");
+        Some(controller)
     }
 
     /// Get a reference to the driver context.
@@ -238,6 +263,17 @@ impl XhciContext {
             return Err("xHCI device gone");
         }
 
+        // Match Linux's early handoff: wait until the controller accepts
+        // operational-register accesses before attempting halt or reset.
+        crate::debug::hint(b"xh_cnr");
+        if crate::timing::wait_timeout_us(5_000_000, || {
+            self.registers.op.usbsts() & USBSTS_CNR == 0
+        })
+        .is_err()
+        {
+            return Err("controller not ready before init");
+        }
+
         // Phase 1: Full HCRST.
         // Stop the controller first (it cannot be running during HCRST).
         let sts = self.registers.op.usbsts();
@@ -245,7 +281,9 @@ impl XhciContext {
             log::info!("xHCI: controller running, halting before HCRST");
             self.registers
                 .op
-                .set_usbcmd(self.registers.op.usbcmd() & !USBCMD_RS);
+                .set_usbcmd(
+                    self.registers.op.usbcmd() & !(USBCMD_RS | USBCMD_INTE | USBCMD_HSEE),
+                );
             if crate::timing::wait_timeout_us(500_000, || {
                 self.registers.op.usbsts() & USBSTS_HCH != 0
             }).is_err() {
@@ -253,6 +291,7 @@ impl XhciContext {
             }
         }
 
+        crate::debug::hint(b"xh_reset");
         self.controller_reset()?;
         self.configure_before_start();
         self.setup_erst()?;
@@ -264,9 +303,12 @@ impl XhciContext {
             self.clear_hse_and_recover();
         }
 
+        crate::debug::hint(b"xh_start");
         self.start_controller()?;
         self.clear_hse_and_recover();
+        crate::debug::hint(b"xh_ports");
         self.init_ports();
+        crate::debug::hint(b"xh_ready");
 
         Ok(())
     }

--- a/nitrogen/src/usb/xhci/register.rs
+++ b/nitrogen/src/usb/xhci/register.rs
@@ -417,11 +417,23 @@ pub struct RegisterContext {
 //  Legacy / Extended Capabilities
 // ══════════════════════════════════════════════════════════════
 
+fn extended_cap_in_bounds(dword_offset: usize, bytes: usize) -> bool {
+    dword_offset != 0
+        && dword_offset
+            .checked_mul(4)
+            .and_then(|offset| offset.checked_add(bytes))
+            .is_some_and(|end| end <= crate::usb::HOST_CONTROLLER_BAR_SIZE)
+}
+
+fn next_extended_cap(offset: usize, next: u8) -> Option<usize> {
+    (next != 0).then(|| offset.checked_add(next as usize)).flatten()
+}
+
 pub fn dump_extended_capabilities(mmio_base: *mut u8, ext_cap_ptr: u16) {
     let m = Mmio(mmio_base);
     let mut off = ext_cap_ptr as usize;
     let mut iters = 0;
-    while off != 0 && off < 0x100000 {
+    while extended_cap_in_bounds(off, 12) {
         iters += 1;
         if iters > 64 {
             log::warn!("xHCI: EC list exceeded max iterations");
@@ -459,10 +471,8 @@ pub fn dump_extended_capabilities(mmio_base: *mut u8, ext_cap_ptr: u16) {
                 if major_rev >= 3 { "USB 3.x" } else { "USB 2.0" }
             );
         }
-        if ec_next == 0 {
-            break;
-        }
-        off += ec_next as usize;
+        let Some(next) = next_extended_cap(off, ec_next) else { break };
+        off = next;
     }
 }
 
@@ -478,7 +488,7 @@ pub fn parse_port_protocols(
     let mut bitmap = alloc::vec![0u32; n_words];
     let mut off = ext_cap_ptr as usize;
     let mut iters = 0;
-    while off != 0 && off < 0x100000 {
+    while extended_cap_in_bounds(off, 12) {
         iters += 1;
         if iters > 64 {
             log::warn!("xHCI: parse_port_protocols exceeded max iterations");
@@ -490,10 +500,8 @@ pub fn parse_port_protocols(
             let port_off = (dw2 & 0xFF) as u32;
             if port_off == 0 {
                 let next = (m.read32(off * 4) >> 8) as u8;
-                if next == 0 {
-                    break;
-                }
-                off += next as usize;
+                let Some(next) = next_extended_cap(off, next) else { break };
+                off = next;
                 continue;
             }
             let port_cnt = ((dw2 >> 8) & 0xFF) as u32;
@@ -515,10 +523,8 @@ pub fn parse_port_protocols(
             }
         }
         let ec_next = (m.read32(off * 4) >> 8) as u8;
-        if ec_next == 0 {
-            break;
-        }
-        off += ec_next as usize;
+        let Some(next) = next_extended_cap(off, ec_next) else { break };
+        off = next;
     }
     bitmap
 }
@@ -526,15 +532,14 @@ pub fn parse_port_protocols(
 pub fn try_legacy_handoff(mmio_base: *mut u8, ext_cap_ptr: u16) -> Result<bool, &'static str> {
     const BIOS_OWNED: u32 = 1 << 16;
     const OS_OWNED: u32 = 1 << 24;
-    // Preserve SMI enables (bits 29-31) in their BIOS-default state.
-    // Enabling USB SMIs on real hardware can cause SMM-BIOS/OS-MMIO
-    // conflicts that manifest as a complete system hang.
-    const LEGACY_PRESERVE: u32 = (0x7 << 1) | (0xFF << 5) | (0x7 << 17) | (0x7 << 29);
+    // Preserve reserved fields, disable SMI enables, and clear RW1C events.
+    const LEGACY_DISABLE_SMI: u32 = (0x7 << 1) | (0xFF << 5) | (0x7 << 17);
+    const LEGACY_SMI_EVENTS: u32 = 0x7 << 29;
 
     let m = Mmio(mmio_base);
     let mut off = ext_cap_ptr as usize;
     let mut iters = 0;
-    while off != 0 && off < 0x100000 {
+    while extended_cap_in_bounds(off, 8) {
         iters += 1;
         if iters > 64 {
             return Err("circular capability list");
@@ -545,7 +550,10 @@ pub fn try_legacy_handoff(mmio_base: *mut u8, ext_cap_ptr: u16) -> Result<bool, 
             let legsup = m.read32(cap_base);
             if legsup & BIOS_OWNED == 0 {
                 let control = m.read32(cap_base + 4);
-                m.write32(cap_base + 4, control & LEGACY_PRESERVE);
+                m.write32(
+                    cap_base + 4,
+                    (control & LEGACY_DISABLE_SMI) | LEGACY_SMI_EVENTS,
+                );
                 return Ok(true);
             }
             m.write32(cap_base, legsup | OS_OWNED);
@@ -558,14 +566,15 @@ pub fn try_legacy_handoff(mmio_base: *mut u8, ext_cap_ptr: u16) -> Result<bool, 
                 m.write32(cap_base, (m.read32(cap_base) | OS_OWNED) & !BIOS_OWNED);
             }
             let control = m.read32(cap_base + 4);
-            m.write32(cap_base + 4, control & LEGACY_PRESERVE);
+            m.write32(
+                cap_base + 4,
+                (control & LEGACY_DISABLE_SMI) | LEGACY_SMI_EVENTS,
+            );
             return Ok(false);
         }
         let ec_next = (m.read32(off * 4) >> 8) as u8;
-        if ec_next == 0 {
-            break;
-        }
-        off += ec_next as usize;
+        let Some(next) = next_extended_cap(off, ec_next) else { break };
+        off = next;
     }
     Ok(true)
 }
@@ -805,9 +814,23 @@ mod tests {
     #[test]
     fn test_legacy_handoff_no_bios() {
         let sim = SimHc::new(2);
-        let result = try_legacy_handoff(sim.base(), 0x3000);
+        let result = try_legacy_handoff(sim.base(), 0x3000 / 4);
         // No legacy support capability → Ok(true) = OS owns controller
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_legacy_handoff_disables_smi_and_clears_events() {
+        let mut sim = SimHc::new(2);
+        let ec_base = 0x3000;
+        sim.write_hw(ec_base, 1 | (1 << 24));
+        sim.write_hw(ec_base + 4, u32::MAX);
+
+        assert_eq!(try_legacy_handoff(sim.base(), (ec_base / 4) as u16), Ok(true));
+        assert_eq!(
+            sim.read_hw(ec_base + 4),
+            (0x7 << 1) | (0xFF << 5) | (0x7 << 17) | (0x7 << 29)
+        );
     }
 
     #[test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - USB controllers can now be activated on demand, with hotplug devices discovered during polling or re-enumeration.
  - System information now reports whether USB is active, deferred, or unavailable.

- **Bug Fixes**
  - Improved USB controller compatibility during startup, including safer Intel xHCI/EHCI handoff handling.
  - Added safeguards to prevent invalid hardware-register access and boot delays.
  - Improved USB device registration and recovery during polling.

- **Documentation**
  - Updated architecture and hardware guidance to describe deferred activation, controller ordering, and compatibility requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->