### PR TITLE
Fix SD card directory open hangs

### DIFF
--- a/nitrogen/src/storage/rtsx.rs
+++ b/nitrogen/src/storage/rtsx.rs
@@ -376,6 +376,9 @@ impl RtsxController {
                 .as_ref()
                 .ok_or("RTSX host command buffer unavailable")?;
             command_buffer.flush_for_cpu();
+            // AUTO_RESPONSE packs one byte per READ_REG at the start of the
+            // command buffer; responses do not remain in their u32 slots.
+            // This matches Linux rtsx_pci_read_ppbuf/get_cmd_data semantics.
             output.copy_from_slice(&command_buffer.as_slice()[..output.len()]);
         }
         Ok(())

--- a/nitrogen/src/storage/rtsx.rs
+++ b/nitrogen/src/storage/rtsx.rs
@@ -4,20 +4,31 @@
 //! in a 16-bit internal register space accessed through `RTSX_HAIMR`; treating
 //! those addresses as BAR byte offsets leaves the engine completely untouched.
 
+use core::mem::size_of;
+
 use spin::Mutex;
 
 use crate::driver_context::DriverContext;
-use crate::mmio::MemRegion;
+use crate::mmio::{DmaRegion, MemRegion};
 use crate::pci::{PciConfigSpace, PciDevice, PciScanner};
 use crate::pci_health::PciHealth;
 use crate::timing::delay_ms;
 
+const RTSX_HCBAR: usize = 0x00;
+const RTSX_HCBCTLR: usize = 0x04;
 const RTSX_HAIMR: usize = 0x10;
 const RTSX_BIPR: usize = 0x14;
 const RTSX_BIER: usize = 0x18;
 const HAIMR_START: u32 = 1 << 31;
 const HAIMR_WRITE: u32 = 1 << 30;
 const SD_EXIST: u32 = 1 << 16;
+const TRANS_OK_INT: u32 = 1 << 29;
+const TRANS_FAIL_INT: u32 = 1 << 28;
+const HOST_COMMAND_START: u32 = 1 << 31;
+const HOST_COMMAND_AUTO_RESPONSE: u32 = 1 << 30;
+const HOST_COMMAND_STOP: u32 = 1 << 28;
+const HOST_COMMAND_BUFFER_SIZE: usize = 1024;
+const HOST_COMMAND_CHUNK: usize = HOST_COMMAND_BUFFER_SIZE / size_of::<u32>();
 
 const CARD_PWR_CTL: u16 = 0xFD50;
 const CARD_SHARE_MODE: u16 = 0xFD52;
@@ -95,6 +106,7 @@ pub struct RtsxController {
     sd_card: Option<SdCardInfo>,
     card_was_present: bool,
     health: PciHealth,
+    host_commands: Option<DmaRegion>,
 }
 
 // Access to the controller is serialized by `CONTROLLER`; its pointer denotes
