### PR TITLE
fix(storage): prevent exFAT directory scan stalls

### DIFF
--- a/fullerene-kernel/src/drivers/exfat.rs
+++ b/fullerene-kernel/src/drivers/exfat.rs
@@ -4,6 +4,7 @@ use alloc::boxed::Box;
 use alloc::collections::BTreeSet;
 use alloc::string::String;
 use alloc::sync::Arc;
+use alloc::vec;
 use alloc::vec::Vec;
 use core::mem;
 use core::pin::Pin;
@@ -19,6 +20,7 @@ use crate::drivers::fat::BlockDevice;
 use crate::klog_fmt;
 
 const SECTOR_SIZE: usize = 512;
+const DIRECTORY_READ_SIZE: usize = 4096;
 
 struct ExFatDevice {
     inner: Arc<Mutex<Box<dyn BlockDevice>>>,
@@ -293,6 +295,10 @@ impl ExFatFileSystem {
 
     fn root_entries(&self) -> Result<Vec<VNode>, FsError> {
         let info = self.fs().info();
+        let cluster_size = usize::try_from(info.bytes_per_cluster)
+            .ok()
+            .filter(|size| *size >= SECTOR_SIZE && size % 32 == 0)
+            .ok_or(FsError::InvalidInput)?;
         let fat = ExFatTable::new(info);
         let mut device = ExFatDevice {
             inner: Arc::clone(&self.device),
@@ -303,6 +309,7 @@ impl ExFatFileSystem {
         let mut visited = BTreeSet::new();
         let mut pending = Vec::with_capacity(19);
         let mut entries = Vec::new();
+        let mut buffer = vec![0; cluster_size.min(DIRECTORY_READ_SIZE)];
 
         loop {
             if !visited.insert(cluster) {
@@ -311,12 +318,20 @@ impl ExFatFileSystem {
             device
                 .seek(SeekFrom::Start(info.cluster_to_offset(cluster)))
                 .map_err(Self::map_io_error)?;
-            for _ in 0..info.bytes_per_cluster / 32 {
-                let mut raw = [0; 32];
-                device.read_exact(&mut raw).map_err(Self::map_io_error)?;
-                if Self::consume_entry(raw, &mut pending, &mut entries) {
-                    return Ok(entries);
+            let mut remaining = cluster_size;
+            while remaining != 0 {
+                let bytes = remaining.min(buffer.len());
+                device
+                    .read_exact(&mut buffer[..bytes])
+                    .map_err(Self::map_io_error)?;
+                for chunk in buffer[..bytes].chunks_exact(32) {
+                    let mut raw = [0; 32];
+                    raw.copy_from_slice(chunk);
+                    if Self::consume_entry(raw, &mut pending, &mut entries) {
+                        return Ok(entries);
+                    }
                 }
+                remaining -= bytes;
             }
             match fat
                 .next_cluster(&mut device, cluster)
@@ -526,6 +541,7 @@ mod tests {
     struct MemoryDevice {
         image: Arc<Mutex<Vec<u8>>>,
         reads: Arc<AtomicUsize>,
+        read_calls: Arc<AtomicUsize>,
     }
 
     impl BlockDevice for MemoryDevice {
@@ -539,6 +555,7 @@ mod tests {
             if buf.len() < len {
                 return Err("test read buffer too small");
             }
+            self.read_calls.fetch_add(1, Ordering::Relaxed);
             self.reads.fetch_add(count as usize, Ordering::Relaxed);
             buf[..len].copy_from_slice(&self.image.lock()[start..start + len]);
             Ok(())
@@ -567,6 +584,7 @@ mod tests {
             Self {
                 image,
                 reads: Arc::new(AtomicUsize::new(0)),
+                read_calls: Arc::new(AtomicUsize::new(0)),
             }
         }
 
@@ -636,11 +654,16 @@ mod tests {
             Err((error, _)) => panic!("remount failed: {error}"),
         };
         block_device.reads.store(0, Ordering::Relaxed);
+        block_device.read_calls.store(0, Ordering::Relaxed);
         let entries = fs.readdir("/").unwrap();
         assert!(entries.iter().any(|entry| entry.name == "Bootlog.txt"));
         assert!(
             block_device.reads.load(Ordering::Relaxed) <= 256,
             "root scan escaped its FAT chain"
+        );
+        assert!(
+            block_device.read_calls.load(Ordering::Relaxed) <= 33,
+            "root scan did not batch contiguous sectors"
         );
     }
 

--- a/fullerene-kernel/src/drivers/fat.rs
+++ b/fullerene-kernel/src/drivers/fat.rs
@@ -178,9 +178,33 @@ impl<D: BlockDevice> BlockDevice for BlockCache<D> {
         if buf.len() < needed { return Err("buffer too small for multi-sector read"); }
         let end_lba = (lba as u64) + (count as u64);
         if end_lba > self.inner.total_sectors() || end_lba > u32::MAX as u64 { return Err("LBA range exceeds device capacity or 32-bit limit"); }
-        for i in 0..count {
-            let off = i * self.bps;
-            self.read_sector(lba + i as u32, &mut buf[off..off + self.bps]).map_err(|e| match e { BlockError::Device(s) => s, _ => "block cache error" })?;
+        let mut index = 0;
+        while index < count {
+            let current_lba = lba + index as u32;
+            if let Some(slot) = self.lookup(current_lba) {
+                let offset = index * self.bps;
+                buf[offset..offset + self.bps].copy_from_slice(&self.entries[slot].1);
+                index += 1;
+                continue;
+            }
+
+            let first = index;
+            while index < count && self.lookup(lba + index as u32).is_none() {
+                index += 1;
+            }
+            let start = first * self.bps;
+            let end = index * self.bps;
+            self.inner.read_sectors(
+                lba + first as u32,
+                (index - first) as u16,
+                &mut buf[start..end],
+            )?;
+            for sector in first..index {
+                let slot = self.evict_slot();
+                let offset = sector * self.bps;
+                self.entries[slot].0 = Some(lba + sector as u32);
+                self.entries[slot].1.copy_from_slice(&buf[offset..offset + self.bps]);
+            }
         }
         Ok(())
     }
@@ -190,11 +214,12 @@ impl<D: BlockDevice> BlockDevice for BlockCache<D> {
         if buf.len() < needed { return Err("buffer too small for multi-sector write"); }
         let end_lba = (lba as u64) + (count as u64);
         if end_lba > self.inner.total_sectors() || end_lba > u32::MAX as u64 { return Err("LBA range exceeds device capacity or 32-bit limit"); }
-        for i in 0..count {
-            let off = i * self.bps;
-            self.write_sector(lba + i as u32, &buf[off..off + self.bps]).map_err(|e| match e { BlockError::Device(s) => s, _ => "block cache error" })?;
+        for index in 0..count {
+            if let Some(slot) = self.lookup(lba + index as u32) {
+                self.entries[slot].0 = None;
+            }
         }
-        Ok(())
+        self.inner.write_sectors(lba, count as u16, &buf[..needed])
     }
     fn sector_size(&self) -> u32 { self.bps as u32 }
     fn total_sectors(&self) -> u64 { self.inner.total_sectors() }

--- a/nitrogen/src/storage/rtsx.rs
+++ b/nitrogen/src/storage/rtsx.rs
@@ -719,6 +719,7 @@ impl RtsxController {
         count: u16,
         buffer: &mut [u8],
     ) -> Result<(), &'static str> {
+        self.prepare_device()?;
         let bytes = usize::from(count)
             .checked_mul(512)
             .ok_or("sector count overflow")?;
@@ -732,6 +733,7 @@ impl RtsxController {
     }
 
     pub fn write_sectors(&mut self, lba: u32, count: u16, buffer: &[u8]) -> Result<(), &'static str> {
+        self.prepare_device()?;
         let bytes = usize::from(count)
             .checked_mul(512)
             .ok_or("sector count overflow")?;


### PR DESCRIPTION
## Summary
- stream exFAT root directories in 4 KiB chunks instead of issuing a block-device read for every 32-byte directory entry
- coalesce contiguous block-cache misses and multi-sector writes into a single lower-layer request
- re-establish RTS5249 PCI D0/MMIO/ASPM prerequisites before every public SD read/write operation
- verify a Windows-sized 128 KiB exFAT root cluster needs at most 33 lower-layer reads, including FAT-chain lookup

## Cause
Mounting only reads the filesystem metadata, while opening `/mnt/sdcard` starts root-directory enumeration. That path repeatedly requested 32-byte records and could generate hundreds of RTSX transactions. It also entered the normal RTSX transfer path without the PCI health preflight required by `PciHealth`, so an idle/power-state transition between mount and directory open could leave the first MMIO cycle unsafe.

## Tests
- `cargo test --workspace` (WSL): passed
- `cargo test -p fullerene-kernel`: 20 passed
- `cargo test -p nitrogen`: 59 passed, 7 doctests ignored
- strict workspace Clippy remains blocked by pre-existing warnings outside this change