### PR TITLE
Expose registered storage through dynamic devfs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -416,6 +416,12 @@ exclusive block-device ownership to a mounted filesystem. An available entry
 contains a device lease; a present entry without a lease means mounted or in
 use. Controller re-enumeration must not invalidate an outstanding lease.
 
+`/dev` is a `DevFs` mount backed directly by that registry, not a tmpfs with
+manually-created placeholder files. Consequently registration and removal are
+visible immediately and `/dev/null` is supplied by DevFs itself. Media
+discovery remains distinct from mounting: `sd_rescan` may retry an inserted SD
+card, while `mount /dev/sd0 <path>` only acquires and mounts its existing lease.
+
 The kernel crate re-exports Genome types and adds the singleton `VfsContext` (wrapping `Vfs` with `spin::Mutex` + handle table) through the kernel's `vfs` and `fs` modules, keeping the core logic framework-agnostic.
 
 ---

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -48,6 +48,11 @@ recovery remains a platform mechanism, not a replacement read primitive.
 Real-hardware validation is still required for the complete controller reset,
 port enumeration, and mass-storage path on this machine.
 
+The Realtek RTS5249 reader (`10ec:5249`) is matched by vendor/device identity,
+because PCI class `0xff` is a real vendor-specific class rather than a driver
+wildcard. An SDXC successfully initialized at boot appears dynamically as
+`/dev/sd0`; `sd_rescan` retries discovery after insertion without mounting it.
+
 Reference: Linux [`drivers/usb/host/pci-quirks.c`](https://github.com/torvalds/linux/blob/master/drivers/usb/host/pci-quirks.c)
 and [`drivers/usb/host/xhci-ext-caps.h`](https://github.com/torvalds/linux/blob/master/drivers/usb/host/xhci-ext-caps.h).
 

--- a/fullerene-kernel/src/contexts/vfs.rs
+++ b/fullerene-kernel/src/contexts/vfs.rs
@@ -332,6 +332,7 @@ where
 ///
 /// Supported `fs_type` values:
 /// - `"tmpfs"` — mounts a fresh in-memory filesystem ([`MemFileSystem`]).
+/// - `"devfs"` — mounts the kernel's dynamic device filesystem.
 /// - `"fat32"` — mounts a FAT32/exFAT filesystem backed by a block device.
 ///
 /// The `device` argument is the path to a block device that the kernel
@@ -342,6 +343,11 @@ pub fn mount(device: &str, mount_point: &str, fs_type: &str) -> Result<(), FsErr
             let memfs = Box::new(MemFileSystem::new());
             vfs.mount(mount_point, memfs)?;
             log::info!("VFS: mounted tmpfs from {} at {}", device, mount_point);
+            Ok(())
+        }
+        "devfs" => {
+            vfs.mount(mount_point, Box::new(crate::devfs::DevFs::new()))?;
+            log::info!("VFS: mounted devfs at {}", mount_point);
             Ok(())
         }
         "fat32" => {

--- a/fullerene-kernel/src/devfs.rs
+++ b/fullerene-kernel/src/devfs.rs
@@ -1,5 +1,5 @@
 use alloc::boxed::Box;
-use alloc::collections::BTreeMap;
+use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::sync::atomic::{AtomicU32, Ordering};
@@ -11,6 +11,7 @@ use genome::vfs::{FileDescriptor, FileSystem, InodeType, VNode};
 use nitrogen::driver_api::DriverBox;
 
 static DEVICE_REGISTRY: Mutex<BTreeMap<String, DriverBox>> = Mutex::new(BTreeMap::new());
+const NULL_DEVICE: &str = "null";
 
 pub fn register_driver(name: &str, driver: DriverBox) {
     DEVICE_REGISTRY.lock().insert(name.to_string(), driver);
@@ -42,17 +43,17 @@ impl FileSystem for DevFs {
         if path.is_empty() {
             return None;
         }
-        let registry = DEVICE_REGISTRY.lock();
-        if registry.contains_key(path) {
-            drop(registry);
-            let ino = stable_ino(path);
-            let fd = next_fd();
-            let name = path.to_string();
-            FD_TABLE.lock().push(FdEntry { name, fd, offset: 0 });
-            Some(FileDescriptor { fd, ino, offset: 0, flags: 0 })
-        } else {
-            None
+        if path != NULL_DEVICE
+            && !DEVICE_REGISTRY.lock().contains_key(path)
+            && !block_device_exists(path)
+        {
+            return None;
         }
+        let ino = stable_ino(path);
+        let fd = next_fd();
+        let name = path.to_string();
+        FD_TABLE.lock().push(FdEntry { name, fd, offset: 0 });
+        Some(FileDescriptor { fd, ino, offset: 0, flags: 0 })
     }
 
     fn read(&mut self, fd: u32, buf: &mut [u8]) -> Result<usize, FsError> {
@@ -61,6 +62,9 @@ impl FileSystem for DevFs {
             let entry = table.iter().find(|e| e.fd == fd).ok_or(FsError::InvalidFileDescriptor)?;
             (entry.name.clone(), entry.offset)
         };
+        if name == NULL_DEVICE {
+            return Ok(0);
+        }
         // TODO: registry lock held during I/O blocks other registry ops.
         // Refactor to use ref-counted driver handles so the lock is dropped before I/O.
         let (result, new_offset) = {
@@ -112,6 +116,12 @@ impl FileSystem for DevFs {
             let entry = table.iter().find(|e| e.fd == fd).ok_or(FsError::InvalidFileDescriptor)?;
             (entry.name.clone(), entry.offset)
         };
+        if name == NULL_DEVICE {
+            if let Some(entry) = FD_TABLE.lock().iter_mut().find(|entry| entry.fd == fd) {
+                entry.offset = entry.offset.saturating_add(data.len());
+            }
+            return Ok(data.len());
+        }
         let (result, new_offset) = {
             let registry = DEVICE_REGISTRY.lock();
             match registry.get(&name) {
@@ -194,9 +204,12 @@ impl FileSystem for DevFs {
         if !path.is_empty() {
             return Err(FsError::NotADirectory);
         }
-        let registry = DEVICE_REGISTRY.lock();
-        Ok(registry.keys().map(|name| VNode {
-            name: name.clone(),
+        let mut names = BTreeSet::new();
+        names.insert(String::from(NULL_DEVICE));
+        names.extend(DEVICE_REGISTRY.lock().keys().cloned());
+        names.extend(BLOCK_DEVICE_REGISTRY.lock().keys().cloned());
+        Ok(names.into_iter().map(|name| VNode {
+            name,
             size: 0,
             is_dir: false,
         }).collect())
@@ -204,7 +217,10 @@ impl FileSystem for DevFs {
 
     fn exists(&mut self, path: &str) -> bool {
         let path = path.trim_start_matches('/');
-        path.is_empty() || DEVICE_REGISTRY.lock().contains_key(path)
+        path.is_empty()
+            || path == NULL_DEVICE
+            || DEVICE_REGISTRY.lock().contains_key(path)
+            || block_device_exists(path)
     }
 }
 

--- a/fullerene-kernel/src/drivers/registry.rs
+++ b/fullerene-kernel/src/drivers/registry.rs
@@ -246,8 +246,8 @@ pub struct SdCardDriver;
 
 #[cfg(not(nitrogen_no_storage))]
 impl Driver for SdCardDriver {
-    fn pci_class(&self) -> Option<(u8, u8)> {
-        Some((0xFF, 0x00)) // vendor-specific (RTSX)
+    fn pci_id(&self) -> (u16, u16) {
+        (0x10EC, 0x5249)
     }
     fn probe(&self, _ctx: &dyn DriverContext, _device: &PciDevice) -> DriverBox {
         DriverBox::Storage(Box::new(SdCardStorageCtl))
@@ -510,9 +510,6 @@ fn register_pending_usb() {
 
         crate::klog_fmt!("USB: registered /dev/{} (bulk-only)\n", dev_name);
         crate::devfs::register_block_device(dev_name.clone(), bdev);
-
-        let _ = crate::contexts::vfs::mkdir("/dev");
-        let _ = crate::contexts::vfs::create(&alloc::format!("/dev/{}", dev_name));
     }
     let _ = crate::klog::flush_to_vfs();
 }
@@ -569,9 +566,6 @@ pub fn sd_probe_and_register() -> bool {
     let dev_name = alloc::format!("sd{}", 0);
     crate::klog_fmt!("SD card: registered /dev/{}\n", dev_name);
     crate::devfs::register_block_device(dev_name.clone(), bdev);
-
-    let _ = crate::contexts::vfs::mkdir("/dev");
-    let _ = crate::contexts::vfs::create(&alloc::format!("/dev/{}", dev_name));
     true
 }
 

--- a/fullerene-kernel/src/init.rs
+++ b/fullerene-kernel/src/init.rs
@@ -207,8 +207,9 @@ pub fn init_common(_physical_memory_offset: x86_64::VirtAddr) {
         petroleum::init_step!("devfs", || {
             petroleum::write_serial_bytes(0x3F8, 0x3FD, b"[step] devfs start\n");
             let _ = crate::contexts::vfs::mkdir("/dev");
-            let _ = crate::contexts::vfs::mount("", "/dev", "tmpfs");
-            petroleum::serial::serial_log(format_args!("DevFS /dev/ mounted\n"));
+            crate::contexts::vfs::mount("", "/dev", "devfs")
+                .map_err(|_| "Failed to mount DevFS")?;
+            petroleum::serial::serial_log(format_args!("DevFS mounted at /dev\n"));
             petroleum::write_serial_bytes(0x3F8, 0x3FD, b"[step] devfs done\n");
             Ok(())
         }),

--- a/fullerene-kernel/src/linux/launch.rs
+++ b/fullerene-kernel/src/linux/launch.rs
@@ -77,8 +77,7 @@ pub fn init_initramfs() {
         let _ = crate::contexts::vfs::mkdir(dir);
     }
 
-    // Create /dev/null
-    let _ = crate::contexts::vfs::create("/dev/null");
+    // /dev/null is provided by the dynamic DevFs mount.
 
     // Create a simple /etc/hostname
     let _ = crate::fs::write_entire_file("/etc/hostname", b"fullerene\n");

--- a/fullerene-kernel/src/shell.rs
+++ b/fullerene-kernel/src/shell.rs
@@ -532,6 +532,14 @@ fn register_nozzle_hooks() {
                 ctx.terminal.write_str("USB rescan: no storage device registered.\n");
             }
         }
+        "sd_rescan" => {
+            if crate::drivers::registry::sd_probe_and_register() {
+                ctx.terminal.write_str("SD rescan: /dev/sd0 registered.\n");
+            } else {
+                ctx.terminal
+                    .write_str("SD rescan: no usable card; see dmesg for details.\n");
+            }
+        }
         "usb_info" => {
             use crate::drivers::registry;
             let count = crate::devfs::list_block_device_names().len();

--- a/nitrogen/src/driver_api.rs
+++ b/nitrogen/src/driver_api.rs
@@ -89,9 +89,9 @@ pub struct DriverDescriptor {
     pub vendor: u16,
     /// PCI device ID (0xFFFF = wildcard; ignored when vendor is wildcard).
     pub device: u16,
-    /// PCI class code (0xFF = wildcard).
+    /// PCI class code (`0xFF/0xFF` class/subclass pair = unspecified).
     pub class: u8,
-    /// PCI subclass (only meaningful when class is not wildcard).
+    /// PCI subclass (`0xFF/0xFF` class/subclass pair = unspecified).
     pub subclass: u8,
 }
 
@@ -131,11 +131,51 @@ impl DriverDescriptor {
         let vendor = self.vendor != 0xFFFF
             && self.vendor == device.vendor_id
             && (self.device == 0xFFFF || self.device == device.device_id);
-        let class = self.class != 0xFF
+        // PCI class 0xff is a real vendor-specific class. Treat only the
+        // pair (class, subclass) == (0xff, 0xff) as unspecified.
+        let class = (self.class != 0xFF || self.subclass != 0xFF)
             && self.class == device.class_code
             && self.subclass == device.subclass;
-        let wildcard = self.vendor == 0xFFFF && self.device == 0xFFFF && self.class == 0xFF;
+        let wildcard = self.vendor == 0xFFFF
+            && self.device == 0xFFFF
+            && self.class == 0xFF
+            && self.subclass == 0xFF;
         vendor || class || wildcard
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DriverDescriptor;
+    use crate::pci::PciDevice;
+
+    fn device(class_code: u8, subclass: u8) -> PciDevice {
+        PciDevice {
+            bus: 0,
+            device: 0,
+            function: 0,
+            handle: 0,
+            vendor_id: 0x10EC,
+            device_id: 0x5249,
+            class_code,
+            subclass,
+            prog_if: 0,
+            header_type: 0,
+        }
+    }
+
+    #[test]
+    fn vendor_specific_class_is_not_a_wildcard() {
+        let descriptor = DriverDescriptor::from_class(0xFF, 0x00);
+        assert!(descriptor.matches(&device(0xFF, 0x00)));
+        assert!(!descriptor.matches(&device(0x03, 0x00)));
+    }
+
+    #[test]
+    fn explicit_wildcard_still_matches_every_class() {
+        let descriptor = DriverDescriptor::wildcard();
+        assert!(descriptor.matches(&device(0x03, 0x00)));
+        assert!(descriptor.matches(&device(0xFF, 0x00)));
     }
 }
 

--- a/nozzle/src/builtins.rs
+++ b/nozzle/src/builtins.rs
@@ -246,6 +246,7 @@ pub fn cmd_write(ctx: &mut CommandContext) -> bool {
 
 sys_info_cmd!(cmd_usb_info, "usb_info");
 sys_info_cmd!(cmd_usb_rescan, "usb_rescan");
+sys_info_cmd!(cmd_sd_rescan, "sd_rescan");
 
 /// `mount` — mount a block device to a directory
 ///

--- a/nozzle/src/lib.rs
+++ b/nozzle/src/lib.rs
@@ -160,6 +160,11 @@ pub fn default_commands() -> &'static [&'static dyn Command] {
             builtins::cmd_usb_rescan
         ),
         (
+            "sd_rescan",
+            "Rescan the SD card reader without mounting",
+            builtins::cmd_sd_rescan
+        ),
+        (
             "hello_linux",
             "Launch the built-in Linux test binary",
             builtins::cmd_hello_linux


### PR DESCRIPTION
## Summary
- mount the dynamic DevFs at /dev instead of an unrelated tmpfs
- expose block-registry entries immediately and provide /dev/null from DevFs
- fix PCI class 0xff wildcard ambiguity and match the RTS5249 by 10ec:5249
- add sd_rescan for safe post-insertion discovery without mounting

## Root cause
The old /dev mount was a tmpfs, so registered block devices depended on manual placeholder files. Separately, class 0xff was interpreted as a wildcard, causing the SD driver to attach to unrelated PCI devices, including xHCI.

## Validation
- cargo check --workspace
- 57 Nitrogen/Nozzle tests
- x86_64-unknown-uefi build
- nitrogen_no_usb + nitrogen_no_storage configuration