### PR TITLE
Clarify storage probe boundaries and remove boot-time AHCI/NVMe attach

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -411,6 +411,13 @@ activate the Nitrogen state machine from rendering or input dispatch. Explicit
 `usb_rescan` is the activation boundary; device discovery and `/dev`
 registration remain separate from filesystem mount policy.
 
+PCI storage follows the same lifecycle rule. Boot may discover an RTSX
+controller and prepare its service, but card-register MMIO begins only at the
+explicit `sd_rescan` boundary. AHCI and NVMe drivers must not be registered in
+the boot attach pipeline until they expose real block-device ownership; a
+controller reset performed by a placeholder wrapper is not service
+registration.
+
 The kernel device registry preserves `/dev/<name>` identity while transferring
 exclusive block-device ownership to a mounted filesystem. An available entry
 contains a device lease; a present entry without a lease means mounted or in
@@ -418,9 +425,10 @@ use. Controller re-enumeration must not invalidate an outstanding lease.
 
 `/dev` is a `DevFs` mount backed directly by that registry, not a tmpfs with
 manually-created placeholder files. Consequently registration and removal are
-visible immediately and `/dev/null` is supplied by DevFs itself. Media
-discovery remains distinct from mounting: `sd_rescan` may retry an inserted SD
-card, while `mount /dev/sd0 <path>` only acquires and mounts its existing lease.
+visible immediately and `/dev/null` is supplied by DevFs itself. Seeing only
+`/dev/null` before an explicit media rescan is expected. Media discovery remains
+distinct from mounting: `sd_rescan` may retry an inserted SD card, while
+`mount /dev/sd0 <path>` only acquires and mounts its existing lease.
 
 The kernel crate re-exports Genome types and adds the singleton `VfsContext` (wrapping `Vfs` with `spin::Mutex` + handle table) through the kernel's `vfs` and `fs` modules, keeping the core logic framework-agnostic.
 
@@ -696,5 +704,4 @@ The goal is to reduce cognitive load, improve maintainability, and provide a sta
 Rule of thumb:
 
 > If multiple functions share the same conceptual state, create a Context structure and move the state into it.
-
 

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -50,8 +50,13 @@ port enumeration, and mass-storage path on this machine.
 
 The Realtek RTS5249 reader (`10ec:5249`) is matched by vendor/device identity,
 because PCI class `0xff` is a real vendor-specific class rather than a driver
