### PR TITLE
fix(gui): unblock Explorer after exFAT directory display

### DIFF
--- a/fullerene-kernel/src/contexts/framebuffer.rs
+++ b/fullerene-kernel/src/contexts/framebuffer.rs
@@ -247,15 +247,10 @@ impl FramebufferContext {
                 let (w, h) = (i.width, i.height);
                 gpu.flush(w, h);
             }
-        } else if self.renderer.is_some() {
-            // The framebuffer is in PCI MMIO space; the firmware MTRR
-            // override typically sets it to UC or WC.  In both cases
-            // writes bypass the CPU cache and SFENCE is sufficient to
-            // drain the write-combining or posted-write buffers.
-            // CLFLUSH is deliberately NOT used here — on some hardware
-            // it can trigger machine checks on UC/WC MMIO regions.
-            unsafe { core::arch::x86_64::_mm_sfence() };
         }
+        // GOP is direct scanout and has no present transaction. Its volatile
+        // blits are already submitted; waiting for a PCI completion fence here
+        // can indefinitely stop the desktop after a large dirty-region update.
         nitrogen::hda::HdaController::tick_vm_exit();
     }
     pub fn has_virtio_gpu(&self) -> bool {

--- a/fullerene-kernel/src/drivers/exfat.rs
+++ b/fullerene-kernel/src/drivers/exfat.rs
@@ -247,7 +247,6 @@ impl ExFatFileSystem {
         let prefetch = ExFatBootSector::read(&mut adapter)
             .map_err(Self::map_error)
             .and_then(|boot| {
-                cache.lock().clear();
                 Self::scan_root(&mut adapter, boot.info(), |sector| {
                     sector.chunks_exact(32).any(|entry| entry[0] == 0)
                 })

--- a/fullerene-kernel/src/gui.rs
+++ b/fullerene-kernel/src/gui.rs
@@ -187,7 +187,7 @@ fn render_fallback(label: &[u8]) {
     }
 }
 
-/// Submit a frame for backends that require an explicit present.
+/// Flush backends that require explicit frame submission.
 fn finish_frame() {
     crate::graphics::flush_gpu();
 }

--- a/fullerene-kernel/src/gui.rs
+++ b/fullerene-kernel/src/gui.rs
@@ -18,7 +18,6 @@
 //! ```
 
 use core::sync::atomic::{AtomicBool, Ordering};
-use petroleum::graphics::Renderer;
 use solvent;
 
 use genome::fs::FsError;
@@ -188,13 +187,8 @@ fn render_fallback(label: &[u8]) {
     }
 }
 
-/// Signal present and flush GPU after rendering.
+/// Submit a frame for backends that require an explicit present.
 fn finish_frame() {
-    crate::contexts::kernel::with_kernel_mut(|k| {
-        if let Some(ref mut renderer) = k.framebuffer.renderer {
-            renderer.present();
-        }
-    });
     crate::graphics::flush_gpu();
 }
 

--- a/lattice/src/wm.rs
+++ b/lattice/src/wm.rs
@@ -61,17 +61,19 @@ const RESIZE_HANDLE_SIZE: u32 = 16;
 const MIN_WINDOW_W: u32 = 80;
 const MIN_WINDOW_H: u32 = 40;
 
-/// TITLE_BAR_HEIGHT from compositor — kept in sync manually.
-const TITLE_BAR_H: u32 = 20;
-const BORDER: u32 = 2;
-
 /// Build a dirty rect for the full decorated area of a window.
 pub(crate) fn window_dirty_rect(w: &Window) -> DirtyRect {
-    let x0 = w.x.saturating_sub(BORDER as i32).max(0) as u32;
-    let y0 = w.y.saturating_sub(BORDER as i32).max(0) as u32;
-    let ww = w.width + BORDER * 2;
-    let wh = w.height + TITLE_BAR_H + BORDER * 2;
-    DirtyRect::new(x0, y0, ww, wh)
+    let border = if w.title.is_some() {
+        crate::compositor::WINDOW_BORDER
+    } else {
+        0
+    };
+    DirtyRect::new(
+        w.x.saturating_sub(border as i32).max(0) as u32,
+        w.y.saturating_sub(border as i32).max(0) as u32,
+        w.decorated_width(),
+        w.decorated_height(),
+    )
 }
 
 impl WindowManager {
@@ -692,7 +694,7 @@ mod tests {
     fn test_title_bar_drag() {
         let mut wm = WindowManager::new();
         wm.create_titled_window(10, 10, 100, 100, 0xFF0000, "Test");
-        // y=20 is inside title bar (y=10..30, TITLE_BAR_HEIGHT=20)
+        // y=20 is inside the title bar that starts at y=10.
         wm.on_mouse_down(50, 20);
         assert!(matches!(
             wm.drag,
@@ -729,5 +731,11 @@ mod tests {
         let rects = wm.consume_dirty_rects();
         assert!(!rects.is_empty());
         assert!(wm.consume_dirty_rects().is_empty());
+    }
+
+    #[test]
+    fn titled_window_dirty_rect_matches_compositor_decoration() {
+        let window = Window::new_with_title(WindowId(1), 10, 10, 100, 80, 0, "Test");
+        assert_eq!(window_dirty_rect(&window), DirtyRect::new(9, 9, 102, 110));
     }
 }

--- a/lattice/src/wm.rs
+++ b/lattice/src/wm.rs
@@ -68,11 +68,13 @@ pub(crate) fn window_dirty_rect(w: &Window) -> DirtyRect {
     } else {
         0
     };
+    let x = w.x.saturating_sub(border as i32);
+    let y = w.y.saturating_sub(border as i32);
     DirtyRect::new(
-        w.x.saturating_sub(border as i32).max(0) as u32,
-        w.y.saturating_sub(border as i32).max(0) as u32,
-        w.decorated_width(),
-        w.decorated_height(),
+        x.max(0) as u32,
+        y.max(0) as u32,
+        w.decorated_width().saturating_sub(x.min(0).unsigned_abs()),
+        w.decorated_height().saturating_sub(y.min(0).unsigned_abs()),
     )
 }
 
@@ -737,5 +739,22 @@ mod tests {
     fn titled_window_dirty_rect_matches_compositor_decoration() {
         let window = Window::new_with_title(WindowId(1), 10, 10, 100, 80, 0, "Test");
         assert_eq!(window_dirty_rect(&window), DirtyRect::new(9, 9, 102, 110));
+    }
+
+    #[test]
+    fn dirty_rect_clips_windows_above_and_left_of_screen() {
+        let window = Window::new_with_title(WindowId(1), -20, -15, 100, 80, 0, "Test");
+        assert_eq!(window_dirty_rect(&window), DirtyRect::new(0, 0, 81, 94));
+
+        let offscreen = Window::new_with_title(
+            WindowId(2),
+            i32::MIN,
+            i32::MIN,
+            100,
+            80,
+            0,
+            "Offscreen",
+        );
+        assert_eq!(window_dirty_rect(&offscreen), DirtyRect::new(0, 0, 0, 0));
     }
 }

--- a/solvent/src/explorer.rs
+++ b/solvent/src/explorer.rs
@@ -157,6 +157,7 @@ pub enum SortMode {
 pub struct FileEntryDisplay {
     pub name: String,
     pub size_str: String,
+    pub size: u64,
     pub is_dir: bool,
 }
 
@@ -232,8 +233,6 @@ pub struct ExplorerContext {
     pub window_id: Option<WindowId>,
     pub current_dir: String,
     pub entries: Vec<FileEntryDisplay>,
-    pub raw_names: Vec<String>,
-    pub raw_is_dir: Vec<bool>,
     pub selected_index: Option<usize>,
     pub scroll_offset: usize,
     pub sidebar_items: Vec<SidebarItem>,
@@ -252,6 +251,7 @@ pub struct ExplorerContext {
     status_message: Option<String>,
     rename_shift_held: bool,
     pending_navigation: Option<PendingNavigation>,
+    rendered_navigation: Option<usize>,
 }
 
 #[derive(Debug, Clone)]
@@ -279,8 +279,6 @@ impl ExplorerContext {
             window_id: None,
             current_dir: String::from("/"),
             entries: Vec::new(),
-            raw_names: Vec::new(),
-            raw_is_dir: Vec::new(),
             selected_index: None,
             scroll_offset: 0,
             sidebar_items: Self::default_sidebar(),
@@ -298,6 +296,7 @@ impl ExplorerContext {
             status_message: None,
             rename_shift_held: false,
             pending_navigation: None,
+            rendered_navigation: None,
         }
     }
 
@@ -362,12 +361,11 @@ impl ExplorerContext {
             Ok(entries) => entries,
             Err(error) => {
                 self.status_message = Some(format!("Open failed: {}", error));
+                self.rendered_navigation = None;
                 return;
             }
         };
         self.current_dir = path.clone();
-        self.raw_names = entries.iter().map(|entry| entry.name.clone()).collect();
-        self.raw_is_dir = entries.iter().map(|entry| entry.is_dir).collect();
         self.entries = entries
             .into_iter()
             .map(|entry| FileEntryDisplay {
@@ -377,6 +375,7 @@ impl ExplorerContext {
                     format_size(entry.size)
                 },
                 name: entry.name,
+                size: entry.size,
                 is_dir: entry.is_dir,
             })
             .collect();
@@ -384,11 +383,16 @@ impl ExplorerContext {
         self.selected_index = None;
         self.scroll_offset = 0;
         self.status_message = None;
+        self.rendered_navigation = Some(self.entries.len());
         if self.history_pos >= self.history.len() || self.history[self.history_pos] != path {
             self.history.truncate(self.history_pos + 1);
             self.history.push(path);
             self.history_pos = self.history.len() - 1;
         }
+    }
+
+    pub(crate) fn take_rendered_navigation(&mut self) -> Option<usize> {
+        self.rendered_navigation.take()
     }
 
     pub fn refresh(&mut self) {
@@ -443,33 +447,17 @@ impl ExplorerContext {
 
     fn sort_entries(&mut self) {
         let ascending = self.sort_ascending;
-        // Keep directories first
-        let mut indices: Vec<usize> = (0..self.entries.len()).collect();
-        indices.sort_by(|&a, &b| {
-            let ea = &self.entries[a];
-            let eb = &self.entries[b];
+        self.entries.sort_unstable_by(|ea, eb| {
             if ea.is_dir != eb.is_dir {
                 return eb.is_dir.cmp(&ea.is_dir);
             }
             let cmp = match self.sort_mode {
                 SortMode::Name => ea.name.cmp(&eb.name),
-                SortMode::Size => {
-                    let sa = parse_size_for_sort(&ea.size_str);
-                    let sb = parse_size_for_sort(&eb.size_str);
-                    sa.cmp(&sb)
-                }
+                SortMode::Size => ea.size.cmp(&eb.size),
                 SortMode::Date => ea.name.cmp(&eb.name),
             };
             if ascending { cmp } else { cmp.reverse() }
         });
-        let sorted_entries: Vec<FileEntryDisplay> =
-            indices.iter().map(|&i| self.entries[i].clone()).collect();
-        let sorted_names: Vec<String> =
-            indices.iter().map(|&i| self.raw_names[i].clone()).collect();
-        let sorted_is_dir: Vec<bool> = indices.iter().map(|&i| self.raw_is_dir[i]).collect();
-        self.entries = sorted_entries;
-        self.raw_names = sorted_names;
-        self.raw_is_dir = sorted_is_dir;
     }
 
     pub fn go_back(&mut self) {
@@ -495,8 +483,9 @@ impl ExplorerContext {
 
     /// Queue a directory navigation or return a file path for launching.
     pub fn activate_entry(&mut self, idx: usize) -> Option<String> {
-        let path = join_path(&self.current_dir, self.raw_names.get(idx)?);
-        if *self.raw_is_dir.get(idx)? {
+        let entry = self.entries.get(idx)?;
+        let path = join_path(&self.current_dir, &entry.name);
+        if entry.is_dir {
             self.navigate_to(&path);
             None
         } else {
@@ -505,9 +494,9 @@ impl ExplorerContext {
     }
 
     fn selected_entry(&self) -> Option<(String, String, bool)> {
-        let index = self.selected_index?;
-        let name = self.raw_names.get(index)?.clone();
-        Some((join_path(&self.current_dir, &name), name, *self.raw_is_dir.get(index)?))
+        let entry = self.entries.get(self.selected_index?)?;
+        let name = entry.name.clone();
+        Some((join_path(&self.current_dir, &name), name, entry.is_dir))
     }
 
     /// Execute an Explorer context-menu command. A returned path is a file
@@ -761,25 +750,6 @@ fn format_size(size: u64) -> String {
         format!("{}.{} KB", size / 1024, (size % 1024) * 10 / 1024)
     } else {
         format!("{} B", size)
-    }
-}
-
-fn parse_size_for_sort(s: &str) -> u64 {
-    if s == "<DIR>" {
-        return 0;
-    }
-    let mut num = 0u64;
-    for c in s.bytes() {
-        if c >= b'0' && c <= b'9' {
-            num = num * 10 + (c - b'0') as u64;
-        }
-    }
-    if s.ends_with("KB") {
-        num * 1024
-    } else if s.ends_with("MB") {
-        num * 1048576
-    } else {
-        num
     }
 }
 
@@ -1221,8 +1191,21 @@ mod tests {
     fn activating_entries_uses_one_path_for_keyboard_and_mouse() {
         let mut explorer = ExplorerContext::new();
         explorer.current_dir = String::from("/mnt");
-        explorer.raw_names = alloc::vec![String::from("sdcard"), String::from("Bootlog.txt")];
-        explorer.raw_is_dir = alloc::vec![true, false];
+        explorer.finish_navigation(
+            String::from("/mnt"),
+            Ok(alloc::vec![
+                VfsEntry {
+                    name: String::from("sdcard"),
+                    size: 0,
+                    is_dir: true,
+                },
+                VfsEntry {
+                    name: String::from("Bootlog.txt"),
+                    size: 512,
+                    is_dir: false,
+                },
+            ]),
+        );
 
         assert_eq!(explorer.activate_entry(0), None);
         assert_eq!(

--- a/solvent/src/explorer.rs
+++ b/solvent/src/explorer.rs
@@ -453,7 +453,10 @@ impl ExplorerContext {
             }
             let cmp = match self.sort_mode {
                 SortMode::Name => ea.name.cmp(&eb.name),
-                SortMode::Size => ea.size.cmp(&eb.size),
+                SortMode::Size => ea
+                    .size
+                    .cmp(&eb.size)
+                    .then_with(|| ea.name.cmp(&eb.name)),
                 SortMode::Date => ea.name.cmp(&eb.name),
             };
             if ascending { cmp } else { cmp.reverse() }
@@ -1156,7 +1159,7 @@ fn draw_glyph(surface: &mut Surface, ch: u8, x: u32, y: u32, fg: u32, bg: u32) {
 
 #[cfg(test)]
 mod tests {
-    use super::{ExplorerContext, NavigationStep};
+    use super::{ExplorerContext, NavigationStep, SortMode};
     use crate::VfsEntry;
     use alloc::string::String;
 
@@ -1220,5 +1223,28 @@ mod tests {
             explorer.activate_entry(1).as_deref(),
             Some("/mnt/Bootlog.txt")
         );
+    }
+
+    #[test]
+    fn size_sort_uses_names_as_a_deterministic_tiebreaker() {
+        let mut explorer = ExplorerContext::new();
+        explorer.sort_mode = SortMode::Size;
+        explorer.finish_navigation(
+            String::from("/mnt/sdcard"),
+            Ok(alloc::vec![
+                VfsEntry {
+                    name: String::from("b.txt"),
+                    size: 512,
+                    is_dir: false,
+                },
+                VfsEntry {
+                    name: String::from("a.txt"),
+                    size: 512,
+                    is_dir: false,
+                },
+            ]),
+        );
+        assert_eq!(explorer.entries[0].name, "a.txt");
+        assert_eq!(explorer.entries[1].name, "b.txt");
     }
 }

--- a/solvent/src/lib.rs
+++ b/solvent/src/lib.rs
@@ -581,16 +581,21 @@ fn service_explorer_navigation() {
         .and_then(|read| read(&path));
     let outcome = result.as_ref().map(Vec::len).map_err(|error| *error);
 
-    if let Some(runtime) = RUNTIME.lock().as_mut()
+    let applied = if let Some(runtime) = RUNTIME.lock().as_mut()
         && let Some(explorer) = runtime.explorer.as_mut()
     {
         explorer.finish_navigation(path, result);
         runtime.explorer_dirty = true;
         runtime.frame_due = true;
-    }
-    match outcome {
-        Ok(entries) => nitrogen::debug_status!("Explorer", "applied: {} entries", entries),
-        Err(error) => nitrogen::debug_status!("Explorer", "readdir failed: {}", error),
+        true
+    } else {
+        false
+    };
+    if applied {
+        match outcome {
+            Ok(entries) => nitrogen::debug_status!("Explorer", "applied: {} entries", entries),
+            Err(error) => nitrogen::debug_status!("Explorer", "readdir failed: {}", error),
+        }
     }
 }
 

--- a/solvent/src/lib.rs
+++ b/solvent/src/lib.rs
@@ -579,10 +579,7 @@ fn service_explorer_navigation() {
     let result = callback
         .ok_or("filesystem unavailable")
         .and_then(|read| read(&path));
-    match &result {
-        Ok(entries) => nitrogen::debug_status!("Explorer", "ready: {} entries", entries.len()),
-        Err(error) => nitrogen::debug_status!("Explorer", "readdir failed: {}", error),
-    }
+    let outcome = result.as_ref().map(Vec::len).map_err(|error| *error);
 
     if let Some(runtime) = RUNTIME.lock().as_mut()
         && let Some(explorer) = runtime.explorer.as_mut()
@@ -590,6 +587,10 @@ fn service_explorer_navigation() {
         explorer.finish_navigation(path, result);
         runtime.explorer_dirty = true;
         runtime.frame_due = true;
+    }
+    match outcome {
+        Ok(entries) => nitrogen::debug_status!("Explorer", "applied: {} entries", entries),
+        Err(error) => nitrogen::debug_status!("Explorer", "readdir failed: {}", error),
     }
 }
 
@@ -860,6 +861,9 @@ pub(crate) fn render_explorer(rt: &mut RuntimeState) {
         }
     };
     explorer::render_explorer(explorer, &mut window.surface);
+    if let Some(entries) = explorer.take_rendered_navigation() {
+        nitrogen::debug_status!("Explorer", "displayed: {} entries", entries);
+    }
     rt.desktop.invalidate_window(explorer_id);
     rt.explorer_dirty = false;
 }


### PR DESCRIPTION
## Summary
- stop treating GOP direct scanout like a command-based GPU present path, avoiding a blocking PCI completion fence after large Explorer updates
- collapse Explorer's parallel entry/name/type vectors into one owned entry list and sort it in place
- report `applied` and `displayed` navigation checkpoints so the taskbar reflects model and surface completion separately
- derive window dirty rectangles from the compositor's actual decoration dimensions instead of stale duplicated constants
- retain the exFAT boot sector in the metadata cache, addressing the remaining PR #263 review finding

## Root cause
`Explorer ready: 1 entries` was emitted before the returned VFS entries were applied. Because that message was visible on the taskbar, the readdir, model update, surface render, and framebuffer blit had in fact progressed far enough to display a new frame. The remaining physical-GOP path then executed `SFENCE` as if GOP required an explicit present completion. Fullerene's GOP is direct scanout; waiting for posted PCI writes there can stall indefinitely after the large dirty region produced by directory navigation.

The update also removes avoidable allocation pressure after readdir: names and directory flags were stored in two parallel vectors, then cloned again through an index vector during sorting. Entries now have one source of truth and are sorted in place.

## Verification
- `cargo test -p solvent -p lattice -p fullerene-kernel`
- `cargo test --workspace`
- `cargo build -Z build-std=core,alloc -p fullerene-kernel --target x86_64-unknown-uefi`
- `git diff --check`

## Hardware retest
1. Reboot with this branch's image.
2. `mount /dev/sd0 /mnt/sdcard`
3. Select `sdcard` in Explorer and press Enter.
4. Confirm the directory contents appear and the taskbar reaches `Explorer displayed: 1 entries` without freezing.