### PR TITLE
fix(storage): support exFAT SDXC and complete file operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +139,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +175,21 @@ dependencies = [
  "spin 0.10.0",
  "x86_64 0.15.4",
 ]
+
+[[package]]
+name = "bisync"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5020822f6d6f23196ccaf55e228db36f9de1cf788052b37992e17cbc96ec41a7"
+dependencies = [
+ "bisync_macros",
+]
+
+[[package]]
+name = "bisync_macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d21f40d350a700f6aa107e45fb26448cf489d34794b2ba4522181dc9f1173af6"
 
 [[package]]
 name = "bit_field"
@@ -195,6 +228,15 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "block-device-driver"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c051592f59fe68053524b4c4935249b806f72c1f544cfb7abe4f57c3be258e"
+dependencies = [
+ "aligned",
+]
 
 [[package]]
 name = "bonder"
@@ -440,6 +482,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "exfat-slim"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0d52062563c55c3bf779070a52e67d1e6de78d2cb48b68722320ef8037dca8"
+dependencies = [
+ "aligned",
+ "bisync",
+ "bitflags 2.11.1",
+ "block-device-driver",
+ "byteorder",
+ "heapless",
+ "thiserror",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,10 +590,12 @@ version = "0.1.0"
 name = "fullerene-kernel"
 version = "0.1.0"
 dependencies = [
+ "aligned",
  "bitfield",
  "bitflags 2.11.1",
  "bonder",
  "embedded-graphics",
+ "exfat-slim",
  "fullerene-abi",
  "genome",
  "goblin",
@@ -1503,6 +1562,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -60,6 +60,12 @@ because PCI class `0xff` is a real vendor-specific class rather than a driver
 wildcard. Boot registers the reader without accessing its device registers.
 The explicit `sd_rescan` command is the first BAR0 MMIO boundary; a successfully
 initialized SDXC then appears dynamically as `/dev/sd0` without being mounted.
+Later `sd_rescan` calls are idempotent while that device is registered or
+mounted; they do not reset the live card with CMD0/ACMD41.
+Mount FAT or exFAT media with, for example,
+`mount /dev/sd0 /mnt/sdcard`. The mount point is any absolute VFS directory;
+`mount` creates it when absent. Refresh an already-open File Manager to add the
+mounted drive to its sidebar.
 This keeps an uncompleted PCIe load out of the boot path. AHCI and NVMe are not
 attached at boot until their kernel adapters can publish usable block devices;
 their former adapters reset hardware but returned zero-sized placeholder

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -71,11 +71,11 @@
 |---------|-------|-------|-------|
 | Read | ✅ | ✅ | ✅ |
 | Write | ✅ | ✅ | ✅ |
-| Create | ✅ | ❌ | ❌ |
-| Mkdir | ✅ | ❌ | ❌ |
-| Unlink | ✅ | ❌ | ❌ |
+| Create | ✅ | ✅ | ✅ |
+| Mkdir | ✅ | ✅ | ✅ |
+| Unlink | ✅ | ✅ | ✅ |
 | Symlink | ✅ | ❌ | ❌ |
-| Large files (>4GB) | ✅ | ❌ | 🔶 |
+| Large files (>4GB) | ✅ | ❌ | ✅ |
 
 ## Drivers
 

--- a/docs/api/genome.md
+++ b/docs/api/genome.md
@@ -131,6 +131,7 @@ impl Vfs {
 |---|---|
 | `MemFileSystem` | B-tree based in-memory tmpfs. Bundled with Genome. |
 | `FatFileSystem` | FAT32 backend. Located in kernel `drivers/fat.rs`. |
+| `ExFatFileSystem` | Read/write exFAT backend. Located in kernel `drivers/exfat.rs`. |
 
 ---
 

--- a/fullerene-kernel/Cargo.toml
+++ b/fullerene-kernel/Cargo.toml
@@ -49,6 +49,8 @@ paste = "1.0.15"
 log = { workspace = true }
 wasi_runtime = { path = "../wasi_runtime" }
 fatfs = { package = "starry-fatfs", version = "0.4.1-preview.2", default-features = false, features = ["alloc", "lfn", "unicode"] }
+exfat-slim = { version = "0.5.0", default-features = false }
+aligned = { version = "0.4.2", default-features = false }
 # shell-words = "1.1"  # Cannot use in no_std kernel
 
 [features]

--- a/fullerene-kernel/src/boot_stage.rs
+++ b/fullerene-kernel/src/boot_stage.rs
@@ -2,7 +2,7 @@
 //!
 //! Tracks the furthest boot stage reached.  The current stage can be
 //! queried at any time and is included as a `LastStage=…` line in
-//! `/bootlog.txt` on panic or clean shutdown.
+//! `/bootlog/Bootlog.txt` on panic or clean shutdown.
 //!
 //! # Usage
 //!
@@ -192,7 +192,7 @@ pub fn last_stage() -> Option<BootStage> {
     BootStage::from_u8(raw)
 }
 
-/// Format a `LastStage=…` line for inclusion in `/bootlog.txt`.
+/// Format a `LastStage=…` line for inclusion in `/bootlog/Bootlog.txt`.
 pub fn last_stage_line() -> alloc::string::String {
     match last_stage() {
         Some(s) => alloc::format!("LastStage={}\n", s.label()),

--- a/fullerene-kernel/src/contexts/vfs.rs
+++ b/fullerene-kernel/src/contexts/vfs.rs
@@ -307,6 +307,95 @@ impl VfsContext {
         self.inner.lock().exists(path)
     }
 
+    /// Replace a regular file and persist the complete buffer, even when the
+    /// backing filesystem accepts only a partial write per call.
+    pub fn replace_file(&self, path: &str, data: &[u8]) -> Result<(), FsError> {
+        if self.exists(path) {
+            self.unlink(path)?;
+        }
+        let descriptor = self.create(path)?;
+        let result = self.write_all(descriptor.fd, data);
+        let close_result = self.close(descriptor.fd);
+        result.and(close_result)
+    }
+
+    fn write_all(&self, fd: u32, mut data: &[u8]) -> Result<(), FsError> {
+        while !data.is_empty() {
+            let written = self.write(fd, data)?;
+            if written == 0 {
+                return Err(FsError::InvalidInput);
+            }
+            data = &data[written..];
+        }
+        Ok(())
+    }
+
+    /// Copy a file or directory tree without buffering whole files in the GUI.
+    pub fn copy_path(&self, source: &str, destination: &str, is_dir: bool) -> Result<(), FsError> {
+        let destination_suffix = destination.strip_prefix(source);
+        if source == destination
+            || is_dir
+                && destination_suffix.is_some_and(|suffix| suffix.starts_with('/'))
+        {
+            return Err(FsError::InvalidPath);
+        }
+        if is_dir {
+            self.mkdir(destination)?;
+            for entry in self.readdir(source)? {
+                self.copy_path(
+                    &join_path(source, &entry.name),
+                    &join_path(destination, &entry.name),
+                    entry.is_dir,
+                )?;
+            }
+            return Ok(());
+        }
+
+        let source_fd = self.open(source, 0).ok_or(FsError::FileNotFound)?;
+        if self.exists(destination) {
+            if let Err(error) = self.unlink(destination) {
+                let _ = self.close(source_fd.fd);
+                return Err(error);
+            }
+        }
+        let destination_fd = match self.create(destination) {
+            Ok(descriptor) => descriptor,
+            Err(error) => {
+                let _ = self.close(source_fd.fd);
+                return Err(error);
+            }
+        };
+        let result = (|| {
+            let mut buffer = [0; 4096];
+            loop {
+                let read = self.read(source_fd.fd, &mut buffer)?;
+                if read == 0 {
+                    return Ok(());
+                }
+                self.write_all(destination_fd.fd, &buffer[..read])?;
+            }
+        })();
+        let source_close = self.close(source_fd.fd);
+        let destination_close = self.close(destination_fd.fd);
+        result.and(source_close).and(destination_close)
+    }
+
+    /// Recursively remove a path selected by the file manager.
+    pub fn remove_path(&self, path: &str, is_dir: bool) -> Result<(), FsError> {
+        if is_dir {
+            for entry in self.readdir(path)? {
+                self.remove_path(&join_path(path, &entry.name), entry.is_dir)?;
+            }
+        }
+        self.unlink(path)
+    }
+
+    /// Move within or across mounts while preserving the source until copy succeeds.
+    pub fn move_path(&self, source: &str, destination: &str, is_dir: bool) -> Result<(), FsError> {
+        self.copy_path(source, destination, is_dir)?;
+        self.remove_path(source, is_dir)
+    }
+
     fn register_handle(
         &self,
         mount_index: usize,
@@ -340,7 +429,7 @@ impl VfsContext {
 pub fn init_vfs() {
     // VfsContext is already created inside KernelContext::new().
     // This function exists for the bootstrap sequence and backward
-    // compatibility.  Additional per-fs init (e.g. creating /bootlogs)
+    // compatibility. Additional per-filesystem initialization
     // is handled by the caller.
     log::info!("VFS: mounted MemFileSystem at /");
 }
@@ -374,7 +463,8 @@ where
 /// Supported `fs_type` values:
 /// - `"tmpfs"` — mounts a fresh in-memory filesystem ([`MemFileSystem`]).
 /// - `"devfs"` — mounts the kernel's dynamic device filesystem.
-/// - `"fat32"` — mounts a FAT32/exFAT filesystem backed by a block device.
+/// - `"auto"` — detects and mounts a FAT12/16/32 or exFAT block device.
+/// - `"fat32"` — retained as a backward-compatible alias for `"auto"`.
 ///
 /// The `device` argument is the path to a block device that the kernel
 /// can open.  For `tmpfs`, `device` is ignored.
@@ -391,7 +481,7 @@ pub fn mount(device: &str, mount_point: &str, fs_type: &str) -> Result<(), FsErr
             log::info!("VFS: mounted devfs at {}", mount_point);
             Ok(())
         }
-        "fat32" => {
+        "auto" | "fat32" => {
             let mount_point = vfs.inner.lock().resolve_path(mount_point);
             let device_name = device
                 .strip_prefix("/dev/")
@@ -417,15 +507,15 @@ pub fn mount(device: &str, mount_point: &str, fs_type: &str) -> Result<(), FsErr
 
             let bdev =
                 crate::devfs::lease_block_device(device_name).ok_or(FsError::PermissionDenied)?;
-            match crate::drivers::fat::FatFileSystem::from_device(bdev) {
+            match crate::drivers::fat::mount_device(bdev) {
                 Ok(fs) => {
-                    if let Err(e) = vfs.mount(&mount_point, Box::new(fs)) {
+                    if let Err(e) = vfs.mount(&mount_point, fs) {
                         // Mount failed after device was consumed; clean up registry entry
                         crate::devfs::unregister_block_device(device_name);
                         return Err(e);
                     }
                     vfs.record_device_mount(device, &mount_point);
-                    log::info!("VFS: mounted fat32 from {} at {}", device, mount_point);
+                    log::info!("VFS: mounted removable filesystem from {} at {}", device, mount_point);
                     Ok(())
                 }
                 Err((e, returned_bdev)) => {
@@ -503,6 +593,33 @@ pub fn unlink(path: &str) -> Result<(), FsError> {
 /// Backward-compatible wrapper: exists.
 pub fn exists(path: &str) -> bool {
     with_vfs(|vfs| vfs.exists(path)).unwrap_or(false)
+}
+
+/// Replace a complete file through the canonical VFS context.
+pub fn replace_file(path: &str, data: &[u8]) -> Result<(), FsError> {
+    with_vfs(|vfs| vfs.replace_file(path, data)).ok_or(FsError::PermissionDenied)?
+}
+
+pub fn copy_path(source: &str, destination: &str, is_dir: bool) -> Result<(), FsError> {
+    with_vfs(|vfs| vfs.copy_path(source, destination, is_dir))
+        .ok_or(FsError::PermissionDenied)?
+}
+
+pub fn move_path(source: &str, destination: &str, is_dir: bool) -> Result<(), FsError> {
+    with_vfs(|vfs| vfs.move_path(source, destination, is_dir))
+        .ok_or(FsError::PermissionDenied)?
+}
+
+pub fn remove_path(path: &str, is_dir: bool) -> Result<(), FsError> {
+    with_vfs(|vfs| vfs.remove_path(path, is_dir)).ok_or(FsError::PermissionDenied)?
+}
+
+fn join_path(parent: &str, name: &str) -> String {
+    if parent == "/" {
+        alloc::format!("/{}", name)
+    } else {
+        alloc::format!("{}/{}", parent.trim_end_matches('/'), name)
+    }
 }
 
 /// Backward-compatible wrapper: working directory.
@@ -639,5 +756,56 @@ mod tests {
         );
         assert!(context.unmount("/mnt").unwrap());
         assert!(context.mounted_block_devices().is_empty());
+    }
+
+    #[test]
+    fn copy_path_streams_complete_files_across_mounts() {
+        let context = VfsContext::new();
+        context.mkdir("/mnt").unwrap();
+        context
+            .mount("/mnt", Box::new(MemFileSystem::new()))
+            .unwrap();
+        let expected: Vec<u8> = (0..9_000).map(|index| (index % 251) as u8).collect();
+
+        context.replace_file("/source.bin", &expected).unwrap();
+        context
+            .copy_path("/source.bin", "/mnt/copied.bin", false)
+            .unwrap();
+
+        let descriptor = context.open("/mnt/copied.bin", 0).unwrap();
+        let mut actual = vec![0; expected.len()];
+        let mut offset = 0;
+        while offset < actual.len() {
+            let read = context.read(descriptor.fd, &mut actual[offset..]).unwrap();
+            if read == 0 {
+                break;
+            }
+            offset += read;
+        }
+        context.close(descriptor.fd).unwrap();
+        assert_eq!(offset, expected.len());
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn recursive_file_operations_preserve_source_until_copy_finishes() {
+        let context = VfsContext::new();
+        context.mkdir("/tree").unwrap();
+        context.mkdir("/tree/nested").unwrap();
+        context.replace_file("/tree/nested/file", b"data").unwrap();
+
+        assert_eq!(
+            context.copy_path("/tree", "/tree/child", true),
+            Err(FsError::InvalidPath)
+        );
+        context.copy_path("/tree", "/copied", true).unwrap();
+        assert!(context.exists("/tree/nested/file"));
+        assert!(context.exists("/copied/nested/file"));
+
+        context.move_path("/copied", "/moved", true).unwrap();
+        assert!(!context.exists("/copied"));
+        assert!(context.exists("/moved/nested/file"));
+        context.remove_path("/moved", true).unwrap();
+        assert!(!context.exists("/moved"));
     }
 }

--- a/fullerene-kernel/src/drivers/exfat.rs
+++ b/fullerene-kernel/src/drivers/exfat.rs
@@ -1,0 +1,238 @@
+//! exFAT filesystem adapter for the kernel VFS.
+
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use aligned::{A4, Aligned};
+use exfat_slim::blocking::{
+    BlockDevice as ExFatBlockDevice, error::ExFatError, file::OpenOptions,
+    file_system::FileSystem as ExFat,
+};
+use genome::fs::FsError;
+
+use crate::contexts::vfs::{FileDescriptor, FileSystem, InodeType, VNode};
+use crate::drivers::fat::BlockDevice;
+use crate::klog_fmt;
+
+const SECTOR_SIZE: usize = 512;
+const CACHE_SLOTS: usize = 8;
+type ExFatErrorKind = ExFatError<&'static str>;
+
+struct ExFatDevice {
+    inner: Box<dyn BlockDevice>,
+}
+
+impl ExFatBlockDevice<SECTOR_SIZE> for ExFatDevice {
+    type Error = &'static str;
+    type Align = A4;
+
+    fn read(
+        &mut self,
+        lba: u32,
+        blocks: &mut [Aligned<Self::Align, [u8; SECTOR_SIZE]>],
+    ) -> Result<(), Self::Error> {
+        blocks
+            .iter_mut()
+            .enumerate()
+            .try_for_each(|(index, block)| {
+                self.inner.read_sectors(
+                    lba.checked_add(index as u32).ok_or("exFAT LBA overflow")?,
+                    1,
+                    &mut block[..],
+                )
+            })
+    }
+
+    fn write(
+        &mut self,
+        lba: u32,
+        blocks: &[Aligned<Self::Align, [u8; SECTOR_SIZE]>],
+    ) -> Result<(), Self::Error> {
+        blocks.iter().enumerate().try_for_each(|(index, block)| {
+            self.inner.write_sectors(
+                lba.checked_add(index as u32).ok_or("exFAT LBA overflow")?,
+                1,
+                &block[..],
+            )
+        })
+    }
+
+    fn size(&mut self) -> Result<u64, Self::Error> {
+        self.inner
+            .total_sectors()
+            .checked_mul(SECTOR_SIZE as u64)
+            .ok_or("exFAT device size overflow")
+    }
+}
+
+type ExFatInner = ExFat<ExFatDevice, SECTOR_SIZE, CACHE_SLOTS>;
+
+pub struct ExFatFileSystem {
+    inner: ExFatInner,
+    next_fd: u32,
+    handles: Vec<(u32, String, u64)>,
+}
+
+impl ExFatFileSystem {
+    pub fn new(
+        device: Box<dyn BlockDevice>,
+    ) -> Result<Self, (FsError, Option<Box<dyn BlockDevice>>)> {
+        if device.sector_size() as usize != SECTOR_SIZE {
+            return Err((FsError::NotSupported, Some(device)));
+        }
+        let mut inner = ExFat::new(ExFatDevice { inner: device });
+        if let Err(error) = inner.mount() {
+            klog_fmt!("exFAT: mount error: {:?}\n", error);
+            return Err((Self::map_error(error), Some(inner.unmount().inner)));
+        }
+        klog_fmt!("exFAT: volume mounted\n");
+        Ok(Self {
+            inner,
+            next_fd: 1,
+            handles: Vec::new(),
+        })
+    }
+
+    fn map_error(error: ExFatErrorKind) -> FsError {
+        match error {
+            ExFatError::FileNotFound | ExFatError::DirectoryNotFound => FsError::FileNotFound,
+            ExFatError::AlreadyExists => FsError::FileExists,
+            ExFatError::DiskFull => FsError::DiskFull,
+            ExFatError::DirectoryNotEmpty => FsError::DirectoryNotEmpty,
+            ExFatError::SeekOutOfRange => FsError::InvalidSeek,
+            ExFatError::WriteNotEnabled | ExFatError::ReadNotEnabled => FsError::PermissionDenied,
+            ExFatError::InvalidFileName { .. } => FsError::InvalidPath,
+            _ => FsError::InvalidInput,
+        }
+    }
+
+    fn handle(&mut self, fd: u32) -> Result<(String, u64), FsError> {
+        self.handles
+            .iter()
+            .find(|handle| handle.0 == fd)
+            .map(|handle| (handle.1.clone(), handle.2))
+            .ok_or(FsError::InvalidFileDescriptor)
+    }
+}
+
+impl FileSystem for ExFatFileSystem {
+    fn open(&mut self, path: &str, flags: u32) -> Option<FileDescriptor> {
+        self.inner.open(path, OpenOptions::new().read(true)).ok()?;
+        let fd = self.next_fd;
+        self.next_fd = self.next_fd.wrapping_add(1);
+        self.handles.push((fd, String::from(path), 0));
+        Some(FileDescriptor {
+            fd,
+            ino: 0,
+            offset: 0,
+            flags,
+        })
+    }
+
+    fn read(&mut self, fd: u32, buf: &mut [u8]) -> Result<usize, FsError> {
+        let (path, offset) = self.handle(fd)?;
+        let mut file = self
+            .inner
+            .open(&path, OpenOptions::new().read(true))
+            .map_err(Self::map_error)?;
+        if offset != 0 {
+            file.seek(&mut self.inner, offset)
+                .map_err(Self::map_error)?;
+        }
+        let read = file
+            .read(&mut self.inner, buf)
+            .map_err(Self::map_error)?
+            .unwrap_or(0);
+        if let Some(handle) = self.handles.iter_mut().find(|handle| handle.0 == fd) {
+            handle.2 += read as u64;
+        }
+        Ok(read)
+    }
+
+    fn write(&mut self, fd: u32, data: &[u8]) -> Result<usize, FsError> {
+        let (path, offset) = self.handle(fd)?;
+        let mut file = self
+            .inner
+            .open(&path, OpenOptions::new().write(true))
+            .map_err(Self::map_error)?;
+        if offset != 0 {
+            file.seek(&mut self.inner, offset)
+                .map_err(Self::map_error)?;
+        }
+        file.write(&mut self.inner, data).map_err(Self::map_error)?;
+        file.close(&mut self.inner).map_err(Self::map_error)?;
+        if let Some(handle) = self.handles.iter_mut().find(|handle| handle.0 == fd) {
+            handle.2 += data.len() as u64;
+        }
+        Ok(data.len())
+    }
+
+    fn close(&mut self, fd: u32) -> Result<(), FsError> {
+        let index = self
+            .handles
+            .iter()
+            .position(|handle| handle.0 == fd)
+            .ok_or(FsError::InvalidFileDescriptor)?;
+        self.handles.remove(index);
+        Ok(())
+    }
+
+    fn seek(&mut self, fd: u32, new_pos: usize) -> Result<(), FsError> {
+        let handle = self
+            .handles
+            .iter_mut()
+            .find(|handle| handle.0 == fd)
+            .ok_or(FsError::InvalidFileDescriptor)?;
+        handle.2 = new_pos as u64;
+        Ok(())
+    }
+
+    fn create(&mut self, path: &str, kind: InodeType) -> Option<u64> {
+        match kind {
+            InodeType::Directory => self.inner.create_directory(path).ok()?,
+            InodeType::File => {
+                let file = self
+                    .inner
+                    .open(path, OpenOptions::new().create_new(true).write(true))
+                    .ok()?;
+                file.close(&mut self.inner).ok()?;
+            }
+            InodeType::Symlink => return None,
+        }
+        Some(0)
+    }
+
+    fn mkdir(&mut self, path: &str) -> Result<(), FsError> {
+        self.inner.create_directory(path).map_err(Self::map_error)
+    }
+
+    fn unlink(&mut self, path: &str) -> Result<(), FsError> {
+        match self.inner.remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(ExFatError::FileNotFound) => self.inner.remove_dir(path).map_err(Self::map_error),
+            Err(error) => Err(Self::map_error(error)),
+        }
+    }
+
+    fn readdir(&mut self, path: &str) -> Result<Vec<VNode>, FsError> {
+        let mut directory = self.inner.read_dir(path).map_err(Self::map_error)?;
+        let mut entries = Vec::new();
+        while let Some(entry) = directory
+            .next_entry(&mut self.inner)
+            .map_err(Self::map_error)?
+        {
+            let metadata = entry.metadata();
+            entries.push(VNode {
+                name: entry.file_name(),
+                size: metadata.len(),
+                is_dir: metadata.is_dir(),
+            });
+        }
+        Ok(entries)
+    }
+
+    fn exists(&mut self, path: &str) -> bool {
+        self.inner.exists(path).unwrap_or(false)
+    }
+}

--- a/fullerene-kernel/src/drivers/fat.rs
+++ b/fullerene-kernel/src/drivers/fat.rs
@@ -1,4 +1,4 @@
-//! FAT32/exFAT filesystem driver — thin wrapper around the `fatfs` crate.
+//! FAT12/16/32 filesystem driver and removable-media format dispatcher.
 //!
 //! Implements the `FileSystem` trait over a block device via `fatfs`.
 
@@ -79,6 +79,34 @@ pub fn find_fat_partition(device: &mut dyn BlockDevice) -> Result<u32, FsError> 
     }
     klog_fmt!("FAT: no FAT partition found in MBR\n");
     Err(FsError::FileNotFound)
+}
+
+/// Detect the volume format and construct the matching VFS implementation.
+pub fn mount_device(
+    mut device: Box<dyn BlockDevice>,
+) -> Result<Box<dyn FileSystem>, (FsError, Option<Box<dyn BlockDevice>>)> {
+    let lba = match find_fat_partition(&mut *device) {
+        Ok(lba) => lba,
+        Err(error) => return Err((error, Some(device))),
+    };
+    let mut boot = [0; 512];
+    if let Err(error) = device.read_sectors(lba, 1, &mut boot) {
+        klog_fmt!("filesystem probe failed at LBA {}: {}\n", lba, error);
+        return Err((FsError::InvalidInput, Some(device)));
+    }
+    let partition: Box<dyn BlockDevice> = if lba == 0 {
+        device
+    } else {
+        Box::new(PartitionBlockDevice { inner: device, offset: lba })
+    };
+    if is_exfat(&boot) {
+        crate::drivers::exfat::ExFatFileSystem::new(partition)
+            .map(|filesystem| Box::new(filesystem) as Box<dyn FileSystem>)
+    } else {
+        FatFileSystem::new(Box::new(BlockCache::new(partition, 64)))
+            .map(|filesystem| Box::new(filesystem) as Box<dyn FileSystem>)
+            .map_err(|error| (error, None))
+    }
 }
 
 pub use genome::block::{BlockDevice, BlockError};
@@ -296,22 +324,6 @@ pub struct FatFileSystem {
 }
 
 impl FatFileSystem {
-    pub fn from_device(device: Box<dyn BlockDevice>) -> Result<Self, (FsError, Option<Box<dyn BlockDevice>>)> {
-        let mut device = device;
-        let lba = match find_fat_partition(&mut *device) {
-            Ok(lba) => lba,
-            Err(e) => return Err((e, Some(device))),
-        };
-        if lba > 0 {
-            let wrapped = PartitionBlockDevice { inner: device, offset: lba };
-            let cached = BlockCache::new(wrapped, 64);
-            Self::new(Box::new(cached)).map_err(|e| (e, None))
-        } else {
-            let cached = BlockCache::new(device, 64);
-            Self::new(Box::new(cached)).map_err(|e| (e, None))
-        }
-    }
-
     pub fn new(device: Box<dyn BlockDevice>) -> Result<Self, FsError> {
         let fat_dev = FatDevice::new(device);
         let opts = fatfs::FsOptions::new();

--- a/fullerene-kernel/src/drivers/mod.rs
+++ b/fullerene-kernel/src/drivers/mod.rs
@@ -1,3 +1,4 @@
+pub mod exfat;
 pub mod fat;
 pub mod registry;
 pub mod virtio_gpu;

--- a/fullerene-kernel/src/drivers/registry.rs
+++ b/fullerene-kernel/src/drivers/registry.rs
@@ -113,7 +113,7 @@ where
 // ── SD card state (formerly drivers/sd_card.rs) ────────────
 
 #[cfg(not(nitrogen_no_storage))]
-pub static SD_PROBED: AtomicBool = AtomicBool::new(false);
+static SD_PROBED: AtomicBool = AtomicBool::new(false);
 
 // ────────────────────────────────────────────────────────────
 //  Driver implementations
@@ -451,6 +451,10 @@ fn register_pending_usb() {
 /// Probe and register an SD card as a block device (no mount).
 #[cfg(not(nitrogen_no_storage))]
 pub fn sd_probe_and_register() -> bool {
+    if crate::devfs::block_device_exists("sd0") {
+        crate::klog_fmt!("SD card: /dev/sd0 already registered\n");
+        return true;
+    }
     if SD_PROBED
         .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
         .is_err()
@@ -502,6 +506,34 @@ pub fn sd_probe_and_register() -> bool {
 #[cfg(nitrogen_no_storage)]
 pub fn sd_probe_and_register() -> bool {
     false
+}
+
+#[cfg(not(nitrogen_no_storage))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SdRescanResult {
+    Registered,
+    AlreadyRegistered,
+    Mounted,
+    Unavailable,
+}
+
+/// Reconcile the SD device node without destructively reinitializing a live card.
+#[cfg(not(nitrogen_no_storage))]
+pub fn rescan_sd() -> SdRescanResult {
+    if crate::devfs::block_device_exists("sd0") {
+        return if crate::devfs::block_device_available("sd0") {
+            SdRescanResult::AlreadyRegistered
+        } else {
+            SdRescanResult::Mounted
+        };
+    }
+
+    SD_PROBED.store(false, Ordering::Release);
+    if sd_probe_and_register() {
+        SdRescanResult::Registered
+    } else {
+        SdRescanResult::Unavailable
+    }
 }
 
 #[cfg(not(nitrogen_no_storage))]

--- a/fullerene-kernel/src/gui.rs
+++ b/fullerene-kernel/src/gui.rs
@@ -83,26 +83,17 @@ pub fn init() {
             Ok(buf)
         }),
         vfs_write: Some(|path, data| {
-            // Open existing file, write, close
-            let fd = crate::contexts::vfs::open(path, 0).map_err(fs_err_str)?;
-            match crate::contexts::vfs::write(fd.fd, data) {
-                Ok(_) => {
-                    let _ = crate::contexts::vfs::close(fd.fd);
-                    Ok(())
-                }
-                Err(e) => {
-                    let _ = crate::contexts::vfs::close(fd.fd);
-                    Err(fs_err_str(e))
-                }
-            }
+            crate::contexts::vfs::replace_file(path, data).map_err(fs_err_str)
         }),
-        vfs_create: Some(|path| {
-            let fd = crate::contexts::vfs::create(path).map_err(fs_err_str)?;
-            let _ = crate::contexts::vfs::close(fd.fd);
-            Ok(())
+        vfs_copy: Some(|source, destination, is_dir| {
+            crate::contexts::vfs::copy_path(source, destination, is_dir).map_err(fs_err_str)
         }),
-        vfs_mkdir: Some(|path| crate::contexts::vfs::mkdir(path).map_err(fs_err_str)),
-        vfs_unlink: Some(|path| crate::contexts::vfs::unlink(path).map_err(fs_err_str)),
+        vfs_move: Some(|source, destination, is_dir| {
+            crate::contexts::vfs::move_path(source, destination, is_dir).map_err(fs_err_str)
+        }),
+        vfs_remove: Some(|path, is_dir| {
+            crate::contexts::vfs::remove_path(path, is_dir).map_err(fs_err_str)
+        }),
         process_list: Some(|| {
             let mut result = alloc::vec::Vec::new();
             crate::process::SCHEDULER.with_list(|list| {

--- a/fullerene-kernel/src/init.rs
+++ b/fullerene-kernel/src/init.rs
@@ -365,7 +365,7 @@ pub fn init_common(_physical_memory_offset: x86_64::VirtAddr) {
     ];
     InitSequence::new(&common_steps).run();
 
-    // Flush boot log to /bootlog.txt so early init messages survive
+    // Flush the early log to /bootlog/Bootlog.txt for File Manager access.
     // even if the system hangs or panics shortly after boot.
     if let Err(e) = crate::klog::flush_to_vfs() {
         petroleum::write_serial_bytes(0x3F8, 0x3FD, b"[init] bootlog flush failed\n");

--- a/fullerene-kernel/src/klog.rs
+++ b/fullerene-kernel/src/klog.rs
@@ -209,7 +209,7 @@ macro_rules! klog_fmt {
 
 // ── VFS flush / boot-log persistence ───────────────────────────────
 
-/// Flush the kernel log ring buffer into `/bootlog.txt` on the VFS
+/// Flush the kernel log ring buffer into `/bootlog/Bootlog.txt` on the VFS
 /// (tmpfs).  Also appends a `LastStage=…` line at the end.
 ///
 /// Returns `Ok(())` if the file was written successfully, or `Err(())`
@@ -231,26 +231,10 @@ pub fn flush_to_vfs() -> Result<(), ()> {
     }
     out.extend_from_slice(b"=== End boot log ===\n");
 
-    // Create /bootlogs/ if it doesn't exist
-    if crate::contexts::vfs::exists("/bootlogs") {
-        // Rotate previous bootlog if present
-        if crate::contexts::vfs::exists("/bootlog.txt") {
-            rotate_bootlog();
-        }
-    } else {
-        // Bootlogs directory doesn't exist yet — try to create it
-        // (ignore failure; we can still write /bootlog.txt)
-        let _ = crate::contexts::vfs::mkdir("/bootlogs");
+    if !crate::contexts::vfs::exists("/bootlog") {
+        crate::contexts::vfs::mkdir("/bootlog").map_err(|_| ())?;
     }
-
-    // Write to /bootlog.txt via the VFS low-level API.
-    // We go through create+write+close manually for error resilience.
-    let fd_info = crate::contexts::vfs::create("/bootlog.txt").map_err(|_| ())?;
-    crate::contexts::vfs::write(fd_info.fd, &out).map_err(|_| {
-        let _ = crate::contexts::vfs::close(fd_info.fd);
-    })?;
-    let _ = crate::contexts::vfs::close(fd_info.fd);
-    Ok(())
+    crate::contexts::vfs::replace_file("/bootlog/Bootlog.txt", &out).map_err(|_| ())
 }
 
 /// Panic-safe variant: best-effort flush, ignores all errors.
@@ -265,48 +249,5 @@ pub fn flush_to_vfs_safe() {
     // steal the locks in a single-threaded kernel).
     if crate::contexts::vfs::vfs_try_access().is_some() {
         let _ = flush_to_vfs();
-    }
-}
-
-/// Move `/bootlog.txt` → `/bootlogs/YYYY-MM-DD-XX.txt` with
-/// a simple ascending counter for the current date.
-fn rotate_bootlog() {
-    // Build date string.  We don't have a real-time clock yet,
-    // so we fall back to a counter-based scheme.
-    // Try YYYY-MM-DD from a not-yet-existing RTC; for now use
-    // a simple "boot-N.txt" style.
-    let mut idx: u32 = 1;
-    let mut path;
-    loop {
-        path = alloc::format!("/bootlogs/boot-{}.txt", idx);
-        if !crate::contexts::vfs::exists(&path) {
-            break;
-        }
-        idx += 1;
-        if idx > 9999 {
-            // Sanity guard — give up rotation.
-            return;
-        }
-    }
-    // Read old content, write to rotated path, then unlink original.
-    if let Ok(fd) = crate::contexts::vfs::open("/bootlog.txt", 0) {
-        let mut buf = [0u8; 512];
-        let mut all = alloc::vec::Vec::new();
-        loop {
-            match crate::contexts::vfs::read(fd.fd, &mut buf) {
-                Ok(0) | Err(_) => break,
-                Ok(n) => all.extend_from_slice(&buf[..n]),
-            }
-        }
-        let _ = crate::contexts::vfs::close(fd.fd);
-        // Write rotated copy
-        if let Ok(fd2) = crate::contexts::vfs::create(&path) {
-            if crate::contexts::vfs::write(fd2.fd, &all).is_ok() {
-                let _ = crate::contexts::vfs::close(fd2.fd);
-                let _ = crate::contexts::vfs::unlink("/bootlog.txt");
-            } else {
-                let _ = crate::contexts::vfs::close(fd2.fd);
-            }
-        }
     }
 }

--- a/fullerene-kernel/src/shell.rs
+++ b/fullerene-kernel/src/shell.rs
@@ -323,7 +323,7 @@ fn register_nozzle_hooks() {
                 return;
             }
             let (device, mount_point) = (ctx.args[1], ctx.args[2]);
-            match crate::contexts::vfs::mount(device, mount_point, "fat32") {
+            match crate::contexts::vfs::mount(device, mount_point, "auto") {
                 Ok(()) => {
                     tline!(ctx.terminal, "mount: OK — {} mounted at {}", device, mount_point);
                     let _ = crate::klog::flush_to_vfs();
@@ -535,19 +535,20 @@ fn register_nozzle_hooks() {
         "sd_rescan" => {
             #[cfg(not(nitrogen_no_storage))]
             {
-                if crate::devfs::block_device_exists("sd0") && !crate::devfs::block_device_available("sd0") {
-                    ctx.terminal.write_str("SD rescan: refusing rescan while SD card is mounted.\n");
-                } else {
-                    ctx.terminal.write_str(
-                        "SD rescan: explicitly activating controller MMIO; this may not return on broken hardware.\n",
-                    );
-                    crate::drivers::registry::SD_PROBED.store(false, core::sync::atomic::Ordering::Release);
-                    if crate::drivers::registry::sd_probe_and_register() {
-                        ctx.terminal.write_str("SD rescan: /dev/sd0 registered.\n");
-                    } else {
-                        ctx.terminal
-                            .write_str("SD rescan: no usable card; see dmesg for details.\n");
+                use crate::drivers::registry::SdRescanResult;
+                match crate::drivers::registry::rescan_sd() {
+                    SdRescanResult::Registered => {
+                        ctx.terminal.write_str("SD rescan: /dev/sd0 registered.\n")
                     }
+                    SdRescanResult::AlreadyRegistered => ctx
+                        .terminal
+                        .write_str("SD rescan: /dev/sd0 is already ready.\n"),
+                    SdRescanResult::Mounted => ctx
+                        .terminal
+                        .write_str("SD rescan: /dev/sd0 is mounted; keeping it online.\n"),
+                    SdRescanResult::Unavailable => ctx.terminal.write_str(
+                        "SD rescan: no usable card; see dmesg for details.\n",
+                    ),
                 }
             }
             #[cfg(nitrogen_no_storage)]

--- a/nitrogen/src/storage/rtsx.rs
+++ b/nitrogen/src/storage/rtsx.rs
@@ -309,6 +309,23 @@ impl RtsxController {
     }
 
     pub fn init_sd_card(&mut self) -> Result<(), &'static str> {
+        // A registered card is already in transfer state. Sending CMD0 and
+        // ACMD41 again without a removal/power-cycle resets the protocol under
+        // a live block device and is known to time out on RTS5249 hardware.
+        if let Some(rca) = self.sd_card.as_ref().map(|card| card.rca) {
+            self.prepare_device()?;
+            if self.card_present()
+                && self
+                    .command(CMD13_SEND_STATUS, u32::from(rca) << 16, SD_RSP_R1)
+                    .is_ok_and(|status| status & (1 << 8) != 0)
+            {
+                self.card_was_present = true;
+                log::info!("RTSX: reusing initialized SD card");
+                return Ok(());
+            }
+            self.sd_card = None;
+        }
+
         // Overall timeout: must complete within 5 seconds on real hardware.
         let start_tsc = unsafe { core::arch::x86_64::_rdtsc() };
         let duration_ticks = 5_000_000u64.saturating_mul(crate::timing::ticks_per_us());

--- a/solvent/src/explorer.rs
+++ b/solvent/src/explorer.rs
@@ -180,6 +180,26 @@ pub enum ExplorerAction {
     None,
 }
 
+#[derive(Debug, Clone)]
+struct ClipboardEntry {
+    path: String,
+    name: String,
+    is_dir: bool,
+}
+
+#[derive(Debug, Clone)]
+enum PendingOperation {
+    Rename {
+        source: String,
+        is_dir: bool,
+        input: String,
+    },
+    Delete {
+        path: String,
+        is_dir: bool,
+    },
+}
+
 const CONTEXT_MENU_ITEMS: &[&str] = &["Open", "Copy", "Paste", "Rename", "Delete", "Properties"];
 
 fn context_menu_action(idx: usize) -> ExplorerAction {
@@ -215,6 +235,10 @@ pub struct ExplorerContext {
     // double-click tracking
     pub last_click_entry: Option<usize>,
     pub last_click_tick: u64,
+    clipboard: Option<ClipboardEntry>,
+    pending_operation: Option<PendingOperation>,
+    status_message: Option<String>,
+    rename_shift_held: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -256,6 +280,10 @@ impl ExplorerContext {
             context_menu: ContextMenuState::closed(),
             last_click_entry: None,
             last_click_tick: 0,
+            clipboard: None,
+            pending_operation: None,
+            status_message: None,
+            rename_shift_held: false,
         }
     }
 
@@ -340,6 +368,7 @@ impl ExplorerContext {
     pub fn refresh(&mut self) {
         let dir = self.current_dir.clone();
         self.navigate_to(&dir);
+        self.refresh_sidebar();
     }
 
     /// Refresh sidebar items (re-detect USB drives etc.).
@@ -506,6 +535,169 @@ impl ExplorerContext {
             None
         }
     }
+
+    fn selected_entry(&self) -> Option<(String, String, bool)> {
+        let index = self.selected_index?;
+        let name = self.raw_names.get(index)?.clone();
+        Some((join_path(&self.current_dir, &name), name, *self.raw_is_dir.get(index)?))
+    }
+
+    /// Execute an Explorer context-menu command. A returned path is a file
+    /// that the runtime should launch after releasing the Explorer borrow.
+    pub fn dispatch_context_action(&mut self, action: ExplorerAction) -> Option<String> {
+        self.status_message = None;
+        match action {
+            ExplorerAction::Open => {
+                let (path, _, is_dir) = self.selected_entry()?;
+                if is_dir {
+                    self.navigate_to(&path);
+                    None
+                } else {
+                    Some(path)
+                }
+            }
+            ExplorerAction::Copy => {
+                if let Some((path, name, is_dir)) = self.selected_entry() {
+                    self.clipboard = Some(ClipboardEntry { path, name: name.clone(), is_dir });
+                    self.status_message = Some(format!("Copied {}", name));
+                } else {
+                    self.status_message = Some(String::from("Copy: select a file or folder"));
+                }
+                None
+            }
+            ExplorerAction::Paste => {
+                let Some(source) = self.clipboard.clone() else {
+                    self.status_message = Some(String::from("Paste: clipboard is empty"));
+                    return None;
+                };
+                let destination = unique_destination(&self.current_dir, &source.name);
+                self.status_message = Some(match copy_entry(&source.path, &destination, source.is_dir) {
+                    Ok(()) => {
+                        self.refresh();
+                        format!("Pasted {}", basename(&destination))
+                    }
+                    Err(error) => format!("Paste failed: {}", error),
+                });
+                None
+            }
+            ExplorerAction::Rename => {
+                if let Some((source, name, is_dir)) = self.selected_entry() {
+                    self.pending_operation = Some(PendingOperation::Rename {
+                        source,
+                        is_dir,
+                        input: name,
+                    });
+                } else {
+                    self.status_message = Some(String::from("Rename: select a file or folder"));
+                }
+                None
+            }
+            ExplorerAction::Delete => {
+                if let Some((path, _, is_dir)) = self.selected_entry() {
+                    self.pending_operation = Some(PendingOperation::Delete { path, is_dir });
+                } else {
+                    self.status_message = Some(String::from("Delete: select a file or folder"));
+                }
+                None
+            }
+            ExplorerAction::Properties => {
+                if let Some((path, name, is_dir)) = self.selected_entry() {
+                    let size = self
+                        .selected_index
+                        .and_then(|index| self.entries.get(index))
+                        .map(|entry| entry.size_str.as_str())
+                        .unwrap_or("unknown");
+                    self.status_message = Some(format!(
+                        "{} | {} | {} | {}",
+                        name,
+                        if is_dir { "folder" } else { "file" },
+                        size,
+                        path
+                    ));
+                } else {
+                    self.status_message = Some(format!("Folder | {}", self.current_dir));
+                }
+                None
+            }
+            ExplorerAction::None => None,
+        }
+    }
+
+    /// Handle rename/delete modal keys before normal Explorer navigation.
+    pub fn handle_operation_key(&mut self, scancode: u8, pressed: bool) -> bool {
+        if self.pending_operation.is_none() {
+            return false;
+        }
+        if matches!(scancode, 0x2A | 0x36) {
+            self.rename_shift_held = pressed;
+            return true;
+        }
+        if !pressed {
+            return true;
+        }
+        match scancode {
+            0x01 => {
+                self.pending_operation = None;
+                self.status_message = Some(String::from("Operation cancelled"));
+            }
+            0x1C => self.commit_pending_operation(),
+            0x0E => {
+                if let Some(PendingOperation::Rename { input, .. }) = self.pending_operation.as_mut() {
+                    input.pop();
+                }
+            }
+            _ => {
+                let mut byte = crate::scancode_to_ascii(scancode);
+                if self.rename_shift_held {
+                    byte = shifted_ascii(byte);
+                }
+                if byte != 0
+                    && byte != b'/'
+                    && byte != b'\\'
+                    && let Some(PendingOperation::Rename { input, .. }) =
+                        self.pending_operation.as_mut()
+                    && input.len() < 255
+                {
+                    input.push(byte as char);
+                }
+            }
+        }
+        true
+    }
+
+    fn commit_pending_operation(&mut self) {
+        let Some(operation) = self.pending_operation.take() else { return };
+        self.status_message = Some(match operation {
+            PendingOperation::Delete { path, is_dir } => match delete_entry(&path, is_dir) {
+                Ok(()) => {
+                    self.refresh();
+                    format!("Deleted {}", basename(&path))
+                }
+                Err(error) => format!("Delete failed: {}", error),
+            },
+            PendingOperation::Rename { source, is_dir, input } => {
+                let name = input.trim();
+                if name.is_empty() || matches!(name, "." | "..") {
+                    String::from("Rename failed: invalid name")
+                } else {
+                    let destination = join_path(&parent_path(&source), name);
+                    if destination == source {
+                        String::from("Rename: name unchanged")
+                    } else if path_exists(&destination) {
+                        String::from("Rename failed: destination already exists")
+                    } else {
+                        match move_entry(&source, &destination, is_dir) {
+                            Ok(()) => {
+                                self.refresh();
+                                format!("Renamed to {}", name)
+                            }
+                            Err(error) => format!("Rename failed: {}", error),
+                        }
+                    }
+                }
+            }
+        });
+    }
 }
 
 // ── Path helpers ───────────────────────────────────────────────
@@ -531,6 +723,62 @@ fn join_path(base: &str, name: &str) -> String {
         format!("/{}", name)
     } else {
         format!("{}/{}", base.trim_end_matches('/'), name)
+    }
+}
+
+fn basename(path: &str) -> &str {
+    path.trim_end_matches('/').rsplit('/').next().unwrap_or(path)
+}
+
+fn path_exists(path: &str) -> bool {
+    let parent = parent_path(path);
+    let name = basename(path);
+    let Some(readdir) = SOLVENT_CALLBACKS.lock().vfs_readdir else {
+        return false;
+    };
+    readdir(&parent)
+        .ok()
+        .is_some_and(|entries| entries.iter().any(|entry| entry.name.eq_ignore_ascii_case(name)))
+}
+
+fn unique_destination(directory: &str, name: &str) -> String {
+    let original = join_path(directory, name);
+    if !path_exists(&original) {
+        return original;
+    }
+    let (stem, extension) = name
+        .rfind('.')
+        .filter(|&index| index > 0)
+        .map_or((name, ""), |index| (&name[..index], &name[index..]));
+    (1..10_000)
+        .map(|index| join_path(directory, &format!("{} - Copy {}{}", stem, index, extension)))
+        .find(|candidate| !path_exists(candidate))
+        .unwrap_or_else(|| join_path(directory, &format!("{} - Copy{}", stem, extension)))
+}
+
+fn copy_entry(source: &str, destination: &str, is_dir: bool) -> Result<(), &'static str> {
+    let copy = SOLVENT_CALLBACKS.lock().vfs_copy.ok_or("copy unavailable")?;
+    copy(source, destination, is_dir)
+}
+
+fn move_entry(source: &str, destination: &str, is_dir: bool) -> Result<(), &'static str> {
+    let move_path = SOLVENT_CALLBACKS.lock().vfs_move.ok_or("move unavailable")?;
+    move_path(source, destination, is_dir)
+}
+
+fn delete_entry(path: &str, is_dir: bool) -> Result<(), &'static str> {
+    let remove = SOLVENT_CALLBACKS.lock().vfs_remove.ok_or("delete unavailable")?;
+    remove(path, is_dir)
+}
+
+fn shifted_ascii(byte: u8) -> u8 {
+    match byte {
+        b'a'..=b'z' => byte.to_ascii_uppercase(),
+        b'1' => b'!', b'2' => b'@', b'3' => b'#', b'4' => b'$', b'5' => b'%',
+        b'6' => b'^', b'7' => b'&', b'8' => b'*', b'9' => b'(', b'0' => b')',
+        b'-' => b'_', b'=' => b'+', b'[' => b'{', b']' => b'}', b';' => b':',
+        b'\'' => b'"', b',' => b'<', b'.' => b'>', b'/' => b'?', b'`' => b'~',
+        other => other,
     }
 }
 
@@ -597,6 +845,13 @@ pub fn hit_file_list(
     }
 }
 
+pub fn hit_file_area(win_w: u32, win_h: u32, rx: i32, ry: i32) -> bool {
+    rx >= SIDEBAR_WIDTH as i32
+        && rx < win_w as i32
+        && ry >= (TOOLBAR_HEIGHT + ROW_HEIGHT) as i32
+        && ry < win_h.saturating_sub(STATUSBAR_HEIGHT) as i32
+}
+
 pub fn hit_sidebar(ctx: &ExplorerContext, rx: i32, ry: i32) -> Option<usize> {
     if rx < 0 || rx >= SIDEBAR_WIDTH as i32 || ry < TOOLBAR_HEIGHT as i32 {
         return None;
@@ -635,10 +890,14 @@ pub fn hit_toolbar_button(rx: i32, ry: i32) -> Option<u8> {
     }
 }
 
-/// Returns true if the click hit the context menu (was consumed).
-pub fn handle_context_menu_click(ctx: &mut ExplorerContext, rx: i32, ry: i32) -> bool {
+/// Return the selected action, or `None` when the menu was dismissed.
+pub fn handle_context_menu_click(
+    ctx: &mut ExplorerContext,
+    rx: i32,
+    ry: i32,
+) -> Option<ExplorerAction> {
     if !ctx.context_menu.open {
-        return false;
+        return None;
     }
     let mx = ctx.context_menu.x as i32;
     let my = ctx.context_menu.y as i32;
@@ -649,31 +908,12 @@ pub fn handle_context_menu_click(ctx: &mut ExplorerContext, rx: i32, ry: i32) ->
             let action = context_menu_action(idx as usize);
             ctx.context_menu.open = false;
             ctx.context_menu.hovered_item = None;
-            dispatch_context_action(ctx, action);
-            return true;
+            return Some(action);
         }
     }
     ctx.context_menu.open = false;
     ctx.context_menu.hovered_item = None;
-    true
-}
-
-fn dispatch_context_action(ctx: &mut ExplorerContext, action: ExplorerAction) {
-    match action {
-        ExplorerAction::Open => {
-            if let Some(idx) = ctx.selected_index {
-                ctx.open_selected(idx);
-            }
-        }
-        ExplorerAction::Copy => {
-            // For now, clipboard is not yet implemented
-        }
-        ExplorerAction::Paste => {}
-        ExplorerAction::Rename => {}
-        ExplorerAction::Delete => {}
-        ExplorerAction::Properties => {}
-        ExplorerAction::None => {}
-    }
+    None
 }
 
 // ── Rendering ─────────────────────────────────────────────────
@@ -866,16 +1106,19 @@ fn draw_file_list(ctx: &ExplorerContext, surface: &mut Surface, win_w: u32, win_
 
 fn draw_statusbar(ctx: &ExplorerContext, surface: &mut Surface, _win_w: u32, win_h: u32) {
     let sy = win_h - STATUSBAR_HEIGHT;
-    let is_usb_path = ctx.current_dir.contains("/mnt");
-    let items_text = if ctx.entries.is_empty() && is_usb_path {
-        "USB storage not yet available"
+    let text = if let Some(operation) = &ctx.pending_operation {
+        match operation {
+            PendingOperation::Rename { input, .. } => {
+                format!("Rename: {}_  |  Enter: apply  Esc: cancel", input)
+            }
+            PendingOperation::Delete { path, .. } => {
+                format!("Delete {}?  |  Enter: yes  Esc: no", basename(path))
+            }
+        }
+    } else if let Some(message) = &ctx.status_message {
+        message.clone()
     } else if ctx.entries.is_empty() {
-        "(empty directory)"
-    } else {
-        ""
-    };
-    let text = if !items_text.is_empty() {
-        format!("{}  |  {}", items_text, ctx.current_dir)
+        format!("(empty directory)  |  {}", ctx.current_dir)
     } else {
         format!("{} items  |  {}", ctx.entries.len(), ctx.current_dir)
     };

--- a/solvent/src/handlers.rs
+++ b/solvent/src/handlers.rs
@@ -145,9 +145,13 @@ fn handle_explorer_click(rt: &mut crate::RuntimeState, btn: MouseButton, cx: i32
 
     // If context menu is open, handle clicks on it first
     if explorer.context_menu.open {
-        crate::explorer::handle_context_menu_click(explorer, rel_x, rel_y);
+        let launch_path = crate::explorer::handle_context_menu_click(explorer, rel_x, rel_y)
+            .and_then(|action| explorer.dispatch_context_action(action));
         rt.explorer_dirty = true;
         rt.frame_due = true;
+        if let Some(path) = launch_path {
+            crate::launch_file(rt, &path);
+        }
         return;
     }
 
@@ -216,17 +220,16 @@ fn handle_explorer_click(rt: &mut crate::RuntimeState, btn: MouseButton, cx: i32
         MouseButton::Right => {
             let win_w = window.width;
             let win_h = window.height;
-            // Only show context menu for file list hits
-            if crate::explorer::hit_file_list(explorer, win_w, win_h, rel_x, rel_y).is_some() {
+            // The empty portion of a directory must expose Paste as well.
+            if crate::explorer::hit_file_area(win_w, win_h, rel_x, rel_y) {
+                let hit = crate::explorer::hit_file_list(explorer, win_w, win_h, rel_x, rel_y);
                 explorer.context_menu.open = true;
-                explorer.context_menu.x = rel_x as u32;
-                explorer.context_menu.y = rel_y as u32;
-                // Also select the item under cursor
-                if let Some(idx) =
-                    crate::explorer::hit_file_list(explorer, win_w, win_h, rel_x, rel_y)
-                {
-                    explorer.selected_index = Some(idx);
-                }
+                explorer.context_menu.x = (rel_x.max(0) as u32)
+                    .min(win_w.saturating_sub(crate::explorer::CONTEXT_MENU_W));
+                explorer.context_menu.y = (rel_y.max(0) as u32).min(
+                    win_h.saturating_sub(6 * crate::explorer::ROW_HEIGHT),
+                );
+                explorer.selected_index = hit;
                 rt.explorer_dirty = true;
                 rt.frame_due = true;
             }

--- a/solvent/src/lib.rs
+++ b/solvent/src/lib.rs
@@ -57,9 +57,9 @@ pub struct SolventCallbacks {
     pub vfs_readdir: Option<fn(&str) -> Result<Vec<VfsEntry>, &'static str>>,
     pub vfs_read: Option<fn(&str) -> Result<Vec<u8>, &'static str>>,
     pub vfs_write: Option<fn(&str, &[u8]) -> Result<(), &'static str>>,
-    pub vfs_create: Option<fn(&str) -> Result<(), &'static str>>,
-    pub vfs_mkdir: Option<fn(&str) -> Result<(), &'static str>>,
-    pub vfs_unlink: Option<fn(&str) -> Result<(), &'static str>>,
+    pub vfs_copy: Option<fn(&str, &str, bool) -> Result<(), &'static str>>,
+    pub vfs_move: Option<fn(&str, &str, bool) -> Result<(), &'static str>>,
+    pub vfs_remove: Option<fn(&str, bool) -> Result<(), &'static str>>,
     pub process_list: Option<fn() -> Vec<ProcessEntry>>,
     pub device_list: Option<fn() -> Vec<DeviceEntry>>,
     pub mounted_drive_list: Option<fn() -> Vec<(alloc::string::String, alloc::string::String)>>,
@@ -77,9 +77,9 @@ impl SolventCallbacks {
             vfs_readdir: None,
             vfs_read: None,
             vfs_write: None,
-            vfs_create: None,
-            vfs_mkdir: None,
-            vfs_unlink: None,
+            vfs_copy: None,
+            vfs_move: None,
+            vfs_remove: None,
             process_list: None,
             device_list: None,
             mounted_drive_list: None,
@@ -918,6 +918,13 @@ pub fn launch_file(rt: &mut RuntimeState, path: &str) {
 
 // ── Explorer keyboard handling ──────────────────────────────
 fn explorer_handle_key(rt: &mut RuntimeState, scancode: u8, pressed: bool) {
+    if let Some(explorer) = rt.explorer.as_mut()
+        && explorer.handle_operation_key(scancode, pressed)
+    {
+        rt.explorer_dirty = true;
+        rt.frame_due = true;
+        return;
+    }
     if !pressed { return; }
     let key = scancode_to_resonance_keycode(scancode);
     let visible_rows = 20usize;


### PR DESCRIPTION
## Summary
- detect FAT12/16/32 and exFAT at mount time and add a read/write exFAT VFS backend
- make `sd_rescan` idempotent for registered or mounted `sd0`, avoiding destructive CMD0/ACMD41 reinitialization
- persist the boot log at `/bootlog/Bootlog.txt` and write complete buffers across partial filesystem writes
- fully implement File Manager Open, Copy, Paste, Rename, Delete, and Properties actions
- stream recursive cross-mount copies in Kernel VFS so Bootlog.txt can be copied to an SDXC card without whole-file GUI buffering

## Validation
- `cargo check -p fullerene-kernel --locked`
- `cargo test -p fullerene-kernel --locked` (19 passed)
- `cargo build -Zbuild-std=core,alloc -p fullerene-kernel --target x86_64-unknown-uefi --locked`
- `cargo test --workspace --exclude bellows --exclude fullerene-kernel --locked`
- exfat-slim bundled mount/read/write/create/copy/rename examples

## Hardware workflow
1. `sd_rescan`
2. `mount /dev/sd0 /mnt/sdcard`
3. Refresh File Manager, copy `/bootlog/Bootlog.txt`, then paste into the mounted drive.