-wildcard. An SDXC successfully initialized at boot appears dynamically as
-`/dev/sd0`; `sd_rescan` retries discovery after insertion without mounting it.
+wildcard. Boot registers the reader without accessing its device registers.
+The explicit `sd_rescan` command is the first BAR0 MMIO boundary; a successfully
+initialized SDXC then appears dynamically as `/dev/sd0` without being mounted.
+This keeps an uncompleted PCIe load out of the boot path. AHCI and NVMe are not
+attached at boot until their kernel adapters can publish usable block devices;
+their former adapters reset hardware but returned zero-sized placeholder
+devices.
 
 Reference: Linux [`drivers/usb/host/pci-quirks.c`](https://github.com/torvalds/linux/blob/master/drivers/usb/host/pci-quirks.c)
 and [`drivers/usb/host/xhci-ext-caps.h`](https://github.com/torvalds/linux/blob/master/drivers/usb/host/xhci-ext-caps.h).

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -85,8 +85,8 @@
 | PS/2 Mouse | ✅ | ✅ | Stable |
 | UEFI Framebuffer | ✅ | ✅ | Stable |
 | VGA Text Mode | ✅ | ✅ | Stable |
-| AHCI | ✅ | 🔶 | Beta |
-| NVMe | ✅ | ✅ | Beta |
+| AHCI | ✅ | 🔶 | Mechanism only; block adapter pending |
+| NVMe | ✅ | ✅ | Mechanism only; block adapter pending |
 | xHCI | ✅ | 🔶 | Beta |
 | eHCI | ✅ | ❌ | Alpha |
 | RTSX | ❌ | ✅ | Alpha |

--- a/fullerene-kernel/src/drivers/mod.rs
+++ b/fullerene-kernel/src/drivers/mod.rs
@@ -1,15 +1,3 @@
 pub mod fat;
 pub mod registry;
 pub mod virtio_gpu;
-
-/// Thin kernel wrapper around `nitrogen::storage::ahci`.
-#[cfg(not(nitrogen_no_storage))]
-pub fn init_ahci() {
-    nitrogen::storage::ahci::init(&crate::driver_context_impl::KernelDriverContext);
-}
-
-/// Thin kernel wrapper around `nitrogen::storage::nvme`.
-#[cfg(not(nitrogen_no_storage))]
-pub fn init_nvme() {
-    nitrogen::storage::nvme::init(&crate::driver_context_impl::KernelDriverContext);
-}

--- a/fullerene-kernel/src/drivers/registry.rs
+++ b/fullerene-kernel/src/drivers/registry.rs
@@ -37,6 +37,7 @@ use nitrogen::DriverContext;
 // ────────────────────────────────────────────────────────────
 
 pub use nitrogen::driver_api::DriverRegistry;
+#[cfg(not(nitrogen_no_storage))]
 use nitrogen::driver_api::StorageDriver;
 
 // ── USB storage state (formerly drivers/usb_storage.rs) ────
@@ -117,74 +118,6 @@ pub static SD_PROBED: AtomicBool = AtomicBool::new(false);
 // ────────────────────────────────────────────────────────────
 //  Driver implementations
 // ────────────────────────────────────────────────────────────
-
-// -- AHCI ----------------------------------------------------
-
-#[cfg(not(nitrogen_no_storage))]
-pub struct AhciDriver;
-
-#[cfg(not(nitrogen_no_storage))]
-impl Driver for AhciDriver {
-    fn pci_class(&self) -> Option<(u8, u8)> {
-        Some((0x01, 0x06)) // mass-storage, SATA (AHCI)
-    }
-    fn probe(&self, _ctx: &dyn DriverContext, _device: &PciDevice) -> DriverBox {
-        DriverBox::Storage(Box::new(AhciStorageCtl))
-    }
-}
-
-#[cfg(not(nitrogen_no_storage))]
-struct AhciStorageCtl;
-
-#[cfg(not(nitrogen_no_storage))]
-impl StorageDriver for AhciStorageCtl {
-    fn init(&mut self) -> Result<(), &'static str> {
-        nitrogen::storage::ahci::init(&crate::driver_context_impl::KernelDriverContext);
-        Ok(())
-    }
-    fn read_blocks(&self, _lba: u64, _count: usize, _buf: &mut [u8]) -> Result<(), &'static str> {
-        Err("not a single block device")
-    }
-    fn write_blocks(&self, _lba: u64, _count: usize, _buf: &[u8]) -> Result<(), &'static str> {
-        Err("not a single block device")
-    }
-    fn block_size(&self) -> u32 { 0 }
-    fn total_blocks(&self) -> u64 { 0 }
-}
-
-// -- NVMe ----------------------------------------------------
-
-#[cfg(not(nitrogen_no_storage))]
-pub struct NvmeDriver;
-
-#[cfg(not(nitrogen_no_storage))]
-impl Driver for NvmeDriver {
-    fn pci_class(&self) -> Option<(u8, u8)> {
-        Some((0x01, 0x08)) // mass-storage, NVM Express
-    }
-    fn probe(&self, _ctx: &dyn DriverContext, _device: &PciDevice) -> DriverBox {
-        DriverBox::Storage(Box::new(NvmeStorageCtl))
-    }
-}
-
-#[cfg(not(nitrogen_no_storage))]
-struct NvmeStorageCtl;
-
-#[cfg(not(nitrogen_no_storage))]
-impl StorageDriver for NvmeStorageCtl {
-    fn init(&mut self) -> Result<(), &'static str> {
-        nitrogen::storage::nvme::init(&crate::driver_context_impl::KernelDriverContext);
-        Ok(())
-    }
-    fn read_blocks(&self, _lba: u64, _count: usize, _buf: &mut [u8]) -> Result<(), &'static str> {
-        Err("not a single block device")
-    }
-    fn write_blocks(&self, _lba: u64, _count: usize, _buf: &[u8]) -> Result<(), &'static str> {
-        Err("not a single block device")
-    }
-    fn block_size(&self) -> u32 { 0 }
-    fn total_blocks(&self) -> u64 { 0 }
-}
 
 // -- USB storage (formerly usb_storage::init) -----------------
 