@@ -102,6 +114,13 @@ pub struct RtsxController {
 unsafe impl Send for RtsxController {}
 
 impl RtsxController {
+    fn host_command(kind: u32, address: u16, mask: u8, value: u8) -> u32 {
+        (kind << 30)
+            | (u32::from(address & 0x3FFF) << 16)
+            | (u32::from(mask) << 8)
+            | u32::from(value)
+    }
+
     fn read_reg(&self, address: u16) -> Result<u8, &'static str> {
         self.mmio.write32(
             RTSX_HAIMR,
@@ -294,14 +313,113 @@ impl RtsxController {
         ])
     }
 
-    fn ppbuf_read(&self, buffer: &mut [u8]) -> Result<(), &'static str> {
+    fn run_host_commands(&mut self, count: usize) -> Result<(), &'static str> {
+        let bytes = count
+            .checked_mul(size_of::<u32>())
+            .filter(|&bytes| bytes != 0 && bytes <= HOST_COMMAND_BUFFER_SIZE)
+            .ok_or("RTSX host command overflow")?;
+        let iova = {
+            let commands = self
+                .host_commands
+                .as_ref()
+                .ok_or("RTSX host command buffer unavailable")?;
+            commands.flush_for_device();
+            u32::try_from(commands.dma_iova()).map_err(|_| "RTSX command address exceeds 32-bit")?
+        };
+
+        self.mmio.write32(RTSX_BIPR, TRANS_OK_INT | TRANS_FAIL_INT);
+        self.mmio.write_batch_then_barrier(&[
+            (RTSX_HCBAR, iova),
+            (
+                RTSX_HCBCTLR,
+                HOST_COMMAND_START | HOST_COMMAND_AUTO_RESPONSE | bytes as u32,
+            ),
+        ]);
+        let result = crate::timing::poll_timeout_us(250_000, || {
+            let status = self.mmio.read32(RTSX_BIPR);
+            (status & TRANS_FAIL_INT != 0)
+                .then_some(Err("RTSX host command failed"))
+                .or_else(|| (status & TRANS_OK_INT != 0).then_some(Ok(())))
+        });
+        self.mmio.write32(RTSX_BIPR, TRANS_OK_INT | TRANS_FAIL_INT);
+        let result = result.unwrap_or(Err("RTSX host command timed out"));
+        if result.is_err() {
+            self.mmio.write32(RTSX_HCBCTLR, HOST_COMMAND_STOP);
+            let _ = self.write_reg(CARD_STOP, 0x44, 0x44);
+        }
+        result
+    }
+
+    fn ppbuf_read_fast(&mut self, buffer: &mut [u8]) -> Result<(), &'static str> {
+        for (chunk_index, output) in buffer.chunks_mut(HOST_COMMAND_CHUNK).enumerate() {
+            let first_register = PPBUF_BASE2 + (chunk_index * HOST_COMMAND_CHUNK) as u16;
+            {
+                let command_buffer = self
+                    .host_commands
+                    .as_mut()
+                    .ok_or("RTSX host command buffer unavailable")?;
+                for (index, command) in command_buffer
+                    .as_mut_slice()
+                    .chunks_exact_mut(size_of::<u32>())
+                    .take(output.len())
+                    .enumerate()
+                {
+                    command.copy_from_slice(
+                        &Self::host_command(0, first_register + index as u16, 0, 0)
+                            .to_le_bytes(),
+                    );
+                }
+            }
+            self.run_host_commands(output.len())?;
+            let command_buffer = self
+                .host_commands
+                .as_ref()
+                .ok_or("RTSX host command buffer unavailable")?;
+            command_buffer.flush_for_cpu();
+            output.copy_from_slice(&command_buffer.as_slice()[..output.len()]);
+        }
+        Ok(())
+    }
+
+    fn ppbuf_read(&mut self, buffer: &mut [u8]) -> Result<(), &'static str> {
+        if self.host_commands.is_some() {
+            return self.ppbuf_read_fast(buffer);
+        }
         buffer.iter_mut().enumerate().try_for_each(|(index, byte)| {
             *byte = self.read_reg(PPBUF_BASE2 + index as u16)?;
             Ok(())
         })
     }
 
-    fn ppbuf_write(&self, buffer: &[u8]) -> Result<(), &'static str> {
+    fn ppbuf_write_fast(&mut self, buffer: &[u8]) -> Result<(), &'static str> {
+        for (chunk_index, input) in buffer.chunks(HOST_COMMAND_CHUNK).enumerate() {
+            let first_register = PPBUF_BASE2 + (chunk_index * HOST_COMMAND_CHUNK) as u16;
+            {
+                let command_buffer = self
+                    .host_commands
+                    .as_mut()
+                    .ok_or("RTSX host command buffer unavailable")?;
+                for (index, (command, &value)) in command_buffer
+                    .as_mut_slice()
+                    .chunks_exact_mut(size_of::<u32>())
+                    .zip(input)
+                    .enumerate()
+                {
+                    command.copy_from_slice(
+                        &Self::host_command(1, first_register + index as u16, 0xFF, value)
+                            .to_le_bytes(),
+                    );
+                }
+            }
+            self.run_host_commands(input.len())?;
+        }
+        Ok(())
+    }
+
+    fn ppbuf_write(&mut self, buffer: &[u8]) -> Result<(), &'static str> {
+        if self.host_commands.is_some() {
+            return self.ppbuf_write_fast(buffer);
+        }
         buffer
             .iter()
             .enumerate()
@@ -444,7 +562,7 @@ impl RtsxController {
         }
     }
 
