### PR TITLE
fix(storage): unblock SD directory navigation

### DIFF
--- a/nitrogen/src/storage/rtsx.rs
+++ b/nitrogen/src/storage/rtsx.rs
@@ -30,6 +30,16 @@ const HOST_COMMAND_STOP: u32 = 1 << 28;
 const HOST_COMMAND_BUFFER_SIZE: usize = 1024;
 const HOST_COMMAND_CHUNK: usize = HOST_COMMAND_BUFFER_SIZE / size_of::<u32>();
 
+#[repr(u32)]
+#[derive(Clone, Copy)]
+enum HostCommandKind {
+    Read,
+    Write,
+    Check,
+}
+
+type RegisterCommand = (HostCommandKind, u16, u8, u8);
+
 const CARD_PWR_CTL: u16 = 0xFD50;
 const CARD_SHARE_MODE: u16 = 0xFD52;
 const CARD_STOP: u16 = 0xFD54;
@@ -114,8 +124,8 @@ pub struct RtsxController {
 unsafe impl Send for RtsxController {}
 
 impl RtsxController {
-    fn host_command(kind: u32, address: u16, mask: u8, value: u8) -> u32 {
-        (kind << 30)
+    fn host_command(kind: HostCommandKind, address: u16, mask: u8, value: u8) -> u32 {
+        ((kind as u32) << 30)
             | (u32::from(address & 0x3FFF) << 16)
             | (u32::from(mask) << 8)
             | u32::from(value)
@@ -350,6 +360,80 @@ impl RtsxController {
         result
     }
 
+    fn run_register_commands(&mut self, commands: &[RegisterCommand]) -> Result<(), &'static str> {
+        {
+            let command_buffer = self
+                .host_commands
+                .as_mut()
+                .ok_or("RTSX host command buffer unavailable")?;
+            for (slot, &(kind, address, mask, value)) in command_buffer
+                .as_mut_slice()
+                .chunks_exact_mut(size_of::<u32>())
+                .zip(commands)
+            {
+                slot.copy_from_slice(&Self::host_command(kind, address, mask, value).to_le_bytes());
+            }
+        }
+        self.run_host_commands(commands.len())
+    }
+
+    fn read_sector_commands(argument: u32) -> [RegisterCommand; 13] {
+        let [arg0, arg1, arg2, arg3] = argument.to_be_bytes();
+        [
+            (
+                HostCommandKind::Write,
+                SD_CMD0,
+                0xFF,
+                SD_CMD_START | CMD17_READ_SINGLE,
+            ),
+            (HostCommandKind::Write, SD_CMD1, 0xFF, arg0),
+            (HostCommandKind::Write, SD_CMD1 + 1, 0xFF, arg1),
+            (HostCommandKind::Write, SD_CMD1 + 2, 0xFF, arg2),
+            (HostCommandKind::Write, SD_CMD1 + 3, 0xFF, arg3),
+            (HostCommandKind::Write, SD_BYTE_CNT_L, 0xFF, 0),
+            (HostCommandKind::Write, SD_BYTE_CNT_H, 0xFF, 2),
+            (HostCommandKind::Write, SD_BLOCK_CNT_L, 0xFF, 1),
+            (HostCommandKind::Write, SD_BLOCK_CNT_H, 0xFF, 0),
+            (HostCommandKind::Write, SD_CFG2, 0xFF, SD_RSP_R1),
+            (HostCommandKind::Write, CARD_DATA_SOURCE, 0x01, 0x01),
+            (
+                HostCommandKind::Write,
+                SD_TRANSFER,
+                0xFF,
+                SD_TRANSFER_START | SD_TM_NORMAL_READ,
+            ),
+            (
+                HostCommandKind::Check,
+                SD_TRANSFER,
+                SD_TRANSFER_END,
+                SD_TRANSFER_END,
+            ),
+        ]
+    }
+
+    fn write_sector_commands() -> [RegisterCommand; 8] {
+        [
+            (HostCommandKind::Write, SD_BYTE_CNT_L, 0xFF, 0),
+            (HostCommandKind::Write, SD_BYTE_CNT_H, 0xFF, 2),
+            (HostCommandKind::Write, SD_BLOCK_CNT_L, 0xFF, 1),
+            (HostCommandKind::Write, SD_BLOCK_CNT_H, 0xFF, 0),
+            (HostCommandKind::Write, SD_CFG2, 0xFF, 0),
+            (HostCommandKind::Write, CARD_DATA_SOURCE, 0x01, 0x01),
+            (
+                HostCommandKind::Write,
+                SD_TRANSFER,
+                0xFF,
+                SD_TRANSFER_START | SD_TM_AUTO_WRITE_3,
+            ),
+            (
+                HostCommandKind::Check,
+                SD_TRANSFER,
+                SD_TRANSFER_END,
+                SD_TRANSFER_END,
+            ),
+        ]
+    }
+
     fn ppbuf_read_fast(&mut self, buffer: &mut [u8]) -> Result<(), &'static str> {
         for (chunk_index, output) in buffer.chunks_mut(HOST_COMMAND_CHUNK).enumerate() {
             let first_register = PPBUF_BASE2 + (chunk_index * HOST_COMMAND_CHUNK) as u16;
@@ -365,8 +449,13 @@ impl RtsxController {
                     .enumerate()
                 {
                     command.copy_from_slice(
-                        &Self::host_command(0, first_register + index as u16, 0, 0)
-                            .to_le_bytes(),
+                        &Self::host_command(
+                            HostCommandKind::Read,
+                            first_register + index as u16,
+                            0,
+                            0,
+                        )
+                        .to_le_bytes(),
                     );
                 }
             }
@@ -409,8 +498,13 @@ impl RtsxController {
                     .enumerate()
                 {
                     command.copy_from_slice(
-                        &Self::host_command(1, first_register + index as u16, 0xFF, value)
-                            .to_le_bytes(),
+                        &Self::host_command(
+                            HostCommandKind::Write,
+                            first_register + index as u16,
+                            0xFF,
+                            value,
+                        )
+                        .to_le_bytes(),
                     );
                 }
             }
@@ -566,14 +660,19 @@ impl RtsxController {
     }
 
     fn read_sector(&mut self, lba: u32, buffer: &mut [u8]) -> Result<(), &'static str> {
-        self.set_command(CMD17_READ_SINGLE, self.card_address(lba)?)?;
-        self.set_data_len()?;
-        self.write_regs(&[
-            (SD_CFG2, 0xFF, SD_RSP_R1),
-            (CARD_DATA_SOURCE, 0x01, 0x01),
-            (SD_TRANSFER, 0xFF, SD_TRANSFER_START | SD_TM_NORMAL_READ),
-        ])?;
-        self.wait_transfer(SD_TRANSFER_END)?;
+        let argument = self.card_address(lba)?;
+        if self.host_commands.is_some() {
+            self.run_register_commands(&Self::read_sector_commands(argument))?;
+        } else {
+            self.set_command(CMD17_READ_SINGLE, argument)?;
+            self.set_data_len()?;
+            self.write_regs(&[
+                (SD_CFG2, 0xFF, SD_RSP_R1),
+                (CARD_DATA_SOURCE, 0x01, 0x01),
+                (SD_TRANSFER, 0xFF, SD_TRANSFER_START | SD_TM_NORMAL_READ),
+            ])?;
+            self.wait_transfer(SD_TRANSFER_END)?;
+        }
         self.ppbuf_read(buffer)
     }
 
@@ -581,12 +680,16 @@ impl RtsxController {
         let rca = self.sd_card.as_ref().ok_or("no initialized card")?.rca;
         self.command(CMD24_WRITE_SINGLE, self.card_address(lba)?, SD_RSP_R1)?;
         self.ppbuf_write(buffer)?;
-        self.set_data_len()?;
-        self.write_regs(&[
-            (SD_CFG2, 0xFF, 0),
-            (SD_TRANSFER, 0xFF, SD_TRANSFER_START | SD_TM_AUTO_WRITE_3),
-        ])?;
-        self.wait_transfer(SD_TRANSFER_END)?;
+        if self.host_commands.is_some() {
+            self.run_register_commands(&Self::write_sector_commands())?;
+        } else {
+            self.set_data_len()?;
+            self.write_regs(&[
+                (SD_CFG2, 0xFF, 0),
+                (SD_TRANSFER, 0xFF, SD_TRANSFER_START | SD_TM_AUTO_WRITE_3),
+            ])?;
+            self.wait_transfer(SD_TRANSFER_END)?;
+        }
         if crate::timing::poll_timeout_us(2_000_000, || {
             self.command(CMD13_SEND_STATUS, u32::from(rca) << 16, SD_RSP_R1)
                 .ok()
@@ -768,14 +871,26 @@ pub fn is_card_detected() -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::RtsxController;
+    use super::{HostCommandKind, RtsxController, SD_TRANSFER, SD_TRANSFER_END};
 
     #[test]
     fn host_command_uses_realtek_wire_format() {
-        assert_eq!(RtsxController::host_command(0, 0xFA00, 0, 0), 0x3A00_0000);
         assert_eq!(
-            RtsxController::host_command(1, 0xFA00, 0xFF, 0x5A),
+            RtsxController::host_command(HostCommandKind::Read, 0xFA00, 0, 0),
+            0x3A00_0000
+        );
+        assert_eq!(
+            RtsxController::host_command(HostCommandKind::Write, 0xFA00, 0xFF, 0x5A),
             0x7A00_FF5A
+        );
+        assert_eq!(
+            RtsxController::host_command(
+                HostCommandKind::Check,
+                SD_TRANSFER,
+                SD_TRANSFER_END,
+                SD_TRANSFER_END,
+            ),
+            0xBDB3_4040
         );
     }
 }

--- a/solvent/src/explorer.rs
+++ b/solvent/src/explorer.rs
@@ -475,20 +475,14 @@ impl ExplorerContext {
         self.navigate_to(&parent);
     }
 
-    pub fn open_selected(&mut self, idx: usize) {
-        if idx < self.raw_is_dir.len() && self.raw_is_dir[idx] {
-            let name = &self.raw_names[idx];
-            let new_path = join_path(&self.current_dir, name);
-            self.navigate_to(&new_path);
-        }
-    }
-
-    /// Get the full path of a file entry (for launching).
-    pub fn get_file_path(&self, idx: usize) -> Option<String> {
-        if idx < self.raw_names.len() {
-            Some(join_path(&self.current_dir, &self.raw_names[idx]))
-        } else {
+    /// Queue a directory navigation or return a file path for launching.
+    pub fn activate_entry(&mut self, idx: usize) -> Option<String> {
+        let path = join_path(&self.current_dir, self.raw_names.get(idx)?);
+        if *self.raw_is_dir.get(idx)? {
+            self.navigate_to(&path);
             None
+        } else {
+            Some(path)
         }
     }
 
@@ -1199,5 +1193,23 @@ mod tests {
         );
         assert_eq!(explorer.current_dir, "/mnt/sdcard");
         assert_eq!(explorer.entries[0].name, "Bootlog.txt");
+    }
+
+    #[test]
+    fn activating_entries_uses_one_path_for_keyboard_and_mouse() {
+        let mut explorer = ExplorerContext::new();
+        explorer.current_dir = String::from("/mnt");
+        explorer.raw_names = alloc::vec![String::from("sdcard"), String::from("Bootlog.txt")];
+        explorer.raw_is_dir = alloc::vec![true, false];
+
+        assert_eq!(explorer.activate_entry(0), None);
+        assert_eq!(
+            explorer.take_navigation_request().as_deref(),
+            Some("/mnt/sdcard")
+        );
+        assert_eq!(
+            explorer.activate_entry(1).as_deref(),
+            Some("/mnt/Bootlog.txt")
+        );
     }
 }

--- a/solvent/src/handlers.rs
+++ b/solvent/src/handlers.rs
@@ -7,6 +7,8 @@ use crate::{FB_DIMS, RUNTIME, SUPER_HELD};
 use lattice::shell_overlay::ShellState;
 use resonance::{Event, EventHandler, InputEvent, KeyCode, MouseButton};
 
+const DOUBLE_CLICK_TICKS: u64 = 500;
+
 pub(crate) struct WmEventHandler;
 
 impl EventHandler for WmEventHandler {
@@ -192,20 +194,17 @@ fn handle_explorer_click(rt: &mut crate::RuntimeState, btn: MouseButton, cx: i32
                 let now = crate::GLOBAL_TICK.load(core::sync::atomic::Ordering::Relaxed);
                 let is_double = explorer.selected_index == Some(idx)
                     && explorer.last_click_entry == Some(idx)
-                    && now.wrapping_sub(explorer.last_click_tick) < 60;
+                    && now.wrapping_sub(explorer.last_click_tick) <= DOUBLE_CLICK_TICKS;
 
                 explorer.selected_index = Some(idx);
 
                 if is_double {
-                    if idx < explorer.raw_is_dir.len() && explorer.raw_is_dir[idx] {
-                        explorer.open_selected(idx);
-                        explorer.last_click_entry = None;
-                    } else if let Some(path) = explorer.get_file_path(idx) {
+                    let launch_path = explorer.activate_entry(idx);
+                    explorer.last_click_entry = None;
+                    if let Some(path) = launch_path {
                         // Save path, drop explorer borrow, then launch
-                        explorer.last_click_entry = None;
-                        let file_path = path;
                         let _ = explorer;
-                        crate::launch_file(rt, &file_path);
+                        crate::launch_file(rt, &path);
                         return;
                     }
                 } else {

--- a/solvent/src/lib.rs
+++ b/solvent/src/lib.rs
@@ -954,7 +954,7 @@ fn explorer_handle_key(rt: &mut RuntimeState, scancode: u8, pressed: bool) {
     let key = scancode_to_resonance_keycode(scancode);
     let visible_rows = 20usize;
     // Pre-compute enter action to avoid borrow conflicts.
-    let mut enter_action: Option<(String, bool)> = None;
+    let mut enter_action = None;
     match key {
         resonance::KeyCode::Up => {
             let explorer = match rt.explorer.as_mut() { Some(e) => e, None => return };
@@ -981,28 +981,14 @@ fn explorer_handle_key(rt: &mut RuntimeState, scancode: u8, pressed: bool) {
         resonance::KeyCode::Enter => {
             let explorer = match rt.explorer.as_mut() { Some(e) => e, None => return };
             if let Some(idx) = explorer.selected_index {
-                let name = match explorer.raw_names.get(idx) {
-                    Some(n) => n,
-                    None => return,
-                };
-                let is_dir = explorer.raw_is_dir.get(idx).copied().unwrap_or(false);
-                let path = if explorer.current_dir.ends_with('/') {
-                    alloc::format!("{}{}", explorer.current_dir, name)
-                } else {
-                    alloc::format!("{}/{}", explorer.current_dir, name)
-                };
-                if is_dir {
-                    explorer.navigate_to(&path);
-                    rt.explorer_dirty = true;
-                    rt.frame_due = true;
-                } else {
-                    enter_action = Some((path, is_dir));
-                }
+                enter_action = explorer.activate_entry(idx);
+                rt.explorer_dirty = true;
+                rt.frame_due = true;
             }
         }
         _ => {}
     }
-    if let Some((path, false)) = enter_action {
+    if let Some(path) = enter_action {
         launch_file(rt, &path);
     }
 }


### PR DESCRIPTION
## Summary
- Batch RTS5249 CMD17 setup, data length, PPBUF selection, transfer start, and completion check into one DMA host-command submission, following the Linux rtsx_pci_sdmmc sequence.
- Keep the PIO path as a compatibility fallback while removing repeated HAIMR polling from the real-device read hot path.
- Route Enter and double-click through one Explorer activation method and use a human-scale 500-tick double-click window.

## Verification
- cargo test --workspace
- cargo check -p fullerene-kernel --target x86_64-unknown-uefi
- cargo build -p fullerene-kernel --target x86_64-unknown-uefi

## Real hardware follow-up
- Mount the exFAT SDXC card at /mnt/sdcard, then open it with both Enter and double-click on Fullerene/RTS5249.