@@ -290,11 +223,7 @@ pub fn build_registry() -> DriverRegistry {
     #[cfg(any(not(nitrogen_no_usb), not(nitrogen_no_storage)))]
     let mut reg = reg;
     #[cfg(not(nitrogen_no_storage))]
-    {
-        reg.register("ahci", Box::new(AhciDriver));
-        reg.register("nvme", Box::new(NvmeDriver));
-        reg.register("sd_card", Box::new(SdCardDriver));
-    }
+    reg.register("sd_card", Box::new(SdCardDriver));
     #[cfg(not(nitrogen_no_usb))]
     reg.register("usb_storage", Box::new(UsbStorageDriver::new()));
     // Future: virtio_gpu, iwlwifi, hda, …

--- a/fullerene-kernel/src/init.rs
+++ b/fullerene-kernel/src/init.rs
@@ -205,6 +205,8 @@ pub fn init_common(_physical_memory_offset: x86_64::VirtAddr) {
             Ok(())
         }),
         petroleum::init_step!("devfs", || {
+            crate::boot_stage::draw_boot_label(b"DEVFS");
+            crate::boot_stage::draw_step_hint(b"devfs");
             petroleum::write_serial_bytes(0x3F8, 0x3FD, b"[step] devfs start\n");
             let _ = crate::contexts::vfs::mkdir("/dev");
             crate::contexts::vfs::mount("", "/dev", "devfs")
@@ -214,6 +216,8 @@ pub fn init_common(_physical_memory_offset: x86_64::VirtAddr) {
             Ok(())
         }),
         petroleum::init_step!("device_probe", || {
+            crate::boot_stage::draw_boot_label(b"DEVICE PROBE");
+            crate::boot_stage::draw_step_hint(b"pci_scan");
             petroleum::write_serial_bytes(0x3F8, 0x3FD, b"[init] Device probe step start\n");
             let registry = crate::drivers::registry::build_registry();
             let ctx = &crate::driver_context_impl::KernelDriverContext;
@@ -325,16 +329,6 @@ pub fn init_common(_physical_memory_offset: x86_64::VirtAddr) {
                 .map_err(|_| "Failed to initialize device manager")?;
             petroleum::serial::serial_log(format_args!("Device manager initialised\n"));
             petroleum::write_serial_bytes(0x3F8, 0x3FD, b"[step] device_mgr done\n");
-            Ok(())
-        }),
-        petroleum::init_step!("sd_card", || {
-            crate::boot_stage::draw_step_hint(b"sd_strt");
-            petroleum::write_serial_bytes(0x3F8, 0x3FD, b"[step] sd_card start\n");
-            crate::boot_stage::draw_boot_label(b"SD CARD");
-            crate::drivers::registry::sd_probe_and_register();
-            petroleum::serial::serial_log(format_args!("SD card subsystem initialised\n"));
-            crate::boot_stage::draw_step_hint(b"sd_ok  ");
-            petroleum::write_serial_bytes(0x3F8, 0x3FD, b"[step] sd_card done\n");
             Ok(())
         }),
         #[cfg(not(nitrogen_no_iwlwifi))]

--- a/fullerene-kernel/src/shell.rs
+++ b/fullerene-kernel/src/shell.rs
@@ -538,6 +538,9 @@ fn register_nozzle_hooks() {
                 if crate::devfs::block_device_exists("sd0") && !crate::devfs::block_device_available("sd0") {
                     ctx.terminal.write_str("SD rescan: refusing rescan while SD card is mounted.\n");
                 } else {
+                    ctx.terminal.write_str(
+                        "SD rescan: explicitly activating controller MMIO; this may not return on broken hardware.\n",
+                    );
                     crate::drivers::registry::SD_PROBED.store(false, core::sync::atomic::Ordering::Release);
                     if crate::drivers::registry::sd_probe_and_register() {
                         ctx.terminal.write_str("SD rescan: /dev/sd0 registered.\n");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SD card discovery now occurs through the explicit `sd_rescan` command, with detected media appearing as `/dev/sd0` without being mounted automatically.
  * Boot diagnostics now show clearer labels and progress hints for device filesystem setup and hardware discovery.
  * `sd_rescan` warns that activating controller hardware may not return on faulty hardware.

* **Documentation**
  * Clarified storage initialization, device ownership, mounting, and PCI hardware behavior.
  * Updated AHCI and NVMe support notes to indicate that block-device support is not yet available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->