### PR TITLE
fix(gui): avoid framebuffer read hang after Explorer update

### DIFF
--- a/lattice/src/compositor.rs
+++ b/lattice/src/compositor.rs
@@ -181,16 +181,15 @@ fn blit_button(fb: &mut [u32], fbw: u32, cache: &[u32; 14 * 14], bx: i32, by: i3
     }
 }
 
-fn draw_cursor_impl(
+/// Blend the cursor into a RAM-backed render target within `clip`.
+pub fn render_cursor(
     fb: &mut [u32],
     fbw: u32,
     fbh: u32,
     cur: &Cursor,
-    cx: u32,
-    cy: u32,
-    cw: u32,
-    ch: u32,
+    clip: DirtyRect,
 ) {
+    let DirtyRect { x: cx, y: cy, width: cw, height: ch } = clip;
     let pixels = Cursor::shape();
     let sz = Cursor::SIZE as i32;
     let dst_x = cur.x - Cursor::HOTSPOT_X;
@@ -434,11 +433,17 @@ impl Compositor {
         // new cursor positions is already pushed by prepare_frame(), so
         // the compositor redraws both the restored old area and the new
         // cursor position in a single pass.
-        if let Some(c) = scene.cursor {
-            if c.visible {
-                Self::draw_cursor_clipped(framebuffer, fb_width, fb_height, c, dx, dy, dw, dh);
-                inc_draw_calls();
-            }
+        if let Some(c) = scene.cursor
+            && c.visible
+        {
+            render_cursor(
+                framebuffer,
+                fb_width,
+                fb_height,
+                c,
+                DirtyRect::new(dx, dy, dw, dh),
+            );
+            inc_draw_calls();
         }
 
         // Debug overlay (FPS + draw calls)
@@ -515,24 +520,6 @@ impl Compositor {
         let mut p = crate::painter::Painter::new(fb, fbw, fbh);
         let x = (fbw.saturating_sub(150)) as i32;
         p.draw_text(x, 4, text_str, accent, 13.0);
-    }
-
-    // ── Cursor ────────────────────────────────────────────
-
-    pub fn draw_cursor_direct(fb: &mut [u32], fbw: u32, fbh: u32, cur: &Cursor) {
-        draw_cursor_impl(fb, fbw, fbh, cur, 0, 0, fbw, fbh);
-    }
-    fn draw_cursor_clipped(
-        fb: &mut [u32],
-        fbw: u32,
-        fbh: u32,
-        cur: &Cursor,
-        cx: u32,
-        cy: u32,
-        cw: u32,
-        ch: u32,
-    ) {
-        draw_cursor_impl(fb, fbw, fbh, cur, cx, cy, cw, ch);
     }
 
     // ── Window drawing ────────────────────────────────────

--- a/lattice/src/desktop.rs
+++ b/lattice/src/desktop.rs
@@ -409,13 +409,6 @@ impl Desktop {
         self.wm.on_mouse_down(self.cursor.x, self.cursor.y);
     }
 
-    /// Returns `true` when any transient overlay (context menu, network
-    /// menu, password dialog) is open.  Callers can use this to decide
-    /// whether a cursor‑only update is safe.
-    pub fn has_active_overlays(&self) -> bool {
-        self.active_menu.is_some() || self.network_menu_open || self.pwd_dialog_open
-    }
-
     /// Force a full-screen redraw on the next frame.
     ///
     /// Useful when overlay modes (TaskOverview / AppGrid) need every frame
@@ -712,13 +705,7 @@ impl Desktop {
     pub fn scene(&self) -> Scene<'_> {
         Scene {
             windows: self.wm.windows(),
-            // Cursor is drawn by solvent::render() via
-            // `draw_cursor_direct` as the final layer.
-            // Including it here would cause the compositor to
-            // render it into the back‑buffer, which then gets
-            // captured by the lightweight‑update save buffer,
-            // producing ghost cursors after overlay transitions.
-            cursor: None,
+            cursor: Some(&self.cursor),
             bg_color: self.bg_color,
             dirty_rects: &self.dirty_cache,
             taskbar: Some(&self.taskbar),
@@ -794,6 +781,12 @@ mod tests {
 
         // Top‑left corner of the window should be red.
         assert_eq!(target.pixels[0], 0xFF0000);
+    }
+
+    #[test]
+    fn scene_delegates_cursor_rendering_to_compositor() {
+        let dt = Desktop::new(0x202020);
+        assert!(dt.scene().cursor.is_some());
     }
 
     #[test]

--- a/solvent/src/handlers.rs
+++ b/solvent/src/handlers.rs
@@ -27,17 +27,9 @@ impl EventHandler for WmEventHandler {
             Event::Input(InputEvent::MouseMove { x, y }) => {
                 rt.desktop.mouse_move(*x, *y);
                 rt.frame_due = true;
-                // When only the cursor moves (no menus or dialogs open),
-                // skip the full compositor redraw and just update the cursor.
-                if !rt.desktop.has_active_overlays() {
-                    rt.cursor_only_update = true;
-                }
                 true
             }
             Event::Input(InputEvent::MouseDown(btn)) => {
-                // Clear cursor-only mode since mouse down is a scene-mutating event
-                rt.cursor_only_update = false;
-
                 let cx = rt.desktop.cursor.x;
                 let cy = rt.desktop.cursor.y;
 
@@ -242,25 +234,17 @@ fn handle_overlay_event(rt: &mut crate::RuntimeState, event: &Event) -> bool {
         Event::Input(InputEvent::MouseMove { x, y }) => {
             rt.desktop.mouse_move(*x, *y);
             rt.frame_due = true;
-            // During overlay mode, mark cursor-only so the render pass
-            // skips the full compositor/overlay re-render.
-            if rt.shell_state != lattice::shell_overlay::ShellState::Desktop {
-                rt.cursor_only_update = true;
-            }
             true
         }
         Event::Input(InputEvent::MouseDown(_))
             if rt.shell_state == ShellState::TimeZoneSelector =>
         {
-            rt.cursor_only_update = false;
             handle_timezone_click(rt)
         }
         Event::Input(InputEvent::MouseDown(_)) if rt.shell_state == ShellState::AppGrid => {
-            rt.cursor_only_update = false;
             handle_appgrid_click(rt)
         }
         Event::Input(InputEvent::MouseDown(_)) => {
-            rt.cursor_only_update = false;
             rt.shell_state = ShellState::Desktop;
             rt.frame_due = true;
             true

--- a/solvent/src/lib.rs
+++ b/solvent/src/lib.rs
@@ -31,7 +31,7 @@ mod viewers;
 
 // ── Sub-module re-exports ─────────────────────────────────────
 pub use clock::clock_string;
-pub use render::{cursor_save_background, render, set_render_progress_fn};
+pub use render::{render, set_render_progress_fn};
 pub use terminal::{LatticeTerminal, PIPE_STDIN, PIPE_STDOUT, render_terminal};
 
 use alloc::boxed::Box;
@@ -253,11 +253,6 @@ pub struct RuntimeState {
     pub shell_state: ShellState,
     pub shell_launch_pending: bool,
     pub clock_changed: bool,
-    pub cursor_save_buf: [u32;
-        lattice::cursor::Cursor::SIZE as usize * lattice::cursor::Cursor::SIZE as usize],
-    pub cursor_save_x: i32,
-    pub cursor_save_y: i32,
-    pub cursor_save_valid: bool,
     pub editor_window: Option<WindowId>,
     pub editor_buf: EditorBuffer,
     pub editor_launch_pending: bool,
@@ -267,7 +262,6 @@ pub struct RuntimeState {
     pub explorer_dirty: bool,
     pub settings_window: Option<WindowId>,
     pub settings_dirty: bool,
-    pub cursor_only_update: bool,
 }
 
 pub fn init() {
@@ -312,11 +306,6 @@ pub fn init() {
         shell_state: ShellState::Desktop,
         shell_launch_pending: false,
         clock_changed: false,
-        cursor_save_buf: [0u32;
-            lattice::cursor::Cursor::SIZE as usize * lattice::cursor::Cursor::SIZE as usize],
-        cursor_save_x: 0,
-        cursor_save_y: 0,
-        cursor_save_valid: false,
         editor_window: None,
         editor_buf: EditorBuffer::new(),
         editor_launch_pending: false,
@@ -326,7 +315,6 @@ pub fn init() {
         explorer_dirty: false,
         settings_window: None,
         settings_dirty: false,
-        cursor_only_update: false,
     });
 }
 

--- a/solvent/src/render.rs
+++ b/solvent/src/render.rs
@@ -1,9 +1,9 @@
-//! Desktop rendering — compositor pass, brightness, cursor save/restore.
+//! Desktop rendering — compositor pass, brightness, and framebuffer blit.
 //!
 //! Extracted from `lib.rs` to reduce the size of the god-module.
 
 use crate::{DISPLAY_BRIGHTNESS_X100, HEAP_EXTEND_RESERVE, RUNTIME, SOLVENT_CALLBACKS};
-use lattice::compositor::{Compositor, RenderTarget};
+use lattice::compositor::{Compositor, RenderTarget, render_cursor};
 use lattice::shell_overlay::{ShellState, render_app_grid, render_task_overview};
 use spin::Mutex;
 
@@ -25,52 +25,6 @@ impl RenderTarget for FramebufferTarget<'_> {
     }
 }
 
-// ── Cursor helpers ────────────────────────────────────────────
-
-pub fn cursor_save_background(
-    cursor: &lattice::cursor::Cursor,
-    buf: &mut [u32; lattice::cursor::Cursor::SIZE as usize
-             * lattice::cursor::Cursor::SIZE as usize],
-    save_x: &mut i32,
-    save_y: &mut i32,
-    save_valid: &mut bool,
-    fb: &[u32],
-    fb_stride: u32,
-    fb_width: u32,
-    fb_height: u32,
-) {
-    if !cursor.visible {
-        return;
-    }
-    let cur_sz = lattice::cursor::Cursor::SIZE as i32;
-    let cx = cursor.x - lattice::cursor::Cursor::HOTSPOT_X;
-    let cy = cursor.y - lattice::cursor::Cursor::HOTSPOT_Y;
-    let stride_i = fb_stride as i32;
-    let fbw_i = fb_width as i32;
-    let fbh_i = fb_height as i32;
-    let fb_len = (fb_stride as usize).saturating_mul(fb_height as usize);
-    for row in 0..cur_sz {
-        let sy = cy + row;
-        for col in 0..cur_sz {
-            let val = if sy >= 0 && sy < fbh_i {
-                let sx = cx + col;
-                if sx >= 0 && sx < fbw_i {
-                    let idx = (sy * stride_i + sx) as usize;
-                    if idx < fb_len { fb[idx] } else { 0 }
-                } else {
-                    0
-                }
-            } else {
-                0
-            };
-            buf[(row * cur_sz + col) as usize] = val;
-        }
-    }
-    *save_x = cx;
-    *save_y = cy;
-    *save_valid = true;
-}
-
 // ── Progress callback ────────────────────────────────────────
 
 static RENDER_PROGRESS_FN: Mutex<Option<fn(&[u8])>> = Mutex::new(None);
@@ -82,6 +36,52 @@ pub fn set_render_progress_fn(f: fn(&[u8])) {
 fn render_progress(label: &[u8]) {
     if let Some(f) = *RENDER_PROGRESS_FN.lock() {
         f(label);
+    }
+}
+
+fn clip_region(
+    region: lattice::scene::DirtyRect,
+    width: u32,
+    height: u32,
+) -> Option<lattice::scene::DirtyRect> {
+    (region.x < width && region.y < height)
+        .then(|| {
+            lattice::scene::DirtyRect::new(
+                region.x,
+                region.y,
+                region.width.min(width - region.x),
+                region.height.min(height - region.y),
+            )
+        })
+        .filter(|region| region.width != 0 && region.height != 0)
+}
+
+fn blit_region(
+    back: &[u32],
+    back_width: usize,
+    framebuffer: &mut [u32],
+    framebuffer_stride: usize,
+    region: lattice::scene::DirtyRect,
+) {
+    for row in region.y as usize..(region.y + region.height) as usize {
+        let src = row * back_width + region.x as usize;
+        let dst = row * framebuffer_stride + region.x as usize;
+        let width = region.width as usize;
+        let (Some(src_end), Some(dst_end)) = (src.checked_add(width), dst.checked_add(width)) else {
+            return;
+        };
+        let Some(source) = back.get(src..src_end) else {
+            return;
+        };
+        if dst_end > framebuffer.len() {
+            return;
+        }
+        // SAFETY: the range checks above prove that each destination pixel is
+        // inside the framebuffer. Volatile stores are required for GOP MMIO.
+        let destination = unsafe { framebuffer.as_mut_ptr().add(dst) };
+        for (column, &pixel) in source.iter().enumerate() {
+            unsafe { core::ptr::write_volatile(destination.add(column), pixel) };
+        }
     }
 }
 
@@ -111,7 +111,6 @@ pub fn render(fb: &mut petroleum::graphics::FramebufferGuard) {
         let prev = *PREV_SHELL_STATE.lock();
         if rt.shell_state != prev {
             rt.desktop.force_full_redraw();
-            rt.cursor_only_update = false;
             *PREV_SHELL_STATE.lock() = rt.shell_state;
             *PREV_TRANSITION.lock() = true;
         }
@@ -195,10 +194,6 @@ pub fn render(fb: &mut petroleum::graphics::FramebufferGuard) {
 
     let has_dirty = rt.desktop.has_pending_dirty_rects();
     if has_dirty {
-        let cursor_only = core::mem::replace(&mut rt.cursor_only_update, false);
-
-        // When cursor_only, skip compositor + overlay — just update cursor below.
-        if !cursor_only {
         render_progress(b"RENDER: has dirty");
         {
             let back_needed = back_len.saturating_mul(4);
@@ -235,7 +230,10 @@ pub fn render(fb: &mut petroleum::graphics::FramebufferGuard) {
                 height: fb_height,
             };
             render_progress(b"RENDER: compositor");
-            let scene = rt.desktop.scene();
+            let mut scene = rt.desktop.scene();
+            // Cursor must remain the final system layer, but is composed in RAM
+            // so rendering never needs to sample the physical GOP framebuffer.
+            let cursor = scene.cursor.take();
             let (bx, by, bw, bh) = Compositor::render(&scene, &mut back_target);
             render_progress(b"RENDER: compositor done");
             let brightness = DISPLAY_BRIGHTNESS_X100.load(core::sync::atomic::Ordering::Relaxed);
@@ -261,118 +259,94 @@ pub fn render(fb: &mut petroleum::graphics::FramebufferGuard) {
                     }
                 }
             }
-            if was_transition || (bw > 0 && bh > 0) {
-                let back_w = fb_width as usize;
-                render_progress(b"RENDER: copy to fb");
-                let fb_base = fb_pixels.as_mut_ptr();
-                let fb_stride_u = fb_stride;
-                if was_transition {
-                    for row in 0..fb_height as usize {
-                        let src_off = row * back_w;
-                        let dst_off = row * fb_stride_u;
-                        for col in 0..back_w {
-                            unsafe {
-                                core::ptr::write_volatile(
-                                    fb_base.add(dst_off + col),
-                                    back[src_off + col],
-                                );
-                            }
-                        }
-                    }
-                } else {
-                    for row in 0..bh {
-                        let src_off = ((by + row) as usize) * back_w + (bx as usize);
-                        let dst_off = ((by + row) as usize) * fb_stride_u + (bx as usize);
-                        for col in 0..bw as usize {
-                            unsafe {
-                                core::ptr::write_volatile(
-                                    fb_base.add(dst_off + col),
-                                    back[src_off + col],
-                                );
-                            }
-                        }
-                    }
-                }
-            }
-        }
 
-        match rt.shell_state {
-            ShellState::TaskOverview => render_task_overview(
-                fb_pixels,
-                fb_width,
-                fb_height,
-                fb_stride_pixels,
-                rt.desktop.wm.windows(),
-            ),
-            ShellState::AppGrid => {
-                render_app_grid(fb_pixels, fb_width, fb_height, fb_stride_pixels)
-            }
-            ShellState::TimeZoneSelector => {
-                let offset =
-                    crate::clock::TIMEZONE_OFFSET_HOURS.load(core::sync::atomic::Ordering::Relaxed);
-                lattice::shell_overlay::render_timezone_selector(
-                    fb_pixels,
+            render_progress(b"RENDER: system layers");
+            match rt.shell_state {
+                ShellState::TaskOverview => render_task_overview(
+                    back,
                     fb_width,
                     fb_height,
-                    fb_stride_pixels,
-                    offset,
+                    fb_width,
+                    scene.windows,
+                ),
+                ShellState::AppGrid => render_app_grid(back, fb_width, fb_height, fb_width),
+                ShellState::TimeZoneSelector => {
+                    let offset = crate::clock::TIMEZONE_OFFSET_HOURS
+                        .load(core::sync::atomic::Ordering::Relaxed);
+                    lattice::shell_overlay::render_timezone_selector(
+                        back, fb_width, fb_height, fb_width, offset,
+                    );
+                }
+                ShellState::Desktop => {}
+            }
+            if rt.shell_state == ShellState::Desktop
+                && lattice::top_panel::is_top_panel_enabled()
+            {
+                rt.desktop
+                    .top_panel
+                    .render(back, fb_width, fb_height, fb_width);
+            }
+            if let Some(cursor) = cursor.filter(|cursor| cursor.visible) {
+                render_cursor(
+                    back,
+                    fb_width,
+                    fb_height,
+                    cursor,
+                    lattice::scene::DirtyRect::full(fb_width, fb_height),
                 );
             }
-            ShellState::Desktop => {}
-        }
 
-        if rt.shell_state == ShellState::Desktop && lattice::top_panel::is_top_panel_enabled() {
-            rt.desktop
-                .top_panel
-                .render(fb_pixels, fb_width, fb_height, fb_stride_pixels);
-        }
-        } // end !cursor_only
-
-        // Cursor handling: restore old cursor, save background, draw new cursor
-        let cur_sz = lattice::cursor::Cursor::SIZE as i32;
-        if rt.cursor_save_valid {
-            let sx = rt.cursor_save_x;
-            let sy = rt.cursor_save_y;
-            let fbw_i = fb_width as i32;
-            let fbh_i = fb_height as i32;
-            for row in 0..cur_sz {
-                let dy = sy + row;
-                if dy < 0 || dy >= fbh_i {
-                    continue;
-                }
-                for col in 0..cur_sz {
-                    let dx = sx + col;
-                    if dx < 0 || dx >= fbw_i {
-                        continue;
-                    }
-                    let idx = (dy as usize) * fb_stride + (dx as usize);
-                    if idx < fb_pixels_len {
-                        fb_pixels[idx] = rt.cursor_save_buf[(row * cur_sz + col) as usize];
+            if was_transition {
+                render_progress(b"RENDER: copy to fb");
+                blit_region(
+                    back,
+                    fb_width as usize,
+                    fb_pixels,
+                    fb_stride,
+                    lattice::scene::DirtyRect::full(fb_width, fb_height),
+                );
+            } else if bw > 0 && bh > 0 {
+                render_progress(b"RENDER: copy dirty regions");
+                for &region in scene.dirty_rects {
+                    if let Some(region) = clip_region(region, fb_width, fb_height) {
+                        blit_region(back, fb_width as usize, fb_pixels, fb_stride, region);
                     }
                 }
             }
-            rt.cursor_save_valid = false;
-        }
-
-        if rt.desktop.cursor.visible {
-            cursor_save_background(
-                &rt.desktop.cursor,
-                &mut rt.cursor_save_buf,
-                &mut rt.cursor_save_x,
-                &mut rt.cursor_save_y,
-                &mut rt.cursor_save_valid,
-                fb_pixels,
-                fb_stride_pixels,
-                fb_width,
-                fb_height,
-            );
-            Compositor::draw_cursor_direct(
-                fb_pixels,
-                fb_stride_pixels,
-                fb_height,
-                &rt.desktop.cursor,
-            );
         }
     }
 
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clips_regions_to_visible_framebuffer() {
+        assert_eq!(
+            clip_region(lattice::scene::DirtyRect::new(2, 1, 4, 3), 5, 3),
+            Some(lattice::scene::DirtyRect::new(2, 1, 3, 2))
+        );
+        assert_eq!(
+            clip_region(lattice::scene::DirtyRect::new(5, 0, 1, 1), 5, 3),
+            None
+        );
+    }
+
+    #[test]
+    fn blits_only_the_requested_region_and_preserves_stride_padding() {
+        let back = [1, 2, 3, 4, 5, 6];
+        let mut framebuffer = [0; 8];
+
+        blit_region(
+            &back,
+            3,
+            &mut framebuffer,
+            4,
+            lattice::scene::DirtyRect::new(1, 0, 2, 2),
+        );
+
+        assert_eq!(framebuffer, [0, 2, 3, 0, 0, 5, 6, 0]);
+    }
 }


### PR DESCRIPTION
## Summary
- remove the legacy cursor save/restore path that sampled the physical GOP framebuffer after Explorer rendered
- compose shell overlays, top panel, and cursor in the RAM back buffer, then use volatile stores only for the GOP transfer
- blit individual dirty rectangles instead of their large merged bounding box
- remove cursor-only state and thin cursor wrappers made obsolete by compositor ownership

## Diagnosis
`Explorer ready 1 entries` is emitted only after directory enumeration has returned and the Explorer surface has been rendered. The next legacy step read the cursor background from the physical framebuffer. On the affected hardware that framebuffer read can stall after the visible taskbar checkpoint, matching the reported symptom.

## PR #259 follow-up review
- the `bytes_per_cluster` type comment is not applicable to the current `hadris-fat` API/toolchain and is unrelated to this post-VFS stall
- the checkpoint/frame-display comment is diagnostic rather than causal; the physical display of `Explorer ready 1 entries` proves execution passed the VFS completion checkpoint

## Verification
- `cargo test --workspace`
- `cargo build -Z build-std=core,alloc -p fullerene-kernel --target x86_64-unknown-uefi`
- added dirty-region/stride tests and a compositor cursor ownership regression test

## Real-hardware retest
1. `mount /dev/sd0 /mnt/sdcard`
2. open Explorer
3. select `sdcard` and press Enter
4. confirm entries appear and the cursor remains responsive