### PR TITLE
Fix SD mount visibility and xHCI storage enumeration

### DIFF
--- a/fullerene-kernel/src/contexts/vfs.rs
+++ b/fullerene-kernel/src/contexts/vfs.rs
@@ -40,6 +40,10 @@ pub struct VfsContext {
     /// Open-handle tracking so that `read(fd)` / `close(fd)` routes a
     /// VFS-global descriptor to the owning mount and its local descriptor.
     handle_table: Mutex<HandleTable>,
+
+    /// Block-device source and its mount point. Genome remains generic while
+    /// device-facing kernel code can expose only reachable storage.
+    mounted_devices: Mutex<Vec<(String, String)>>,
 }
 
 /// Tracks which mount owns each VFS-global file descriptor.
@@ -125,6 +129,7 @@ impl VfsContext {
         Self {
             inner: Mutex::new(Vfs::new(root_fs)),
             handle_table: Mutex::new(HandleTable::new()),
+            mounted_devices: Mutex::new(Vec::new()),
         }
     }
 
@@ -159,24 +164,44 @@ impl VfsContext {
     /// unmounted filesystem are discarded, and indices of remaining mounts
     /// that shifted left are decremented.
     pub fn unmount(&self, mount_point: &str) -> Result<bool, FsError> {
-        let mut vfs = self.inner.lock();
-        let mut handle_table = self.handle_table.lock();
-        let target_idx = match vfs.mounted_fs_index(mount_point) {
-            Some(idx) => idx,
-            None => return Ok(false),
-        };
-        let removed = vfs.unmount(mount_point)?;
-        if removed {
-            handle_table
-                .entries
-                .retain(|entry| entry.mount_index != target_idx);
-            for entry in &mut handle_table.entries {
-                if entry.mount_index > target_idx {
-                    entry.mount_index -= 1;
+        let mount_point = self.inner.lock().resolve_path(mount_point);
+        let removed = {
+            let mut vfs = self.inner.lock();
+            let mut handle_table = self.handle_table.lock();
+            let target_idx = match vfs.mounted_fs_index(&mount_point) {
+                Some(idx) => idx,
+                None => return Ok(false),
+            };
+            let removed = vfs.unmount(&mount_point)?;
+            if removed {
+                handle_table
+                    .entries
+                    .retain(|entry| entry.mount_index != target_idx);
+                for entry in &mut handle_table.entries {
+                    if entry.mount_index > target_idx {
+                        entry.mount_index -= 1;
+                    }
                 }
             }
+            removed
+        };
+        if removed {
+            self.mounted_devices
+                .lock()
+                .retain(|(_, path)| path != &mount_point);
         }
         Ok(removed)
+    }
+
+    fn record_device_mount(&self, device: &str, mount_point: &str) {
+        let mut mounts = self.mounted_devices.lock();
+        mounts.retain(|(source, path)| source != device && path != mount_point);
+        mounts.push((String::from(device), String::from(mount_point)));
+    }
+
+    /// Return block devices which are currently reachable through the VFS.
+    pub fn mounted_block_devices(&self) -> Vec<(String, String)> {
+        self.mounted_devices.lock().clone()
     }
 
     // ── File operations ─────────────────────────────────────────
@@ -200,25 +225,41 @@ impl VfsContext {
     pub fn read(&self, fd: u32, buf: &mut [u8]) -> Result<usize, FsError> {
         // Acquire inner first, then handle_table (correct lock order).
         let mut vfs = self.inner.lock();
-        let handle = self.handle_table.lock().find(fd).ok_or(FsError::InvalidFileDescriptor)?;
+        let handle = self
+            .handle_table
+            .lock()
+            .find(fd)
+            .ok_or(FsError::InvalidFileDescriptor)?;
         vfs.read_at(handle.mount_index, handle.local_fd, buf)
     }
 
     pub fn write(&self, fd: u32, data: &[u8]) -> Result<usize, FsError> {
         let mut vfs = self.inner.lock();
-        let handle = self.handle_table.lock().find(fd).ok_or(FsError::InvalidFileDescriptor)?;
+        let handle = self
+            .handle_table
+            .lock()
+            .find(fd)
+            .ok_or(FsError::InvalidFileDescriptor)?;
         vfs.write_at(handle.mount_index, handle.local_fd, data)
     }
 
     pub fn close(&self, fd: u32) -> Result<(), FsError> {
         let mut vfs = self.inner.lock();
-        let handle = self.handle_table.lock().take(fd).ok_or(FsError::InvalidFileDescriptor)?;
+        let handle = self
+            .handle_table
+            .lock()
+            .take(fd)
+            .ok_or(FsError::InvalidFileDescriptor)?;
         vfs.close_at(handle.mount_index, handle.local_fd)
     }
 
     pub fn seek(&self, fd: u32, pos: usize) -> Result<(), FsError> {
         let mut vfs = self.inner.lock();
-        let handle = self.handle_table.lock().find(fd).ok_or(FsError::InvalidFileDescriptor)?;
+        let handle = self
+            .handle_table
+            .lock()
+            .find(fd)
+            .ok_or(FsError::InvalidFileDescriptor)?;
         vfs.seek_at(handle.mount_index, handle.local_fd, pos)
     }
 
@@ -351,6 +392,7 @@ pub fn mount(device: &str, mount_point: &str, fs_type: &str) -> Result<(), FsErr
             Ok(())
         }
         "fat32" => {
+            let mount_point = vfs.inner.lock().resolve_path(mount_point);
             let device_name = device
                 .strip_prefix("/dev/")
                 .filter(|name| !name.is_empty() && !name.contains('/'))
@@ -359,20 +401,26 @@ pub fn mount(device: &str, mount_point: &str, fs_type: &str) -> Result<(), FsErr
             if !crate::devfs::block_device_exists(device_name) {
                 return Err(FsError::FileNotFound);
             }
-            if vfs.inner.lock().mounted_fs_index(mount_point).is_some() {
+            if vfs
+                .inner
+                .lock()
+                .mounted_fs_index(&mount_point)
+                .is_some()
+            {
                 return Err(FsError::FileExists);
             }
 
             // Validate mount point before consuming the block device
-            if !vfs.exists(mount_point) {
-                vfs.mkdir(mount_point)?;
+            if !vfs.exists(&mount_point) {
+                vfs.mkdir(&mount_point)?;
             }
 
-            let bdev = crate::devfs::lease_block_device(device_name)
-                .ok_or(FsError::PermissionDenied)?;
+            let bdev =
+                crate::devfs::lease_block_device(device_name).ok_or(FsError::PermissionDenied)?;
             match crate::drivers::fat::FatFileSystem::from_device(bdev) {
                 Ok(fs) => {
-                    vfs.mount(mount_point, Box::new(fs))?;
+                    vfs.mount(&mount_point, Box::new(fs))?;
+                    vfs.record_device_mount(device, &mount_point);
                     log::info!("VFS: mounted fat32 from {} at {}", device, mount_point);
                     Ok(())
                 }
@@ -507,8 +555,7 @@ pub fn vfs_try_access() -> Option<VfsAccessGuard> {
 
     // SAFETY: inner_guard and handle_table_guard also borrow from global
     // statics inside KernelContext.vfs, which lives forever.
-    let inner_guard: spin::MutexGuard<'static, Vfs> =
-        unsafe { core::mem::transmute(inner_guard) };
+    let inner_guard: spin::MutexGuard<'static, Vfs> = unsafe { core::mem::transmute(inner_guard) };
     let handle_table_guard: spin::MutexGuard<'static, HandleTable> =
         unsafe { core::mem::transmute(handle_table_guard) };
 
@@ -568,5 +615,22 @@ mod tests {
         context.read(mounted_file.fd, &mut mounted_data).unwrap();
         assert_eq!(&root_data, b"root");
         assert_eq!(&mounted_data, b"mounted");
+    }
+
+    #[test]
+    fn unmount_removes_device_mount_metadata() {
+        let context = VfsContext::new();
+        context.mkdir("/mnt").unwrap();
+        context
+            .mount("/mnt", Box::new(MemFileSystem::new()))
+            .unwrap();
+        context.record_device_mount("/dev/sd0", "/mnt");
+
+        assert_eq!(
+            context.mounted_block_devices(),
+            vec![(String::from("/dev/sd0"), String::from("/mnt"))]
+        );
+        assert!(context.unmount("/mnt").unwrap());
+        assert!(context.mounted_block_devices().is_empty());
     }
 }

--- a/fullerene-kernel/src/gui.rs
+++ b/fullerene-kernel/src/gui.rs
@@ -140,16 +140,9 @@ pub fn init() {
             }
             result
         }),
-        usb_drive_list: Some(|| {
-            let names = crate::devfs::list_block_device_names();
-            names.iter().map(|n| {
-                let status = if crate::devfs::block_device_available(n) {
-                    "(not mounted — use mount command)"
-                } else {
-                    "(mounted or in use)"
-                };
-                (alloc::format!("/dev/{}", n), alloc::string::String::from(status))
-            }).collect()
+        mounted_drive_list: Some(|| {
+            crate::contexts::vfs::with_vfs(|vfs| vfs.mounted_block_devices())
+                .unwrap_or_default()
         }),
         usb_poll: Some(|| crate::drivers::registry::poll_usb()),
         shell_cmd: None,

--- a/nitrogen/src/usb/context.rs
+++ b/nitrogen/src/usb/context.rs
@@ -10,7 +10,7 @@
 //! let mut usb = USBContext::new(&kernel_ctx);
 //! usb.enable()?;         // PCI scan → init → poll → storage discovery
 //! for disk in usb.disks() {
-//!     println!("{}", disk.name());
+//!     println!("{} blocks", disk.total_blocks);
 //! }
 //! ```
 
@@ -136,7 +136,11 @@ impl ControllerManager {
             }
             log::info!(
                 "USB: found controller at {:02x}:{:02x}.{} (vendor={:#06x} device={:#06x})",
-                dev.bus, dev.device, dev.function, dev.vendor_id, dev.device_id
+                dev.bus,
+                dev.device,
+                dev.function,
+                dev.vendor_id,
+                dev.device_id
             );
 
             let mmio_base = match dev.read_bar(0) {
@@ -174,7 +178,9 @@ impl ControllerManager {
             crate::debug::hint(b"us_map");
             log::info!(
                 "USB: mapping MMIO BAR0 {:#x} -> virt {:#p} ({} bytes)",
-                mmio_base, mmio_virt, bar_size
+                mmio_base,
+                mmio_virt,
+                bar_size
             );
             if ctx
                 .map_mmio_region(mmio_base as usize, mmio_virt as usize, bar_size)
@@ -182,7 +188,9 @@ impl ControllerManager {
             {
                 log::info!(
                     "USB: failed to map MMIO for {:02x}:{:02x}.{}, skipping",
-                    dev.bus, dev.device, dev.function
+                    dev.bus,
+                    dev.device,
+                    dev.function
                 );
                 continue;
             }
@@ -198,7 +206,10 @@ impl ControllerManager {
                 bridge.class_code == 0x06
                     && bridge.subclass == 0x04
                     && PciConfigSpace::read_config_byte(
-                        bridge.bus, bridge.device, bridge.function, 0x19,
+                        bridge.bus,
+                        bridge.device,
+                        bridge.function,
+                        0x19,
                     ) == dev.bus
             });
             if let Some(up) = upstream {
@@ -209,15 +220,20 @@ impl ControllerManager {
             let mut health = upstream.map_or_else(
                 || PciHealth::new(dev),
                 |bridge| {
-                    PciHealth::new(dev)
-                        .with_upstream_bridge(bridge.bus, bridge.device, bridge.function)
+                    PciHealth::new(dev).with_upstream_bridge(
+                        bridge.bus,
+                        bridge.device,
+                        bridge.function,
+                    )
                 },
             );
             if health.pre_mmio_access().is_err() {
                 log::info!(
                     "USB: device at {:02x}:{:02x}.{} failed health check (not in D0 or link \
                      down) — skipping",
-                    dev.bus, dev.device, dev.function
+                    dev.bus,
+                    dev.device,
+                    dev.function
                 );
                 continue;
             }
@@ -237,12 +253,20 @@ impl ControllerManager {
                             log::info!("USB: EHCI init OK, {} ports", hc.n_ports());
                             self.ehci.push(Box::new(hc));
                         } else {
-                            log::info!("USB: EHCI init failed for {:02x}:{:02x}.{}",
-                                dev.bus, dev.device, dev.function);
+                            log::info!(
+                                "USB: EHCI init failed for {:02x}:{:02x}.{}",
+                                dev.bus,
+                                dev.device,
+                                dev.function
+                            );
                         }
                     } else {
-                        log::info!("USB: EHCI new failed for {:02x}:{:02x}.{}",
-                            dev.bus, dev.device, dev.function);
+                        log::info!(
+                            "USB: EHCI new failed for {:02x}:{:02x}.{}",
+                            dev.bus,
+                            dev.device,
+                            dev.function
+                        );
                     }
                 }
                 0x30 => {
@@ -258,12 +282,20 @@ impl ControllerManager {
                             self.xhci.push(Box::new(hc));
                             intel_xhci_active |= dev.vendor_id == 0x8086;
                         } else {
-                            log::info!("USB: xHCI init failed for {:02x}:{:02x}.{}",
-                                dev.bus, dev.device, dev.function);
+                            log::info!(
+                                "USB: xHCI init failed for {:02x}:{:02x}.{}",
+                                dev.bus,
+                                dev.device,
+                                dev.function
+                            );
                         }
                     } else {
-                        log::info!("USB: xHCI new failed for {:02x}:{:02x}.{}",
-                            dev.bus, dev.device, dev.function);
+                        log::info!(
+                            "USB: xHCI new failed for {:02x}:{:02x}.{}",
+                            dev.bus,
+                            dev.device,
+                            dev.function
+                        );
                     }
                 }
                 _ => {
@@ -313,7 +345,6 @@ impl ControllerManager {
             xhci_devices,
         }
     }
-
 }
 
 /// Events from a single poll cycle.
@@ -453,7 +484,7 @@ impl USBContext {
 
     fn register_ehci_storage(&mut self, ctrl_idx: usize, dev_idx: usize) {
         // Borrow scope to avoid conflicting with self.storage later.
-        let (dev_addr, bulk_out, bulk_in) = {
+        let (dev_addr, bulk_out, bulk_out_mps, bulk_in, bulk_in_mps, block_size, total_blocks) = {
             let ehci: &mut EhciContext = &mut *self.controllers.ehci[ctrl_idx];
             ehci.reset_pools();
 
@@ -470,7 +501,14 @@ impl USBContext {
             };
             let dev = match dev {
                 Ok(d) if d.is_mass_storage() => d,
-                _ => return,
+                Ok(_) => {
+                    log::warn!("USB: EHCI device {} is not mass storage", dev_idx);
+                    return;
+                }
+                Err(error) => {
+                    log::warn!("USB: EHCI enumeration failed: {}", error);
+                    return;
+                }
             };
 
             if let Some(slot) = ehci.devices_mut().get_mut(dev_idx) {
@@ -478,36 +516,82 @@ impl USBContext {
             }
 
             let mut bulk_out = 0u8;
+            let mut bulk_out_mps = 0u16;
             let mut bulk_in = 0u8;
+            let mut bulk_in_mps = 0u16;
             for ep in &dev.endpoints {
                 if ep.xfer_type() != super::UsbXferType::Bulk {
                     continue;
                 }
                 match ep.direction() {
-                    super::UsbDirection::Out => bulk_out = ep.b_endpoint_address,
-                    super::UsbDirection::In => bulk_in = ep.b_endpoint_address,
+                    super::UsbDirection::Out => {
+                        bulk_out = ep.b_endpoint_address;
+                        bulk_out_mps = ep.w_max_packet_size;
+                    }
+                    super::UsbDirection::In => {
+                        bulk_in = ep.b_endpoint_address;
+                        bulk_in_mps = ep.w_max_packet_size;
+                    }
                 }
             }
-            if bulk_out == 0 || bulk_in == 0 {
+            if bulk_out == 0 || bulk_out_mps == 0 || bulk_in == 0 || bulk_in_mps == 0 {
+                log::warn!("USB: EHCI mass-storage device has incomplete bulk endpoints");
                 return;
             }
-            (dev.address, bulk_out, bulk_in)
+            let mut tag = 1;
+            let (block_size, total_blocks) = match super::usb_bus::bot_read_capacity(
+                ehci,
+                dev.address,
+                bulk_out,
+                bulk_out_mps,
+                bulk_in,
+                bulk_in_mps,
+                &mut tag,
+            ) {
+                Ok(capacity) => capacity,
+                Err(error) => {
+                    log::warn!("USB: EHCI READ CAPACITY failed: {}", error);
+                    return;
+                }
+            };
+            (
+                dev.address,
+                bulk_out,
+                bulk_out_mps,
+                bulk_in,
+                bulk_in_mps,
+                block_size,
+                total_blocks,
+            )
         };
 
-        self.storage
-            .try_register("EHCI", dev_addr, bulk_out, bulk_in, ctrl_idx);
+        self.storage.try_register(Disk {
+            dev_addr,
+            ep_out: bulk_out,
+            ep_out_mps: bulk_out_mps,
+            ep_in: bulk_in,
+            ep_in_mps: bulk_in_mps,
+            block_size,
+            total_blocks,
+            ctrl_type: "EHCI",
+            ctrl_idx,
+        });
     }
 
     fn register_xhci_storage(&mut self, ctrl_idx: usize, dev_idx: usize) {
-        let (dev_addr, ep_out, ep_out_mps, ep_in, ep_in_mps) = {
+        let (dev_addr, ep_out, ep_out_mps, ep_in, ep_in_mps, block_size, total_blocks) = {
             let xhci: &mut XhciContext = &mut *self.controllers.xhci[ctrl_idx];
 
             let slot_id = match xhci.enable_slot() {
                 Ok(id) => id,
-                Err(_) => return,
+                Err(error) => {
+                    log::warn!("USB: xHCI Enable Slot failed: {}", error);
+                    return;
+                }
             };
-            if xhci.address_device(slot_id).is_err() {
-                let _ = xhci.disable_slot(slot_id);
+            if let Err(error) = xhci.address_device(slot_id, dev_idx) {
+                log::warn!("USB: xHCI Address Device failed: {}", error);
+                xhci.disable_slot(slot_id);
                 return;
             }
 
@@ -517,10 +601,11 @@ impl USBContext {
                 dev_addr,
                 dev_idx,
             );
-            let (ep_out, ep_out_mps, ep_in, ep_in_mps, _blk) = match result {
+            let (ep_out, ep_out_mps, ep_in, ep_in_mps) = match result {
                 Ok(v) => v,
-                Err(_) => {
-                    let _ = xhci.disable_slot(slot_id);
+                Err(error) => {
+                    log::warn!("USB: xHCI mass-storage enumeration failed: {}", error);
+                    xhci.disable_slot(slot_id);
                     return;
                 }
             };
@@ -535,21 +620,50 @@ impl USBContext {
                 .configure_endpoint_bulk(slot_id, ep_out, ep_out_mps)
                 .is_err()
             {
-                let _ = xhci.disable_slot(slot_id);
+                log::warn!("USB: xHCI bulk OUT endpoint configuration failed");
+                xhci.disable_slot(slot_id);
                 return;
             }
             if xhci
                 .configure_endpoint_bulk(slot_id, ep_in, ep_in_mps)
                 .is_err()
             {
-                let _ = xhci.disable_slot(slot_id);
+                log::warn!("USB: xHCI bulk IN endpoint configuration failed");
+                xhci.disable_slot(slot_id);
                 return;
             }
-            (dev_addr, ep_out, ep_out_mps, ep_in, ep_in_mps)
+            let mut tag = 1;
+            let (block_size, total_blocks) = match super::usb_bus::bot_read_capacity(
+                xhci, dev_addr, ep_out, ep_out_mps, ep_in, ep_in_mps, &mut tag,
+            ) {
+                Ok(capacity) => capacity,
+                Err(error) => {
+                    log::warn!("USB: xHCI READ CAPACITY failed: {}", error);
+                    xhci.disable_slot(slot_id);
+                    return;
+                }
+            };
+            (
+                dev_addr,
+                ep_out,
+                ep_out_mps,
+                ep_in,
+                ep_in_mps,
+                block_size,
+                total_blocks,
+            )
         };
 
-        self.storage.try_register_with_mps(
-            "xHCI", dev_addr, ep_out, ep_out_mps, ep_in, ep_in_mps, ctrl_idx,
-        );
+        self.storage.try_register(Disk {
+            dev_addr,
+            ep_out,
+            ep_out_mps,
+            ep_in,
+            ep_in_mps,
+            block_size,
+            total_blocks,
+            ctrl_type: "xHCI",
+            ctrl_idx,
+        });
     }
 }

--- a/nitrogen/src/usb/disk.rs
+++ b/nitrogen/src/usb/disk.rs
@@ -3,7 +3,6 @@
 //! [`StorageManager`] owns discovered block-device metadata. Filesystem and
 //! mount policy remain in the kernel integration layer.
 
-use alloc::string::String;
 use alloc::vec::Vec;
 
 // ============================================================================
@@ -13,8 +12,6 @@ use alloc::vec::Vec;
 /// A discovered USB mass-storage disk.
 #[derive(Clone)]
 pub struct Disk {
-    /// Human-readable name (e.g. "USB Drive 1").
-    pub name: String,
     /// Index into the owning host controller's device list.
     pub dev_addr: u8,
     /// Bulk OUT endpoint address.
@@ -55,47 +52,12 @@ impl StorageManager {
         &self.disks
     }
 
-    /// Register a mass-storage device using default high-speed packet sizes.
-    pub fn try_register(
-        &mut self,
-        ctrl_type: &'static str,
-        dev_addr: u8,
-        ep_out: u8,
-        ep_in: u8,
-        ctrl_idx: usize,
-    ) -> bool {
-        self.try_register_with_mps(ctrl_type, dev_addr, ep_out, 512, ep_in, 512, ctrl_idx)
-    }
-
-    /// Register a mass-storage device with its reported endpoint packet sizes.
-    pub fn try_register_with_mps(
-        &mut self,
-        ctrl_type: &'static str,
-        dev_addr: u8,
-        ep_out: u8,
-        ep_out_mps: u16,
-        ep_in: u8,
-        ep_in_mps: u16,
-        ctrl_idx: usize,
-    ) -> bool {
-        let disk_num = self.disks.len() + 1;
-        let name = alloc::format!("USB Drive {}", disk_num);
-
-        let disk = Disk {
-            name,
-            dev_addr,
-            ep_out,
-            ep_out_mps,
-            ep_in,
-            ep_in_mps,
-            block_size: 512,
-            total_blocks: 0,
-            ctrl_type,
-            ctrl_idx,
-        };
-
+    /// Register a fully enumerated disk, rejecting controller-local duplicates.
+    pub fn try_register(&mut self, disk: Disk) -> bool {
         if self.disks.iter().any(|known| {
-            known.ctrl_type == ctrl_type && known.ctrl_idx == ctrl_idx && known.dev_addr == dev_addr
+            known.ctrl_type == disk.ctrl_type
+                && known.ctrl_idx == disk.ctrl_idx
+                && known.dev_addr == disk.dev_addr
         }) {
             return false;
         }

--- a/nitrogen/src/usb/usb_bus.rs
+++ b/nitrogen/src/usb/usb_bus.rs
@@ -137,6 +137,41 @@ pub fn bot_exec_command(
     Ok(actual)
 }
 
+/// Read the device's logical block geometry with SCSI READ CAPACITY(10).
+pub fn bot_read_capacity(
+    host: &mut dyn HostController,
+    dev_addr: u8,
+    ep_out: u8,
+    ep_out_mps: u16,
+    ep_in: u8,
+    ep_in_mps: u16,
+    tag: &mut u32,
+) -> Result<(u32, u64), &'static str> {
+    let mut response = [0u8; 8];
+    let mut cdb = [0u8; 10];
+    cdb[0] = 0x25;
+    let actual = bot_exec_command(
+        host,
+        dev_addr,
+        ep_out,
+        ep_out_mps,
+        ep_in,
+        ep_in_mps,
+        &cdb,
+        Some(BotBuffer::In(&mut response)),
+        tag,
+    )?;
+    if actual != response.len() {
+        return Err("short READ CAPACITY response");
+    }
+    let last_lba = u32::from_be_bytes(response[..4].try_into().unwrap());
+    let block_size = u32::from_be_bytes(response[4..].try_into().unwrap());
+    if block_size == 0 || !block_size.is_power_of_two() || block_size > 1024 * 1024 {
+        return Err("invalid logical block size");
+    }
+    Ok((block_size, u64::from(last_lba) + 1))
+}
+
 /// Read sectors from a mass-storage device via BOT.
 pub fn bot_read_sectors(
     host: &mut dyn HostController,
@@ -221,13 +256,13 @@ pub fn bot_write_sectors(
 
 /// Enumerate a mass-storage device on the given host controller.
 ///
-/// Returns `(ep_out, ep_out_mps, ep_in, ep_in_mps, block_size)` or an error.
+/// Returns both bulk endpoint addresses and their reported packet sizes.
 /// Uses the host controller's `control_transfer` and `bulk_transfer`.
 pub fn enumerate_mass_storage(
     host: &mut dyn HostController,
     dev_addr: u8,
     dev_idx: usize,
-) -> Result<(u8, u16, u8, u16, u32), &'static str> {
+) -> Result<(u8, u16, u8, u16), &'static str> {
     // Step 1: Get device descriptor (64 bytes for safety)
     let mut desc_buf = [0u8; 64];
     let setup = UsbSetupPacket {
@@ -242,27 +277,12 @@ pub fn enumerate_mass_storage(
         return Err("descriptor too short");
     }
 
-    let dev_class = desc_buf[4];
-    let _dev_subclass = desc_buf[5];
-    let _dev_protocol = desc_buf[6];
     let num_cfgs = desc_buf[17];
-
-    // Accept MSC at device level OR at least one configuration
-    if dev_class != 0x08 && num_cfgs == 0 {
-        return Err("not MSC");
+    if num_cfgs == 0 {
+        return Err("device has no configuration");
     }
 
-    // Step 2: Set configuration (value = 1)
-    let setup_cfg = UsbSetupPacket {
-        bm_request_type: 0x00,
-        b_request: REQ_SET_CONFIGURATION,
-        w_value: 1,
-        w_index: 0,
-        w_length: 0,
-    };
-    host.control_transfer(dev_addr, &setup_cfg, &mut [])?;
-
-    // Step 3: Read configuration descriptor
+    // Step 2: inspect the configuration before selecting it.
     let mut cfg_buf = [0u8; 256];
     let setup_cfg_read = UsbSetupPacket {
         bm_request_type: 0x80,
@@ -271,29 +291,27 @@ pub fn enumerate_mass_storage(
         w_index: 0,
         w_length: 256,
     };
-    let cfg_res = host.control_transfer(dev_addr, &setup_cfg_read, &mut cfg_buf);
+    let cfg_len = host.control_transfer(dev_addr, &setup_cfg_read, &mut cfg_buf)?;
+    let config = parse_mass_storage_config(&cfg_buf, cfg_len)?;
 
-    let (ep_out, ep_out_mps, ep_in, ep_in_mps) = if let Ok(cfg_len) = cfg_res {
-        if cfg_len < 9 {
-            return Err("config too short");
-        }
-        parse_endpoints(&cfg_buf, cfg_len)
-    } else {
-        if dev_class != 0x08 {
-            return Err("not MSC");
-        }
-        // Fallback: hardcoded endpoints (High-speed defaults)
-        (0x02u8, 512u16, 0x82u8, 512u16)
+    // Step 3: select the descriptor's actual configuration value.
+    let setup_cfg = UsbSetupPacket {
+        bm_request_type: 0x00,
+        b_request: REQ_SET_CONFIGURATION,
+        w_value: config.value as u16,
+        w_index: 0,
+        w_length: 0,
     };
+    host.control_transfer(dev_addr, &setup_cfg, &mut [])?;
 
     // Update device metadata
     if let Some(dev) = host.devices_mut().get_mut(dev_idx) {
-        dev.device_class = dev_class;
-        dev.device_subclass = desc_buf[5];
-        dev.device_protocol = desc_buf[6];
+        dev.device_class = 0x08;
+        dev.device_subclass = config.subclass;
+        dev.device_protocol = config.protocol;
     }
 
-    Ok((ep_out, ep_out_mps, ep_in, ep_in_mps, 512))
+    Ok((config.ep_out, config.ep_out_mps, config.ep_in, config.ep_in_mps))
 }
 
 /// Parse bulk IN/OUT endpoints from a configuration descriptor buffer.
@@ -303,13 +321,28 @@ pub fn enumerate_mass_storage(
 /// must be 1024 bytes per USB 3.x spec §4.4.7.1. We use the value reported
 /// by the device so that the xHCI endpoint context is configured correctly;
 /// falling back to a speed-appropriate default when the descriptor is missing.
-fn parse_endpoints(cfg_buf: &[u8], cfg_len: usize) -> (u8, u16, u8, u16) {
+struct MassStorageConfig {
+    value: u8,
+    subclass: u8,
+    protocol: u8,
+    ep_out: u8,
+    ep_out_mps: u16,
+    ep_in: u8,
+    ep_in_mps: u16,
+}
+
+fn parse_mass_storage_config(
+    cfg_buf: &[u8],
+    cfg_len: usize,
+) -> Result<MassStorageConfig, &'static str> {
+    if cfg_len < 9 || cfg_buf.len() < 9 {
+        return Err("config too short");
+    }
     let total_len = u16::from_le_bytes([cfg_buf[2], cfg_buf[3]]) as usize;
     let mut offset: usize = 9;
-    let mut found_out: Option<u8> = None;
-    let mut found_out_mps: Option<u16> = None;
-    let mut found_in: Option<u8> = None;
-    let mut found_in_mps: Option<u16> = None;
+    let mut interface = None;
+    let mut ep_out = None;
+    let mut ep_in = None;
 
     let limit = total_len.min(cfg_len).min(cfg_buf.len());
     while offset + 2 <= limit {
@@ -318,34 +351,39 @@ fn parse_endpoints(cfg_buf: &[u8], cfg_len: usize) -> (u8, u16, u8, u16) {
             break;
         }
         let dtype = cfg_buf[offset + 1];
-        if dtype == 5 && dlen >= 7 {
-            // ENDPOINT descriptor
+        if dtype == 4 && dlen >= 9 {
+            interface = (cfg_buf[offset + 5] == 0x08 && cfg_buf[offset + 7] == 0x50)
+                .then_some((cfg_buf[offset + 6], cfg_buf[offset + 7]));
+            ep_out = None;
+            ep_in = None;
+        } else if dtype == 5 && dlen >= 7 && interface.is_some() {
             let ep_addr = cfg_buf[offset + 2];
             let ep_attr = cfg_buf[offset + 3];
-            // wMaxPacketSize at offset 4..5 (little-endian)
             let mps = u16::from_le_bytes([cfg_buf[offset + 4], cfg_buf[offset + 5]]);
-            if (ep_attr & 0x03) == 2 {
-                // Bulk endpoint
+            if ep_attr & 3 == 2 && mps != 0 {
                 if ep_addr & 0x80 != 0 {
-                    found_in = Some(ep_addr);
-                    found_in_mps = Some(mps);
+                    ep_in = Some((ep_addr, mps));
                 } else {
-                    found_out = Some(ep_addr);
-                    found_out_mps = Some(mps);
+                    ep_out = Some((ep_addr, mps));
                 }
             }
         }
+        if let (Some((subclass, protocol)), Some((out, out_mps)), Some((input, in_mps))) =
+            (interface, ep_out, ep_in)
+        {
+            return Ok(MassStorageConfig {
+                value: cfg_buf[5],
+                subclass,
+                protocol,
+                ep_out: out,
+                ep_out_mps: out_mps,
+                ep_in: input,
+                ep_in_mps: in_mps,
+            });
+        }
         offset += dlen;
     }
-
-    let out = found_out.unwrap_or(0x02);
-    let in_ep = found_in.unwrap_or(0x82);
-    // Default mps to 512 for High-speed / Full-speed. SuperSpeed USB
-    // descriptors report 1024 for bulk endpoints; we use whatever the
-    // descriptor says when it is present.
-    let out_mps = found_out_mps.filter(|&m| m > 0).unwrap_or(512);
-    let in_mps = found_in_mps.filter(|&m| m > 0).unwrap_or(512);
-    (out, out_mps, in_ep, in_mps)
+    Err("no BOT mass-storage interface")
 }
 
 // EHCI-specific enumeration is in hub.rs (enumerate_device).
@@ -394,8 +432,12 @@ impl UsbBus {
 
             let mut health = PciHealth::new(dev);
             if health.pre_mmio_access().is_err() {
-                log::info!("USB: device at {:02x}:{:02x}.{} failed health check — skipping",
-                    dev.bus, dev.device, dev.function);
+                log::info!(
+                    "USB: device at {:02x}:{:02x}.{} failed health check — skipping",
+                    dev.bus,
+                    dev.device,
+                    dev.function
+                );
                 continue;
             }
 
@@ -476,5 +518,29 @@ impl UsbBus {
         }
         pending
     }
+}
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MSC_CONFIG: [u8; 32] = [
+        9, 2, 32, 0, 1, 2, 0, 0x80, 50, 9, 4, 0, 0, 2, 8, 6, 0x50, 0, 7, 5, 2, 2, 0, 2, 0, 7, 5,
+        0x81, 2, 0, 2, 0,
+    ];
+
+    #[test]
+    fn parses_bot_interface_and_reported_endpoints() {
+        let config = parse_mass_storage_config(&MSC_CONFIG, MSC_CONFIG.len()).unwrap();
+        assert_eq!(config.value, 2);
+        assert_eq!((config.ep_out, config.ep_out_mps), (2, 512));
+        assert_eq!((config.ep_in, config.ep_in_mps), (0x81, 512));
+    }
+
+    #[test]
+    fn rejects_non_mass_storage_interface() {
+        let mut config = MSC_CONFIG;
+        config[14] = 3;
+        assert!(parse_mass_storage_config(&config, config.len()).is_err());
+    }
 }

--- a/nitrogen/src/usb/xhci/context.rs
+++ b/nitrogen/src/usb/xhci/context.rs
@@ -22,8 +22,8 @@
 //! xhci.poll_ports();
 //! ```
 
-use core::ptr;
 use alloc::vec::Vec;
+use core::ptr;
 
 use crate::DriverContext;
 use crate::pci_health::PciHealth;
@@ -88,7 +88,11 @@ impl XhciContext {
     /// # Safety
     /// `mmio_base` must reference a mapped xHCI register BAR for the lifetime
     /// of the returned controller.
-    pub unsafe fn new(mmio_base: *mut u8, ctx: &'static dyn DriverContext, health: PciHealth) -> Option<Self> {
+    pub unsafe fn new(
+        mmio_base: *mut u8,
+        ctx: &'static dyn DriverContext,
+        health: PciHealth,
+    ) -> Option<Self> {
         // Brief delay after PCI config-space setup before first MMIO access.
         // On real hardware the controller may need time to stabilise after
         // D0 restoration, memory-space enable, and ASPM disable; skipping
@@ -114,21 +118,14 @@ impl XhciContext {
         let ppc = hcs1.ppc;
         let scratchpad_bufs = hcs1.max_scratchpad_bufs;
 
-        if n_ports == 0
-            || max_slots == 0
-            || cap_regs.db_offset == 0
-            || cap_regs.rt_offset == 0
-        {
+        if n_ports == 0 || max_slots == 0 || cap_regs.db_offset == 0 || cap_regs.rt_offset == 0 {
             log::warn!("xHCI: invalid or inaccessible capability registers");
             return None;
         }
 
         let bar_size = crate::usb::HOST_CONTROLLER_BAR_SIZE;
-        let in_bar = |offset: usize, len: usize| {
-            offset
-                .checked_add(len)
-                .is_some_and(|end| end <= bar_size)
-        };
+        let in_bar =
+            |offset: usize, len: usize| offset.checked_add(len).is_some_and(|end| end <= bar_size);
         let op_len = OP_PORTSC_BASE
             .checked_add(n_ports as usize * OP_PORTSC_STRIDE)
             .and_then(|len| len.checked_add(4));
@@ -281,12 +278,12 @@ impl XhciContext {
             log::info!("xHCI: controller running, halting before HCRST");
             self.registers
                 .op
-                .set_usbcmd(
-                    self.registers.op.usbcmd() & !(USBCMD_RS | USBCMD_INTE | USBCMD_HSEE),
-                );
+                .set_usbcmd(self.registers.op.usbcmd() & !(USBCMD_RS | USBCMD_INTE | USBCMD_HSEE));
             if crate::timing::wait_timeout_us(500_000, || {
                 self.registers.op.usbsts() & USBSTS_HCH != 0
-            }).is_err() {
+            })
+            .is_err()
+            {
                 return Err("controller failed to halt before HCRST");
             }
         }
@@ -393,17 +390,13 @@ impl XhciContext {
         // operational registers may stall the CPU.
         super::port::delay_us(1000);
 
-        if crate::timing::wait_timeout_us(500_000, || {
-            op.usbcmd() & USBCMD_HCRST == 0
-        }).is_err() {
+        if crate::timing::wait_timeout_us(500_000, || op.usbcmd() & USBCMD_HCRST == 0).is_err() {
             log::warn!("xHCI: HCRST did not clear");
             return Err("HCRST timeout");
         }
 
         // Wait for HCHalted
-        if crate::timing::wait_timeout_us(500_000, || {
-            op.usbsts() & USBSTS_HCH != 0
-        }).is_err() {
+        if crate::timing::wait_timeout_us(500_000, || op.usbsts() & USBSTS_HCH != 0).is_err() {
             log::warn!("xHCI: controller did not halt after HCRST");
             return Err("HCHalted timeout");
         }
@@ -411,9 +404,7 @@ impl XhciContext {
         // Wait for CNR (Controller Not Ready) to clear
         // The xHC needs time to initialise its internal state
         // before accepting register writes (xHCI spec §5.4.2).
-        if crate::timing::wait_timeout_us(500_000, || {
-            op.usbsts() & USBSTS_CNR == 0
-        }).is_err() {
+        if crate::timing::wait_timeout_us(500_000, || op.usbsts() & USBSTS_CNR == 0).is_err() {
             log::warn!("xHCI: CNR did not clear after HCRST");
             return Err("CNR timeout");
         }
@@ -473,9 +464,7 @@ impl XhciContext {
         let op = &self.registers.op;
 
         op.set_usbcmd_bits(USBCMD_RS | USBCMD_HSEE);
-        if crate::timing::wait_timeout_us(500_000, || {
-            op.usbsts() & USBSTS_HCH == 0
-        }).is_err() {
+        if crate::timing::wait_timeout_us(500_000, || op.usbsts() & USBSTS_HCH == 0).is_err() {
             log::error!("xHCI: controller failed to start (HCHalted)");
             return Err("controller failed to start");
         }
@@ -601,7 +590,10 @@ impl XhciContext {
         // Determine whether WPR was already attempted for this port on this
         // connect cycle, so ensure_port_ready skips Phase-4 WPR.
         let wpr_done = if is_usb3 && !op.portsc(port_idx).ccs() {
-            self.ports.get(port_idx).map(|p| p.wpr_attempted).unwrap_or(true)
+            self.ports
+                .get(port_idx)
+                .map(|p| p.wpr_attempted)
+                .unwrap_or(true)
         } else {
             true
         };
@@ -719,8 +711,16 @@ impl XhciContext {
     }
 
     /// Address a device.
-    pub fn address_device(&mut self, slot_id: u32) -> Result<(), &'static str> {
+    pub fn address_device(&mut self, slot_id: u32, dev_idx: usize) -> Result<(), &'static str> {
         let dev_addr = slot_id as u8;
+
+        let port_index = self
+            .devices
+            .get(dev_idx)
+            .ok_or("bad device index")?
+            .port_index;
+        let root_port = u8::try_from(port_index + 1).map_err(|_| "root port out of range")?;
+        let speed_id = self.registers.op.portsc(port_index).speed() as u8;
 
         let ep0_ring_phys = {
             let slot = self.device.slots.get(slot_id).ok_or("bad slot")?;
@@ -729,7 +729,7 @@ impl XhciContext {
 
         // Set up input context
         if let Some(in_ctx) = self.device.slots.input_ctx_mut(self.driver_ctx, slot_id) {
-            in_ctx.setup_address_device(dev_addr, ep0_ring_phys);
+            in_ctx.setup_address_device(root_port, speed_id, ep0_ring_phys);
         }
 
         let in_ctx_phys = {
@@ -740,7 +740,7 @@ impl XhciContext {
         self.send_cmd(
             Trb::new(trb_type::ADDRESS_DEVICE, self.rings.command.cycle)
                 .with_data_ptr(in_ctx_phys)
-                .with_flags((slot_id << 24) | trb_flag::IOC),
+                .with_flags(slot_id << 24),
         )?;
 
         // Update slot state
@@ -749,11 +749,8 @@ impl XhciContext {
         }
 
         // Update device address
-        for dev in self.devices.iter_mut() {
-            if dev.address == 0 {
-                dev.address = dev_addr;
-                break;
-            }
+        if let Some(dev) = self.devices.get_mut(dev_idx) {
+            dev.address = dev_addr;
         }
 
         Ok(())
@@ -779,18 +776,7 @@ impl XhciContext {
 
         // Set up input context
         if let Some(in_ctx) = self.device.slots.input_ctx_mut(self.driver_ctx, slot_id) {
-            in_ctx.add_flags = (1 << ctx_idx) | 1; // Add endpoint + slot context
-            in_ctx.drop_flags = 0;
-
-            // Update Context Entries in Slot Context to the highest active endpoint index
-            in_ctx.slot_ctx[0] = (in_ctx.slot_ctx[0] & !0xF800_0000) | ((ctx_idx as u32) << 27);
-
-            if let Some(ep_ctx) = in_ctx.ep_ctx_mut(ctx_idx as u32) {
-                ep_ctx[0] = (mps as u32) << 16 | 2 << 3; // MPS, type=Bulk(2)
-                ep_ctx[1] = b_phys as u32;
-                ep_ctx[2] = (b_phys >> 32) as u32;
-                ep_ctx[3] = 0; // Average TRB Length = 0
-            }
+            in_ctx.setup_bulk_endpoint(ctx_idx as u32, mps, b_phys);
         }
 
         // Get in_ctx_phys before borrowing slot mutably
@@ -802,7 +788,7 @@ impl XhciContext {
         let cmd = self.send_cmd(
             Trb::new(trb_type::CONFIGURE_ENDPOINT, self.rings.command.cycle)
                 .with_data_ptr(in_ctx_phys)
-                .with_flags((slot_id << 24) | trb_flag::IOC),
+                .with_flags(slot_id << 24),
         );
         if cmd.is_err() {
             bulk_ring.free(self.driver_ctx);
@@ -879,7 +865,12 @@ impl XhciContext {
         // the xHC may read stale TRB data from cache.
         crate::mmio::write_barrier();
         self.registers.doorbell.ring(0, 0);
-        let ev = wait_event(&mut self.rings.event, &self.registers.runtime, 5_000_000)?;
+        let ev = wait_event_type(
+            &mut self.rings.event,
+            &self.registers.runtime,
+            5_000_000,
+            trb_type::COMMAND_COMPLETION_EVENT,
+        )?;
         if ev.completion_code() != COMP_SUCCESS {
             return Err("command completion code not success");
         }
@@ -888,9 +879,13 @@ impl XhciContext {
 
     /// Wait for an event with timeout.
     pub fn wait_event(&mut self, timeout: u32) -> Result<Trb, &'static str> {
-        wait_event(&mut self.rings.event, &self.registers.runtime, timeout)
+        wait_event_type(
+            &mut self.rings.event,
+            &self.registers.runtime,
+            timeout,
+            trb_type::TRANSFER_EVENT,
+        )
     }
-
 }
 
 // ============================================================================

--- a/nitrogen/src/usb/xhci/device.rs
+++ b/nitrogen/src/usb/xhci/device.rs
@@ -148,20 +148,42 @@ impl InputContext {
         &mut self.ep_ctx[0]
     }
 
-    /// Set up minimal Input Context for Address Device:
-    /// - Add slot context (bit 0) + EP0 context (bit 1)
-    /// - Set device address in slot context
-    /// - Set EP0 context: MPS=64, type=Control (4), ring pointer
-    pub fn setup_address_device(&mut self, dev_addr: u8, ep0_ring_phys: u64) {
+    /// Set up a root-port device for the Address Device command.
+    pub fn setup_address_device(&mut self, root_port: u8, speed_id: u8, ep0_ring_phys: u64) {
         self.add_flags = 3; // add slot + EP0
         self.drop_flags = 0;
-        self.slot_ctx[0] = 0; // route string = 0 (root port)
-        self.slot_ctx[1] = (dev_addr as u32) << 24; // slot state: addressed
-        // EP0 context: dword 1 contains MPS and EP Type
-        self.ep_ctx[0][1] = (64 << 16) | (4 << 3); // MPS=64, type=Control(4)
-        // TR Dequeue Pointer: dwords 2-3, with DCS bit in low bit of dword 2
-        self.ep_ctx[0][2] = (ep0_ring_phys as u32) | 1; // TR Dequeue Pointer Low + DCS
-        self.ep_ctx[0][3] = (ep0_ring_phys >> 32) as u32; // TR Dequeue Pointer High
+        self.slot_ctx = [0; 8];
+        self.slot_ctx[0] = ((speed_id as u32) << 20) | (1 << 27);
+        self.slot_ctx[1] = (root_port as u32) << 16;
+
+        let max_packet_size = match speed_id {
+            3 => 64,
+            4 | 5 => 512,
+            _ => 8,
+        };
+        let ep0 = &mut self.ep_ctx[0];
+        *ep0 = [0; 8];
+        ep0[1] = (max_packet_size << 16) | (3 << 1) | (4 << 3);
+        ep0[2] = (ep0_ring_phys as u32) | 1;
+        ep0[3] = (ep0_ring_phys >> 32) as u32;
+        ep0[4] = 8;
+    }
+
+    /// Add one bulk endpoint context and keep Slot Context Entries monotonic.
+    pub fn setup_bulk_endpoint(&mut self, ctx_idx: u32, mps: u16, ring_phys: u64) {
+        self.add_flags = (1 << ctx_idx) | 1;
+        self.drop_flags = 0;
+        let entries = (self.slot_ctx[0] >> 27).max(ctx_idx);
+        self.slot_ctx[0] = (self.slot_ctx[0] & !0xF800_0000) | (entries << 27);
+
+        if let Some(ep) = self.ep_ctx_mut(ctx_idx) {
+            *ep = [0; 8];
+            let ep_type = if ctx_idx & 1 == 0 { 2 } else { 6 };
+            ep[1] = ((mps as u32) << 16) | (3 << 1) | (ep_type << 3);
+            ep[2] = (ring_phys as u32) | 1;
+            ep[3] = (ring_phys >> 32) as u32;
+            ep[4] = mps as u32;
+        }
     }
 }
 
@@ -419,5 +441,39 @@ mod tests {
         // Cannot allocate in tests without a real DriverContext,
         // but we can check the limit.
         assert_eq!(mgr.max_slots, 1);
+    }
+
+    #[test]
+    fn address_context_encodes_root_port_speed_and_ep0() {
+        let mut ctx = InputContext {
+            drop_flags: 0,
+            add_flags: 0,
+            _rsvd: [0; 6],
+            slot_ctx: [0; 8],
+            ep_ctx: [[0; 8]; 31],
+        };
+        ctx.setup_address_device(5, 3, 0x1234_5000);
+
+        assert_eq!((ctx.slot_ctx[0] >> 20) & 0xf, 3);
+        assert_eq!((ctx.slot_ctx[0] >> 27) & 0x1f, 1);
+        assert_eq!((ctx.slot_ctx[1] >> 16) & 0xff, 5);
+        assert_eq!(ctx.ep0_ctx()[1] >> 16, 64);
+        assert_eq!(ctx.ep0_ctx()[2], 0x1234_5001);
+    }
+
+    #[test]
+    fn bulk_endpoint_context_uses_direction_specific_type() {
+        let mut ctx = InputContext {
+            drop_flags: 0,
+            add_flags: 0,
+            _rsvd: [0; 6],
+            slot_ctx: [0; 8],
+            ep_ctx: [[0; 8]; 31],
+        };
+        ctx.setup_bulk_endpoint(3, 512, 0x2233_4000);
+        let ep = ctx.ep_ctx_mut(3).unwrap();
+        assert_eq!((ep[1] >> 3) & 7, 6);
+        assert_eq!(ep[1] >> 16, 512);
+        assert_eq!(ep[2], 0x2233_4001);
     }
 }

--- a/nitrogen/src/usb/xhci/interrupt.rs
+++ b/nitrogen/src/usb/xhci/interrupt.rs
@@ -102,22 +102,22 @@ impl InterruptContext {
 //  Event processing
 // ============================================================================
 
-/// Wait for an event on the Event Ring with a timeout.
-///
-/// Returns the flags of the received event TRB, or an error on timeout.
-/// Acknowledges event consumption by updating the ERDP register.
-pub fn wait_event(
+/// Wait for a particular event kind while acknowledging asynchronous events.
+/// Port-change events can share the ring with command completions and must not
+/// be mistaken for the command that happens to be in flight.
+pub fn wait_event_type(
     ev_ring: &mut EventRing,
     rt: &RuntimeRegisters,
     timeout_us: u32,
+    expected_type: u8,
 ) -> Result<Trb, &'static str> {
     for _ in 0..timeout_us {
         if let Some(ev) = ev_ring.pop() {
-            // Acknowledge event consumption by updating ERDP
             rt.set_erdp(ev_ring.dequeue_ptr());
-            return Ok(ev);
-        }
-        if timeout_us > 1000 {
+            if ev.trb_type() == expected_type {
+                return Ok(ev);
+            }
+        } else if timeout_us > 1000 {
             core::hint::spin_loop();
         }
     }

--- a/nitrogen/src/usb/xhci/ring.rs
+++ b/nitrogen/src/usb/xhci/ring.rs
@@ -27,10 +27,13 @@ pub mod trb_type {
     pub const SET_TR_DEQUEUE: u8 = 16;
     pub const RESET_DEVICE: u8 = 17;
     pub const NO_OP: u8 = 23;
+    pub const TRANSFER_EVENT: u8 = 32;
+    pub const COMMAND_COMPLETION_EVENT: u8 = 33;
 }
 
 /// Command completion code for Success (xHCI spec §6.4.2.1, Table 6-93).
 pub const COMP_SUCCESS: u8 = 1;
+pub const COMP_SHORT_PACKET: u8 = 13;
 
 pub mod trb_flag {
     pub const CYCLE: u32 = 1 << 0;
@@ -38,7 +41,6 @@ pub mod trb_flag {
     pub const CHAIN: u32 = 1 << 4;
     pub const IOC: u32 = 1 << 5;
     pub const IDT: u32 = 1 << 6;
-    pub const ENT: u32 = 1 << 11;
     pub const DIR_IN: u32 = 1 << 16;
     pub const TRB_TYPE_SHIFT: u32 = 10;
     pub const TRB_TYPE_MASK: u32 = 0x3F << TRB_TYPE_SHIFT;

--- a/nitrogen/src/usb/xhci/transfer.rs
+++ b/nitrogen/src/usb/xhci/transfer.rs
@@ -8,7 +8,7 @@
 use core::ptr;
 
 use super::context::XhciContext;
-use super::ring::{Trb, trb_flag, trb_type, COMP_SUCCESS};
+use super::ring::{COMP_SHORT_PACKET, COMP_SUCCESS, Trb, trb_flag, trb_type};
 use crate::usb::{UsbDirection, UsbSetupPacket};
 
 impl XhciContext {
@@ -95,21 +95,27 @@ impl XhciContext {
         self.registers.doorbell.ring(slot_id, 1);
         let res = self.wait_event(5_000_000);
 
-        if res.is_ok() && is_in && data_len > 0 {
+        let actual = res
+            .as_ref()
+            .ok()
+            .filter(|ev| matches!(ev.completion_code(), COMP_SUCCESS | COMP_SHORT_PACKET))
+            .map(|ev| data_len.saturating_sub((ev.remaining() as usize).min(data_len)));
+
+        if let Some(actual) = actual.filter(|_| is_in && data_len > 0) {
             unsafe {
-                ptr::copy_nonoverlapping(staging_virt, buf.as_mut_ptr(), data_len);
+                ptr::copy_nonoverlapping(staging_virt, buf.as_mut_ptr(), actual);
             }
         }
 
-        match res {
-            Ok(_) => {
+        match (res, actual) {
+            (Ok(_), Some(actual)) => {
                 if staging_phys != 0 {
                     self.driver_ctx
                         .free_contiguous_frames(staging_phys, (data_len + 4095) / 4096);
                 }
-                Ok(data_len)
+                Ok(actual)
             }
-            Err(_) => {
+            _ => {
                 if staging_phys != 0 {
                     self.deferred_free_list
                         .push((staging_phys, (data_len + 4095) / 4096));
@@ -178,16 +184,11 @@ impl XhciContext {
                 UsbDirection::Out => slot.bulk_out_ring.as_mut().unwrap(),
             };
 
-            let dir_flag = if dir == UsbDirection::In {
-                trb_flag::DIR_IN
-            } else {
-                0
-            };
             ring.enqueue(
                 Trb::new(trb_type::NORMAL, ring.cycle)
                     .with_data_ptr(staging_phys)
                     .with_length(len as u32)
-                    .with_flags(dir_flag | trb_flag::IOC | trb_flag::ENT),
+                    .with_flags(trb_flag::IOC),
             );
 
             let ep_num = (endpoint & 0x0F) as u32;
@@ -200,9 +201,8 @@ impl XhciContext {
 
         match res {
             Ok(ev) => {
-                if ev.completion_code() != COMP_SUCCESS {
-                    self.deferred_free_list
-                        .push((staging_phys, staging_pages));
+                if !matches!(ev.completion_code(), COMP_SUCCESS | COMP_SHORT_PACKET) {
+                    self.deferred_free_list.push((staging_phys, staging_pages));
                     return Err("bulk completion code not success");
                 }
                 let remainder = ev.remaining() as usize;
@@ -217,8 +217,7 @@ impl XhciContext {
                 Ok(xfer_len)
             }
             Err(_) => {
-                self.deferred_free_list
-                    .push((staging_phys, staging_pages));
+                self.deferred_free_list.push((staging_phys, staging_pages));
                 Err("bulk transfer failed")
             }
         }

--- a/solvent/src/explorer.rs
+++ b/solvent/src/explorer.rs
@@ -376,7 +376,7 @@ impl ExplorerContext {
                 is_usb: false,
             },
         ];
-        for (name, mount_path) in crate::get_usb_drives() {
+        for (name, mount_path) in crate::get_mounted_drives() {
             items.push(SidebarItem {
                 label: name,
                 path: mount_path,

--- a/solvent/src/lib.rs
+++ b/solvent/src/lib.rs
@@ -62,7 +62,7 @@ pub struct SolventCallbacks {
     pub vfs_unlink: Option<fn(&str) -> Result<(), &'static str>>,
     pub process_list: Option<fn() -> Vec<ProcessEntry>>,
     pub device_list: Option<fn() -> Vec<DeviceEntry>>,
-    pub usb_drive_list: Option<fn() -> Vec<(alloc::string::String, alloc::string::String)>>,
+    pub mounted_drive_list: Option<fn() -> Vec<(alloc::string::String, alloc::string::String)>>,
     pub usb_poll: Option<fn() -> bool>,
     pub settings_save: Option<fn()>,
 }
@@ -82,7 +82,7 @@ impl SolventCallbacks {
             vfs_unlink: None,
             process_list: None,
             device_list: None,
-            usb_drive_list: None,
+            mounted_drive_list: None,
             usb_poll: None,
             settings_save: None,
         }
@@ -148,10 +148,10 @@ const FRAME_TIMER_ID: TimerId = TimerId(2);
 pub(crate) static TSC_PER_MS: core::sync::atomic::AtomicU64 =
     core::sync::atomic::AtomicU64::new(3_000_000);
 
-pub fn get_usb_drives() -> Vec<(String, String)> {
+pub fn get_mounted_drives() -> Vec<(String, String)> {
     SOLVENT_CALLBACKS
         .lock()
-        .usb_drive_list
+        .mounted_drive_list
         .map(|f| f())
         .unwrap_or_default()
 }


### PR DESCRIPTION
## Summary
- track block-device mount targets in the VFS and route File Manager entries to their real paths
- correct xHCI root-port, speed, endpoint-context, command-event, and transfer-TRB encoding
- inspect BOT descriptors before configuration and register USB disks only after READ CAPACITY succeeds
- replace silent USB enumeration exits with stage-specific diagnostics

## Verification
- `cargo test --package nitrogen --lib` (57 passed)
- `cargo test --package solvent --lib`
- `cargo check --workspace --exclude bellows --exclude fullerene-kernel`
- `cargo build -Z build-std=core,alloc --package fullerene-kernel --target x86_64-unknown-uefi`

## Real-hardware follow-up
- `mount /dev/sd0 /mnt` should expose the card directly at `/mnt` and in File Manager
- `usb_rescan` now logs the exact failing xHCI/BOT stage if a disk still cannot be registered