### PR TITLE
Fix SDXC exFAT mount panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,15 +59,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aligned"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
-dependencies = [
- "as-slice",
-]
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,15 +130,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
-name = "as-slice"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
-dependencies = [
- "stable_deref_trait",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,21 +157,6 @@ dependencies = [
  "spin 0.10.0",
  "x86_64 0.15.4",
 ]
-
-[[package]]
-name = "bisync"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5020822f6d6f23196ccaf55e228db36f9de1cf788052b37992e17cbc96ec41a7"
-dependencies = [
- "bisync_macros",
-]
-
-[[package]]
-name = "bisync_macros"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d21f40d350a700f6aa107e45fb26448cf489d34794b2ba4522181dc9f1173af6"
 
 [[package]]
 name = "bit_field"
@@ -230,15 +197,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
-name = "block-device-driver"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c051592f59fe68053524b4c4935249b806f72c1f544cfb7abe4f57c3be258e"
-dependencies = [
- "aligned",
-]
-
-[[package]]
 name = "bonder"
 version = "0.1.0"
 dependencies = [
@@ -257,6 +215,20 @@ name = "bytemuck"
 version = "1.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "byteorder"
@@ -482,21 +454,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "exfat-slim"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0d52062563c55c3bf779070a52e67d1e6de78d2cb48b68722320ef8037dca8"
-dependencies = [
- "aligned",
- "bisync",
- "bitflags 2.11.1",
- "block-device-driver",
- "byteorder",
- "heapless",
- "thiserror",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,15 +547,14 @@ version = "0.1.0"
 name = "fullerene-kernel"
 version = "0.1.0"
 dependencies = [
- "aligned",
  "bitfield",
  "bitflags 2.11.1",
  "bonder",
  "embedded-graphics",
- "exfat-slim",
  "fullerene-abi",
  "genome",
  "goblin",
+ "hadris-fat",
  "heapless",
  "lattice",
  "linked_list_allocator",
@@ -696,6 +652,52 @@ dependencies = [
  "log",
  "plain",
  "scroll",
+]
+
+[[package]]
+name = "hadris-common"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69865bf6659f52a005745c4b92c556950135c0759796b58e6d34914c077e6a40"
+dependencies = [
+ "hadris-io",
+ "noalloc",
+ "zerocopy",
+]
+
+[[package]]
+name = "hadris-fat"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62c5e513feed5c62a4056022b3bd1588f6f96eb61c6583604c1d42dba31d780d"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytemuck",
+ "chrono",
+ "hadris-common",
+ "hadris-io",
+ "hadris-macros",
+ "parse-size",
+ "spin 0.10.0",
+]
+
+[[package]]
+name = "hadris-io"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee996c28ddacd8bc6a9ad0fcb033fa1d50cfd37bbc101dcf711109139e750d2b"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+]
+
+[[package]]
+name = "hadris-macros"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c8bae1a295c4f8753ae8dea0ae0b79d03f737dcc8bf4deb3c7ee876468f437"
+dependencies = [
+ "proc-macro2",
 ]
 
 [[package]]
@@ -962,6 +964,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "noalloc"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a2537501480803dd22fbd79a39ea83318caba3ba936f7554f7139f4180faa94"
+
+[[package]]
 name = "nozzle"
 version = "0.1.0"
 dependencies = [
@@ -1009,6 +1017,12 @@ checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
 dependencies = [
  "ttf-parser",
 ]
+
+[[package]]
+name = "parse-size"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487f2ccd1e17ce8c1bfab3a65c89525af41cfad4c8659021a1e9a2aacd73b89b"
 
 [[package]]
 name = "paste"
@@ -1467,6 +1481,9 @@ name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spin"
@@ -1562,26 +1579,6 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/fullerene-kernel/Cargo.toml
+++ b/fullerene-kernel/Cargo.toml
@@ -49,8 +49,13 @@ paste = "1.0.15"
 log = { workspace = true }
 wasi_runtime = { path = "../wasi_runtime" }
 fatfs = { package = "starry-fatfs", version = "0.4.1-preview.2", default-features = false, features = ["alloc", "lfn", "unicode"] }
-exfat-slim = { version = "0.5.0", default-features = false }
-aligned = { version = "0.4.2", default-features = false }
+hadris-fat = { version = "1.2.1", default-features = false, features = [
+  "alloc",
+  "exfat",
+  "read",
+  "sync",
+  "write",
+] }
 # shell-words = "1.1"  # Cannot use in no_std kernel
 
 [features]

--- a/fullerene-kernel/src/drivers/exfat.rs
+++ b/fullerene-kernel/src/drivers/exfat.rs
@@ -320,10 +320,9 @@ impl FileSystem for ExFatFileSystem {
         if self.handles[index].writer.is_some() {
             return Err(FsError::PermissionDenied);
         }
-        let path = self.handles[index].path.clone();
         let offset = self.handles[index].offset;
         let read = {
-            let mut file = self.fs().open_file(&path).map_err(Self::map_error)?;
+            let mut file = self.fs().open_file(&self.handles[index].path).map_err(Self::map_error)?;
             if offset != 0 {
                 file.seek(SeekFrom::Start(offset))
                     .map_err(Self::map_io_error)?;

--- a/fullerene-kernel/src/drivers/exfat.rs
+++ b/fullerene-kernel/src/drivers/exfat.rs
@@ -2,76 +2,155 @@
 
 use alloc::boxed::Box;
 use alloc::string::String;
+use alloc::sync::Arc;
 use alloc::vec::Vec;
+use core::mem;
+use core::pin::Pin;
 
-use aligned::{A4, Aligned};
-use exfat_slim::blocking::{
-    BlockDevice as ExFatBlockDevice, error::ExFatError, file::OpenOptions,
-    file_system::FileSystem as ExFat,
-};
 use genome::fs::FsError;
+use hadris_fat::FatError;
+use hadris_fat::exfat::{ExFatDir, ExFatFileWriter, ExFatFs};
+use hadris_fat::sync::{Error as IoError, ErrorKind, Read, Seek, SeekFrom, Write};
+use spin::Mutex;
 
 use crate::contexts::vfs::{FileDescriptor, FileSystem, InodeType, VNode};
 use crate::drivers::fat::BlockDevice;
 use crate::klog_fmt;
 
 const SECTOR_SIZE: usize = 512;
-const CACHE_SLOTS: usize = 8;
-type ExFatErrorKind = ExFatError<&'static str>;
 
 struct ExFatDevice {
-    inner: Box<dyn BlockDevice>,
+    inner: Arc<Mutex<Box<dyn BlockDevice>>>,
+    position: u64,
+    size: u64,
 }
 
-impl ExFatBlockDevice<SECTOR_SIZE> for ExFatDevice {
-    type Error = &'static str;
-    type Align = A4;
-
-    fn read(
-        &mut self,
-        lba: u32,
-        blocks: &mut [Aligned<Self::Align, [u8; SECTOR_SIZE]>],
-    ) -> Result<(), Self::Error> {
-        blocks
-            .iter_mut()
-            .enumerate()
-            .try_for_each(|(index, block)| {
-                self.inner.read_sectors(
-                    lba.checked_add(index as u32).ok_or("exFAT LBA overflow")?,
-                    1,
-                    &mut block[..],
-                )
-            })
+impl ExFatDevice {
+    fn error(kind: ErrorKind, message: &'static str) -> IoError {
+        IoError::new_static(kind, message)
     }
 
-    fn write(
-        &mut self,
-        lba: u32,
-        blocks: &[Aligned<Self::Align, [u8; SECTOR_SIZE]>],
-    ) -> Result<(), Self::Error> {
-        blocks.iter().enumerate().try_for_each(|(index, block)| {
-            self.inner.write_sectors(
-                lba.checked_add(index as u32).ok_or("exFAT LBA overflow")?,
-                1,
-                &block[..],
-            )
-        })
-    }
-
-    fn size(&mut self) -> Result<u64, Self::Error> {
-        self.inner
-            .total_sectors()
-            .checked_mul(SECTOR_SIZE as u64)
-            .ok_or("exFAT device size overflow")
+    fn lba(position: u64) -> Result<u32, IoError> {
+        u32::try_from(position / SECTOR_SIZE as u64)
+            .map_err(|_| Self::error(ErrorKind::InvalidInput, "exFAT LBA overflow"))
     }
 }
 
-type ExFatInner = ExFat<ExFatDevice, SECTOR_SIZE, CACHE_SLOTS>;
+impl Read for ExFatDevice {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, IoError> {
+        let len = usize::try_from(
+            self.size
+                .saturating_sub(self.position)
+                .min(buf.len() as u64),
+        )
+        .unwrap_or(buf.len());
+        let mut done = 0;
+        let mut sector = [0; SECTOR_SIZE];
+        let mut device = self.inner.lock();
+
+        while done < len {
+            let position = self.position + done as u64;
+            let offset = position as usize % SECTOR_SIZE;
+            let remaining = len - done;
+            if offset == 0 && remaining >= SECTOR_SIZE {
+                let count = (remaining / SECTOR_SIZE).min(u16::MAX as usize) as u16;
+                let bytes = count as usize * SECTOR_SIZE;
+                device
+                    .read_sectors(Self::lba(position)?, count, &mut buf[done..done + bytes])
+                    .map_err(|message| Self::error(ErrorKind::Other, message))?;
+                done += bytes;
+                continue;
+            }
+            device
+                .read_sectors(Self::lba(position)?, 1, &mut sector)
+                .map_err(|message| Self::error(ErrorKind::Other, message))?;
+            let bytes = (SECTOR_SIZE - offset).min(remaining);
+            buf[done..done + bytes].copy_from_slice(&sector[offset..offset + bytes]);
+            done += bytes;
+        }
+        self.position += done as u64;
+        Ok(done)
+    }
+}
+
+impl Write for ExFatDevice {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, IoError> {
+        let len = usize::try_from(
+            self.size
+                .saturating_sub(self.position)
+                .min(buf.len() as u64),
+        )
+        .unwrap_or(buf.len());
+        let mut done = 0;
+        let mut sector = [0; SECTOR_SIZE];
+        let mut device = self.inner.lock();
+
+        while done < len {
+            let position = self.position + done as u64;
+            let offset = position as usize % SECTOR_SIZE;
+            let remaining = len - done;
+            if offset == 0 && remaining >= SECTOR_SIZE {
+                let count = (remaining / SECTOR_SIZE).min(u16::MAX as usize) as u16;
+                let bytes = count as usize * SECTOR_SIZE;
+                device
+                    .write_sectors(Self::lba(position)?, count, &buf[done..done + bytes])
+                    .map_err(|message| Self::error(ErrorKind::Other, message))?;
+                done += bytes;
+                continue;
+            }
+            device
+                .read_sectors(Self::lba(position)?, 1, &mut sector)
+                .map_err(|message| Self::error(ErrorKind::Other, message))?;
+            let bytes = (SECTOR_SIZE - offset).min(remaining);
+            sector[offset..offset + bytes].copy_from_slice(&buf[done..done + bytes]);
+            device
+                .write_sectors(Self::lba(position)?, 1, &sector)
+                .map_err(|message| Self::error(ErrorKind::Other, message))?;
+            done += bytes;
+        }
+        self.position += done as u64;
+        Ok(done)
+    }
+
+    fn flush(&mut self) -> Result<(), IoError> {
+        Ok(())
+    }
+}
+
+impl Seek for ExFatDevice {
+    fn seek(&mut self, position: SeekFrom) -> Result<u64, IoError> {
+        let position = match position {
+            SeekFrom::Start(offset) => offset as i128,
+            SeekFrom::End(offset) => self.size as i128 + offset as i128,
+            SeekFrom::Current(offset) => self.position as i128 + offset as i128,
+        };
+        if !(0..=self.size as i128).contains(&position) {
+            return Err(Self::error(
+                ErrorKind::InvalidInput,
+                "exFAT seek outside device",
+            ));
+        }
+        self.position = position as u64;
+        Ok(self.position)
+    }
+}
+
+type ExFatInner = ExFatFs<ExFatDevice>;
+type Writer = ExFatFileWriter<'static, ExFatDevice>;
+
+struct Handle {
+    fd: u32,
+    path: String,
+    offset: u64,
+    writer: Option<Writer>,
+}
 
 pub struct ExFatFileSystem {
-    inner: ExFatInner,
+    // Handles must be finalized before `inner` is dropped because writers
+    // contain a stable reference to the pinned filesystem allocation.
+    handles: Vec<Handle>,
+    inner: Pin<Box<ExFatInner>>,
     next_fd: u32,
-    handles: Vec<(u32, String, u64)>,
 }
 
 impl ExFatFileSystem {
@@ -81,47 +160,153 @@ impl ExFatFileSystem {
         if device.sector_size() as usize != SECTOR_SIZE {
             return Err((FsError::NotSupported, Some(device)));
         }
-        let mut inner = ExFat::new(ExFatDevice { inner: device });
-        if let Err(error) = inner.mount() {
-            klog_fmt!("exFAT: mount error: {:?}\n", error);
-            return Err((Self::map_error(error), Some(inner.unmount().inner)));
-        }
-        klog_fmt!("exFAT: volume mounted\n");
+        let size = match device.total_sectors().checked_mul(SECTOR_SIZE as u64) {
+            Some(size) => size,
+            None => return Err((FsError::InvalidInput, Some(device))),
+        };
+        let shared = Arc::new(Mutex::new(device));
+        let adapter = ExFatDevice {
+            inner: Arc::clone(&shared),
+            position: 0,
+            size,
+        };
+        let inner = match ExFatInner::open(adapter) {
+            Ok(inner) => inner,
+            Err(error) => {
+                klog_fmt!("exFAT: mount error: {:?}\n", error);
+                let device = Arc::try_unwrap(shared).ok().map(Mutex::into_inner);
+                return Err((Self::map_error(error), device));
+            }
+        };
+        let info = inner.info();
+        klog_fmt!(
+            "exFAT: volume mounted ({} bytes/sector, {} sectors/cluster)\n",
+            info.bytes_per_sector,
+            info.sectors_per_cluster
+        );
         Ok(Self {
-            inner,
-            next_fd: 1,
             handles: Vec::new(),
+            inner: Box::pin(inner),
+            next_fd: 1,
         })
     }
 
-    fn map_error(error: ExFatErrorKind) -> FsError {
+    fn fs(&self) -> &ExFatInner {
+        self.inner.as_ref().get_ref()
+    }
+
+    fn map_error(error: FatError) -> FsError {
         match error {
-            ExFatError::FileNotFound | ExFatError::DirectoryNotFound => FsError::FileNotFound,
-            ExFatError::AlreadyExists => FsError::FileExists,
-            ExFatError::DiskFull => FsError::DiskFull,
-            ExFatError::DirectoryNotEmpty => FsError::DirectoryNotEmpty,
-            ExFatError::SeekOutOfRange => FsError::InvalidSeek,
-            ExFatError::WriteNotEnabled | ExFatError::ReadNotEnabled => FsError::PermissionDenied,
-            ExFatError::InvalidFileName { .. } => FsError::InvalidPath,
+            FatError::EntryNotFound => FsError::FileNotFound,
+            FatError::AlreadyExists => FsError::FileExists,
+            FatError::NoFreeSpace => FsError::DiskFull,
+            FatError::DirectoryNotEmpty => FsError::DirectoryNotEmpty,
+            FatError::NotADirectory => FsError::NotADirectory,
+            FatError::NotAFile => FsError::IsADirectory,
+            FatError::InvalidPath | FatError::InvalidFilename => FsError::InvalidPath,
+            FatError::Io(error) => Self::map_io_error(error),
+            FatError::IoContext { source, .. } => Self::map_io_error(source),
             _ => FsError::InvalidInput,
         }
     }
 
-    fn handle(&mut self, fd: u32) -> Result<(String, u64), FsError> {
+    fn map_io_error(error: IoError) -> FsError {
+        match error.kind() {
+            ErrorKind::NotFound => FsError::FileNotFound,
+            ErrorKind::AlreadyExists => FsError::FileExists,
+            ErrorKind::PermissionDenied => FsError::PermissionDenied,
+            ErrorKind::OutOfMemory | ErrorKind::WriteZero => FsError::DiskFull,
+            _ => FsError::InvalidInput,
+        }
+    }
+
+    fn split_path(path: &str) -> Result<(&str, &str), FsError> {
+        let path = path.trim_matches('/');
+        if path.is_empty() {
+            return Err(FsError::InvalidPath);
+        }
+        Ok(path.rsplit_once('/').unwrap_or(("", path)))
+    }
+
+    fn directory(&self, path: &str) -> Result<ExFatDir<'_, ExFatDevice>, FsError> {
+        let path = path.trim_matches('/');
+        if path.is_empty() {
+            Ok(self.fs().root_dir())
+        } else {
+            self.fs().open_dir(path).map_err(Self::map_error)
+        }
+    }
+
+    fn create_file(&self, path: &str) -> Result<(), FsError> {
+        let (parent, name) = Self::split_path(path)?;
+        let parent = self.directory(parent)?;
+        self.fs()
+            .create_file(&parent, name)
+            .map(|_| ())
+            .map_err(Self::map_error)
+    }
+
+    fn create_directory(&self, path: &str) -> Result<(), FsError> {
+        let (parent, name) = Self::split_path(path)?;
+        let parent = self.directory(parent)?;
+        self.fs()
+            .create_dir(&parent, name)
+            .map(|_| ())
+            .map_err(Self::map_error)
+    }
+
+    fn next_descriptor(&mut self) -> u32 {
+        loop {
+            let fd = self.next_fd.max(1);
+            self.next_fd = fd.wrapping_add(1).max(1);
+            if self.handles.iter().all(|handle| handle.fd != fd) {
+                return fd;
+            }
+        }
+    }
+
+    fn handle_index(&self, fd: u32) -> Result<usize, FsError> {
         self.handles
             .iter()
-            .find(|handle| handle.0 == fd)
-            .map(|handle| (handle.1.clone(), handle.2))
+            .position(|handle| handle.fd == fd)
             .ok_or(FsError::InvalidFileDescriptor)
+    }
+
+    fn open_writer(&self, path: &str) -> Result<Writer, FsError> {
+        let mut entry = self.fs().open_path(path).map_err(Self::map_error)?;
+        // Empty exFAT streams have no allocation flags on disk. The writer
+        // still has to start in contiguous mode so a second cluster remains
+        // addressable without a FAT chain.
+        if entry.first_cluster == 0 && entry.data_length == 0 {
+            entry.no_fat_chain = true;
+        }
+        let writer = self.fs().write_file(&entry).map_err(Self::map_error)?;
+        // SAFETY: `inner` is pinned in a Box and is therefore never moved. Every
+        // writer is removed/finalized before `inner` is dropped (see `Drop`).
+        Ok(unsafe { mem::transmute::<ExFatFileWriter<'_, ExFatDevice>, Writer>(writer) })
+    }
+}
+
+impl Drop for ExFatFileSystem {
+    fn drop(&mut self) {
+        while let Some(mut handle) = self.handles.pop() {
+            if let Some(writer) = handle.writer.take() {
+                let _ = writer.finish();
+            }
+        }
     }
 }
 
 impl FileSystem for ExFatFileSystem {
     fn open(&mut self, path: &str, flags: u32) -> Option<FileDescriptor> {
-        self.inner.open(path, OpenOptions::new().read(true)).ok()?;
-        let fd = self.next_fd;
-        self.next_fd = self.next_fd.wrapping_add(1);
-        self.handles.push((fd, String::from(path), 0));
+        self.fs().open_file(path).ok()?;
+        let fd = self.next_descriptor();
+        self.handles.push(Handle {
+            fd,
+            path: String::from(path),
+            offset: 0,
+            writer: None,
+        });
         Some(FileDescriptor {
             fd,
             ino: 0,
@@ -131,108 +316,210 @@ impl FileSystem for ExFatFileSystem {
     }
 
     fn read(&mut self, fd: u32, buf: &mut [u8]) -> Result<usize, FsError> {
-        let (path, offset) = self.handle(fd)?;
-        let mut file = self
-            .inner
-            .open(&path, OpenOptions::new().read(true))
-            .map_err(Self::map_error)?;
-        if offset != 0 {
-            file.seek(&mut self.inner, offset)
-                .map_err(Self::map_error)?;
+        let index = self.handle_index(fd)?;
+        if self.handles[index].writer.is_some() {
+            return Err(FsError::PermissionDenied);
         }
-        let read = file
-            .read(&mut self.inner, buf)
-            .map_err(Self::map_error)?
-            .unwrap_or(0);
-        if let Some(handle) = self.handles.iter_mut().find(|handle| handle.0 == fd) {
-            handle.2 += read as u64;
-        }
+        let path = self.handles[index].path.clone();
+        let offset = self.handles[index].offset;
+        let read = {
+            let mut file = self.fs().open_file(&path).map_err(Self::map_error)?;
+            if offset != 0 {
+                file.seek(SeekFrom::Start(offset))
+                    .map_err(Self::map_io_error)?;
+            }
+            file.read(buf).map_err(Self::map_io_error)?
+        };
+        self.handles[index].offset += read as u64;
         Ok(read)
     }
 
     fn write(&mut self, fd: u32, data: &[u8]) -> Result<usize, FsError> {
-        let (path, offset) = self.handle(fd)?;
-        let mut file = self
-            .inner
-            .open(&path, OpenOptions::new().write(true))
-            .map_err(Self::map_error)?;
-        if offset != 0 {
-            file.seek(&mut self.inner, offset)
-                .map_err(Self::map_error)?;
+        let index = self.handle_index(fd)?;
+        if data.is_empty() {
+            return Ok(0);
         }
-        file.write(&mut self.inner, data).map_err(Self::map_error)?;
-        file.close(&mut self.inner).map_err(Self::map_error)?;
-        if let Some(handle) = self.handles.iter_mut().find(|handle| handle.0 == fd) {
-            handle.2 += data.len() as u64;
+        if self.handles[index].writer.is_none() {
+            if self.handles[index].offset != 0 {
+                return Err(FsError::InvalidSeek);
+            }
+            let writer = self.open_writer(&self.handles[index].path)?;
+            self.handles[index].writer = Some(writer);
         }
-        Ok(data.len())
+        let written = self.handles[index]
+            .writer
+            .as_mut()
+            .ok_or(FsError::InvalidInput)?
+            .write(data)
+            .map_err(Self::map_io_error)?;
+        if written == 0 {
+            return Err(FsError::DiskFull);
+        }
+        self.handles[index].offset += written as u64;
+        Ok(written)
     }
 
     fn close(&mut self, fd: u32) -> Result<(), FsError> {
-        let index = self
-            .handles
-            .iter()
-            .position(|handle| handle.0 == fd)
-            .ok_or(FsError::InvalidFileDescriptor)?;
-        self.handles.remove(index);
-        Ok(())
+        let index = self.handle_index(fd)?;
+        let mut handle = self.handles.remove(index);
+        match handle.writer.take() {
+            Some(writer) => writer.finish().map_err(Self::map_error),
+            None => Ok(()),
+        }
     }
 
     fn seek(&mut self, fd: u32, new_pos: usize) -> Result<(), FsError> {
-        let handle = self
-            .handles
-            .iter_mut()
-            .find(|handle| handle.0 == fd)
-            .ok_or(FsError::InvalidFileDescriptor)?;
-        handle.2 = new_pos as u64;
+        let index = self.handle_index(fd)?;
+        let handle = &mut self.handles[index];
+        if handle.writer.is_some() && new_pos as u64 != handle.offset {
+            return Err(FsError::InvalidSeek);
+        }
+        handle.offset = new_pos as u64;
         Ok(())
     }
 
     fn create(&mut self, path: &str, kind: InodeType) -> Option<u64> {
         match kind {
-            InodeType::Directory => self.inner.create_directory(path).ok()?,
-            InodeType::File => {
-                let file = self
-                    .inner
-                    .open(path, OpenOptions::new().create_new(true).write(true))
-                    .ok()?;
-                file.close(&mut self.inner).ok()?;
-            }
+            InodeType::Directory => self.create_directory(path).ok()?,
+            InodeType::File => self.create_file(path).ok()?,
             InodeType::Symlink => return None,
         }
         Some(0)
     }
 
     fn mkdir(&mut self, path: &str) -> Result<(), FsError> {
-        self.inner.create_directory(path).map_err(Self::map_error)
+        self.create_directory(path)
     }
 
     fn unlink(&mut self, path: &str) -> Result<(), FsError> {
-        match self.inner.remove_file(path) {
-            Ok(()) => Ok(()),
-            Err(ExFatError::FileNotFound) => self.inner.remove_dir(path).map_err(Self::map_error),
-            Err(error) => Err(Self::map_error(error)),
-        }
+        let entry = self.fs().open_path(path).map_err(Self::map_error)?;
+        self.fs().delete(&entry).map_err(Self::map_error)
     }
 
     fn readdir(&mut self, path: &str) -> Result<Vec<VNode>, FsError> {
-        let mut directory = self.inner.read_dir(path).map_err(Self::map_error)?;
-        let mut entries = Vec::new();
-        while let Some(entry) = directory
-            .next_entry(&mut self.inner)
-            .map_err(Self::map_error)?
-        {
-            let metadata = entry.metadata();
-            entries.push(VNode {
-                name: entry.file_name(),
-                size: metadata.len(),
-                is_dir: metadata.is_dir(),
-            });
-        }
-        Ok(entries)
+        self.directory(path)?
+            .entries()
+            .map(|entry| {
+                entry
+                    .map(|entry| VNode {
+                        size: entry.size(),
+                        is_dir: entry.is_directory(),
+                        name: entry.name,
+                    })
+                    .map_err(Self::map_error)
+            })
+            .collect()
     }
 
     fn exists(&mut self, path: &str) -> bool {
-        self.inner.exists(path).unwrap_or(false)
+        path.trim_matches('/').is_empty() || self.fs().open_path(path).is_ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use hadris_fat::exfat::{ExFatFormatOptions, format_exfat};
+
+    use super::*;
+
+    const IMAGE_SIZE: usize = 16 * 1024 * 1024;
+
+    #[derive(Clone)]
+    struct MemoryDevice(Arc<Mutex<Vec<u8>>>);
+
+    impl BlockDevice for MemoryDevice {
+        fn read_sectors(
+            &mut self,
+            lba: u32,
+            count: u16,
+            buf: &mut [u8],
+        ) -> Result<(), &'static str> {
+            let (start, len) = Self::range(lba, count)?;
+            if buf.len() < len {
+                return Err("test read buffer too small");
+            }
+            buf[..len].copy_from_slice(&self.0.lock()[start..start + len]);
+            Ok(())
+        }
+
+        fn write_sectors(&mut self, lba: u32, count: u16, buf: &[u8]) -> Result<(), &'static str> {
+            let (start, len) = Self::range(lba, count)?;
+            if buf.len() < len {
+                return Err("test write buffer too small");
+            }
+            self.0.lock()[start..start + len].copy_from_slice(&buf[..len]);
+            Ok(())
+        }
+
+        fn sector_size(&self) -> u32 {
+            SECTOR_SIZE as u32
+        }
+
+        fn total_sectors(&self) -> u64 {
+            IMAGE_SIZE as u64 / SECTOR_SIZE as u64
+        }
+    }
+
+    impl MemoryDevice {
+        fn range(lba: u32, count: u16) -> Result<(usize, usize), &'static str> {
+            let start = lba as usize * SECTOR_SIZE;
+            let len = count as usize * SECTOR_SIZE;
+            if start.checked_add(len).is_none_or(|end| end > IMAGE_SIZE) {
+                return Err("test LBA out of range");
+            }
+            Ok((start, len))
+        }
+    }
+
+    #[test]
+    fn mounts_and_streams_a_windows_sized_exfat_cluster() {
+        let image = Arc::new(Mutex::new(vec![0; IMAGE_SIZE]));
+        let block_device = MemoryDevice(Arc::clone(&image));
+        let shared: Arc<Mutex<Box<dyn BlockDevice>>> =
+            Arc::new(Mutex::new(Box::new(block_device.clone())));
+        let adapter = ExFatDevice {
+            inner: shared,
+            position: 0,
+            size: IMAGE_SIZE as u64,
+        };
+        let options = ExFatFormatOptions::new()
+            .with_label("FULLERENE")
+            .with_sectors_per_cluster(256);
+        drop(format_exfat(adapter, IMAGE_SIZE as u64, &options).unwrap());
+
+        // A shift of 8 (256 sectors) overflowed the old u8 implementation and
+        // triggered the magenta panic screen during `mount`.
+        assert_eq!(image.lock()[109], 8);
+
+        let mut fs = match crate::drivers::fat::mount_device(Box::new(block_device)) {
+            Ok(filesystem) => filesystem,
+            Err((error, _)) => panic!("mount failed: {error}"),
+        };
+        assert_eq!(fs.create("/Bootlog.txt", InodeType::File), Some(0));
+        let fd = fs.open("/Bootlog.txt", 0).unwrap().fd;
+        let expected: Vec<_> = (0..140_000).map(|index| index as u8).collect();
+        for chunk in expected.chunks(4096) {
+            assert_eq!(fs.write(fd, chunk).unwrap(), chunk.len());
+        }
+        fs.close(fd).unwrap();
+
+        let fd = fs.open("/Bootlog.txt", 0).unwrap().fd;
+        let mut actual = vec![0; expected.len()];
+        let mut offset = 0;
+        while offset < actual.len() {
+            let end = (offset + 4096).min(actual.len());
+            let read = fs
+                .read(fd, &mut actual[offset..end])
+                .unwrap_or_else(|error| panic!("read failed at {offset}: {error}"));
+            if read == 0 {
+                break;
+            }
+            offset += read;
+        }
+        fs.close(fd).unwrap();
+        assert_eq!(offset, expected.len());
+        assert_eq!(actual, expected);
     }
 }

--- a/fullerene-kernel/src/drivers/fat.rs
+++ b/fullerene-kernel/src/drivers/fat.rs
@@ -28,7 +28,6 @@ struct MbrPartitionEntry {
     lba_start: u32,
     sector_count: u32,
 }
-
 const MBR_SIGNATURE: u16 = 0xAA55;
 const PARTITION_FAT32: u8 = 0x0B;
 const PARTITION_FAT32_LBA: u8 = 0x0C;
@@ -99,11 +98,12 @@ pub fn mount_device(
     } else {
         Box::new(PartitionBlockDevice { inner: device, offset: lba })
     };
+    let cached: Box<dyn BlockDevice> = Box::new(BlockCache::new(partition, 64));
     if is_exfat(&boot) {
-        crate::drivers::exfat::ExFatFileSystem::new(partition)
+        crate::drivers::exfat::ExFatFileSystem::new(cached)
             .map(|filesystem| Box::new(filesystem) as Box<dyn FileSystem>)
     } else {
-        FatFileSystem::new(Box::new(BlockCache::new(partition, 64)))
+        FatFileSystem::new(cached)
             .map(|filesystem| Box::new(filesystem) as Box<dyn FileSystem>)
             .map_err(|error| (error, None))
     }


### PR DESCRIPTION
## Summary
- replace the `exfat-slim` adapter whose `u8` sectors-per-cluster calculation panics on common 128 KiB SDXC clusters
- add a `no_std` exFAT VFS adapter with persistent streaming writers and batched block I/O
- reuse the block cache for exFAT directory traversal and metadata access
- cover the production mount dispatcher with a shift-8 (256 sectors/cluster) image and a 140,000-byte cross-cluster round trip

## Root cause
`exfat-slim 0.5.0` evaluates `1u8 << sectors_per_cluster_shift`. Windows-formatted SDXC media commonly stores shift 8, which cannot be represented by `u8`; the checked dev build panics during `mount /dev/sd0 /mnt/sdcard`, producing the magenta panic screen.

## Verification
- `cargo test --workspace`
- `cargo test -p fullerene-kernel --locked`
- `cargo check -p fullerene-kernel --locked`
- `cargo build -Zbuild-std=core,alloc -p fullerene-kernel --target x86_64-unknown-uefi --locked`