-    fn read_sector(&self, lba: u32, buffer: &mut [u8]) -> Result<(), &'static str> {
+    fn read_sector(&mut self, lba: u32, buffer: &mut [u8]) -> Result<(), &'static str> {
         self.set_command(CMD17_READ_SINGLE, self.card_address(lba)?)?;
         self.set_data_len()?;
         self.write_regs(&[
@@ -456,8 +574,8 @@ impl RtsxController {
         self.ppbuf_read(buffer)
     }
 
-    fn write_sector(&self, lba: u32, buffer: &[u8]) -> Result<(), &'static str> {
-        let card = self.sd_card.as_ref().ok_or("no initialized card")?;
+    fn write_sector(&mut self, lba: u32, buffer: &[u8]) -> Result<(), &'static str> {
+        let rca = self.sd_card.as_ref().ok_or("no initialized card")?.rca;
         self.command(CMD24_WRITE_SINGLE, self.card_address(lba)?, SD_RSP_R1)?;
         self.ppbuf_write(buffer)?;
         self.set_data_len()?;
@@ -467,7 +585,7 @@ impl RtsxController {
         ])?;
         self.wait_transfer(SD_TRANSFER_END)?;
         if crate::timing::poll_timeout_us(2_000_000, || {
-            self.command(CMD13_SEND_STATUS, u32::from(card.rca) << 16, SD_RSP_R1)
+            self.command(CMD13_SEND_STATUS, u32::from(rca) << 16, SD_RSP_R1)
                 .ok()
                 .filter(|status| status & (1 << 8) != 0)
         }).is_some() {
@@ -477,7 +595,7 @@ impl RtsxController {
     }
 
     pub fn read_sectors(
-        &self,
+        &mut self,
         lba: u32,
         count: u16,
         buffer: &mut [u8],
@@ -494,7 +612,7 @@ impl RtsxController {
             })
     }
 
-    pub fn write_sectors(&self, lba: u32, count: u16, buffer: &[u8]) -> Result<(), &'static str> {
+    pub fn write_sectors(&mut self, lba: u32, count: u16, buffer: &[u8]) -> Result<(), &'static str> {
         let bytes = usize::from(count)
             .checked_mul(512)
             .ok_or("sector count overflow")?;
@@ -570,12 +688,28 @@ pub fn init(context: &dyn DriverContext) {
         },
     );
     let mmio = unsafe { MemRegion::new(virtual_address as *mut u8, 0x1000) };
+    let device_id = (u16::from(device.bus) << 8)
+        | (u16::from(device.device) << 3)
+        | u16::from(device.function);
+    let host_commands = DmaRegion::alloc(context, HOST_COMMAND_BUFFER_SIZE).and_then(|mut buffer| {
+        match buffer.dma_map(context, device_id) {
+            Ok(iova) if u32::try_from(iova).is_ok() => Some(buffer),
+            _ => {
+                buffer.free(context);
+                None
+            }
+        }
+    });
+    if host_commands.is_none() {
+        log::warn!("RTSX: host command DMA unavailable; falling back to slow PIO");
+    }
     *CONTROLLER.lock() = Some(RtsxController {
         device,
         mmio,
         sd_card: None,
         card_was_present: false,
         health,
+        host_commands,
     });
     log::info!("RTSX: RTS5249 registered; SD initialization deferred");
 }
@@ -598,7 +732,7 @@ pub fn sd_card_info() -> Option<SdCardInfo> {
 pub fn read_sectors(lba: u32, count: u16, buffer: &mut [u8]) -> Result<(), &'static str> {
     CONTROLLER
         .lock()
-        .as_ref()
+        .as_mut()
         .ok_or("no RTS5249 controller")?
         .read_sectors(lba, count, buffer)
 }
@@ -606,7 +740,7 @@ pub fn read_sectors(lba: u32, count: u16, buffer: &mut [u8]) -> Result<(), &'sta
 pub fn write_sectors(lba: u32, count: u16, buffer: &[u8]) -> Result<(), &'static str> {
     CONTROLLER
         .lock()
-        .as_ref()
+        .as_mut()
         .ok_or("no RTS5249 controller")?
         .write_sectors(lba, count, buffer)
 }
@@ -627,4 +761,18 @@ pub fn is_card_detected() -> bool {
         .lock()
         .as_ref()
         .is_some_and(|controller| controller.card_was_present)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RtsxController;
+
+    #[test]
+    fn host_command_uses_realtek_wire_format() {
+        assert_eq!(RtsxController::host_command(0, 0xFA00, 0, 0), 0x3A00_0000);
+        assert_eq!(
+            RtsxController::host_command(1, 0xFA00, 0xFF, 0x5A),
+            0x7A00_FF5A
+        );
+    }
 }

--- a/solvent/src/explorer.rs
+++ b/solvent/src/explorer.rs
@@ -22,7 +22,7 @@
 //! +-----------------------------------------------------------+
 //! ```
 
-use crate::SOLVENT_CALLBACKS;
+use crate::{SOLVENT_CALLBACKS, VfsEntry};
 use alloc::format;
 use alloc::string::String;
 use alloc::vec;
@@ -239,6 +239,7 @@ pub struct ExplorerContext {
     pending_operation: Option<PendingOperation>,
     status_message: Option<String>,
     rename_shift_held: bool,
+    pending_navigation: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -284,6 +285,7 @@ impl ExplorerContext {
             pending_operation: None,
             status_message: None,
             rename_shift_held: false,
+            pending_navigation: None,
         }
     }
 
@@ -325,43 +327,49 @@ impl ExplorerContext {
     }
 
     pub fn navigate_to(&mut self, path: &str) {
-        let path_str = String::from(path);
-        let readdir = match SOLVENT_CALLBACKS.lock().vfs_readdir {
-            Some(f) => f,
-            None => return,
-        };
-        match readdir(&path_str) {
-            Ok(entries) => {
-                self.current_dir = path_str.clone();
-                self.raw_names = entries.iter().map(|e| e.name.clone()).collect();
-                self.raw_is_dir = entries.iter().map(|e| e.is_dir).collect();
-                self.entries = entries
-                    .iter()
-                    .map(|e| {
-                        let size_str = if e.is_dir {
-                            String::from("<DIR>")
-                        } else {
-                            format_size(e.size)
-                        };
-                        FileEntryDisplay {
-                            name: e.name.clone(),
-                            size_str,
-                            is_dir: e.is_dir,
-                        }
-                    })
-                    .collect();
-                self.sort_entries();
-                self.selected_index = None;
-                self.scroll_offset = 0;
-                if self.history_pos >= self.history.len()
-                    || self.history[self.history_pos] != path_str
-                {
-                    self.history.truncate(self.history_pos + 1);
-                    self.history.push(path_str);
-                    self.history_pos = self.history.len() - 1;
-                }
+        self.pending_navigation = Some(String::from(path));
+        self.status_message = Some(String::from("Loading..."));
+    }
+
+    pub(crate) fn take_navigation_request(&mut self) -> Option<String> {
+        self.pending_navigation.take()
+    }
+
+    pub(crate) fn finish_navigation(
+        &mut self,
+        path: String,
+        result: Result<Vec<VfsEntry>, &'static str>,
+    ) {
+        let entries = match result {
+            Ok(entries) => entries,
+            Err(error) => {
+                self.status_message = Some(format!("Open failed: {}", error));
+                return;
             }
-            Err(_) => {}
+        };
+        self.current_dir = path.clone();
+        self.raw_names = entries.iter().map(|entry| entry.name.clone()).collect();
+        self.raw_is_dir = entries.iter().map(|entry| entry.is_dir).collect();
+        self.entries = entries
+            .into_iter()
+            .map(|entry| FileEntryDisplay {
+                size_str: if entry.is_dir {
+                    String::from("<DIR>")
+                } else {
+                    format_size(entry.size)
+                },
+                name: entry.name,
+                is_dir: entry.is_dir,
+            })
+            .collect();
+        self.sort_entries();
+        self.selected_index = None;
+        self.scroll_offset = 0;
+        self.status_message = None;
+        if self.history_pos >= self.history.len() || self.history[self.history_pos] != path {
+            self.history.truncate(self.history_pos + 1);
+            self.history.push(path);
+            self.history_pos = self.history.len() - 1;
         }
     }
 
@@ -450,33 +458,7 @@ impl ExplorerContext {
         if self.history_pos > 0 {
             self.history_pos -= 1;
             let path = self.history[self.history_pos].clone();
-            let readdir = match SOLVENT_CALLBACKS.lock().vfs_readdir {
-                Some(f) => f,
-                None => return,
-            };
-            if let Ok(entries) = readdir(&path) {
-                self.current_dir = path;
-                self.raw_names = entries.iter().map(|e| e.name.clone()).collect();
-                self.raw_is_dir = entries.iter().map(|e| e.is_dir).collect();
-                self.entries = entries
-                    .iter()
-                    .map(|e| {
-                        let size_str = if e.is_dir {
-                            String::from("<DIR>")
-                        } else {
-                            format_size(e.size)
-                        };
-                        FileEntryDisplay {
-                            name: e.name.clone(),
-                            size_str,
-                            is_dir: e.is_dir,
-                        }
-                    })
-                    .collect();
-                self.sort_entries();
-                self.selected_index = None;
-                self.scroll_offset = 0;
-            }
+            self.navigate_to(&path);
         }
     }
 
@@ -484,33 +466,7 @@ impl ExplorerContext {
         if self.history_pos + 1 < self.history.len() {
             self.history_pos += 1;
             let path = self.history[self.history_pos].clone();
-            let readdir = match SOLVENT_CALLBACKS.lock().vfs_readdir {
-                Some(f) => f,
-                None => return,
-            };
-            if let Ok(entries) = readdir(&path) {
-                self.current_dir = path;
-                self.raw_names = entries.iter().map(|e| e.name.clone()).collect();
-                self.raw_is_dir = entries.iter().map(|e| e.is_dir).collect();
-                self.entries = entries
-                    .iter()
-                    .map(|e| {
-                        let size_str = if e.is_dir {
-                            String::from("<DIR>")
-                        } else {
-                            format_size(e.size)
-                        };
-                        FileEntryDisplay {
-                            name: e.name.clone(),
-                            size_str,
-                            is_dir: e.is_dir,
-                        }
-                    })
-                    .collect();
-                self.sort_entries();
-                self.selected_index = None;
-                self.scroll_offset = 0;
-            }
+            self.navigate_to(&path);
         }
     }
 
@@ -1213,5 +1169,35 @@ fn draw_glyph(surface: &mut Surface, ch: u8, x: u32, y: u32, fg: u32, bg: u32) {
                 pixels[row_base + dx + gx] = fg;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ExplorerContext;
+    use crate::VfsEntry;
+    use alloc::string::String;
+
+    #[test]
+    fn navigation_is_deferred_until_io_completes() {
+        let mut explorer = ExplorerContext::new();
+        explorer.navigate_to("/mnt/sdcard");
+
+        assert_eq!(explorer.current_dir, "/");
+        assert_eq!(
+            explorer.take_navigation_request().as_deref(),
+            Some("/mnt/sdcard")
+        );
+
+        explorer.finish_navigation(
+            String::from("/mnt/sdcard"),
+            Ok(alloc::vec![VfsEntry {
+                name: String::from("Bootlog.txt"),
+                size: 512,
+                is_dir: false,
+            }]),
+        );
+        assert_eq!(explorer.current_dir, "/mnt/sdcard");
+        assert_eq!(explorer.entries[0].name, "Bootlog.txt");
     }
 }

--- a/solvent/src/lib.rs
+++ b/solvent/src/lib.rs
@@ -568,6 +568,30 @@ pub fn set_render_fn(f: fn()) {
     *RENDER_FN.lock() = Some(f);
 }
 
+fn service_explorer_navigation() {
+    let request = RUNTIME
+        .lock()
+        .as_mut()
+        .and_then(|runtime| runtime.explorer.as_mut()?.take_navigation_request());
+    let Some(path) = request else { return };
+
+    // Filesystem and hardware I/O must run without the runtime lock. Rendering
+    // takes locks in the opposite direction and synchronous removable-media I/O
+    // here previously deadlocked the desktop when a directory was opened.
+    let callback = SOLVENT_CALLBACKS.lock().vfs_readdir;
+    let result = callback
+        .ok_or("filesystem unavailable")
+        .and_then(|read| read(&path));
+
+    if let Some(runtime) = RUNTIME.lock().as_mut()
+        && let Some(explorer) = runtime.explorer.as_mut()
+    {
+        explorer.finish_navigation(path, result);
+        runtime.explorer_dirty = true;
+        runtime.frame_due = true;
+    }
+}
+
 pub fn tick_core(now: u64) {
     GLOBAL_TICK.store(now, core::sync::atomic::Ordering::Relaxed);
 
@@ -598,6 +622,7 @@ pub fn tick_core(now: u64) {
     }
 
     process_events();
+    service_explorer_navigation();
     if RUNTIME.lock().as_mut().map_or(false, |r| {
         let p = r.shell_launch_pending;
         r.shell_launch_pending = false;


### PR DESCRIPTION
## Summary
- defer File Manager directory I/O until the Solvent runtime lock is released, removing the runtime/VFS lock-order inversion
- batch RTS5249 PPBUF reads and writes with the controller host-command DMA engine instead of 512 HAIMR MMIO transactions per sector
- bound host-command failures to 250 ms and retain legacy PIO only when a DMA command buffer cannot be allocated
- add regression tests for deferred navigation and Realtek host-command encoding

## Verification
- `cargo test --workspace`
- `cargo test -p nitrogen storage::rtsx::tests::host_command_uses_realtek_wire_format`
- `cargo test -p solvent explorer::tests::navigation_is_deferred_until_io_completes`
- `cargo build -p fullerene-kernel --target x86_64-unknown-uefi`
- `cargo check -p fullerene-kernel --target x86_64-unknown-uefi`

Real Fullerene hardware validation is still required for the RTS5249 DMA path.