### PR TITLE
feat: unify native and Linux user-memory copy helpers

### DIFF
--- a/docs/fullerene_todo.md
+++ b/docs/fullerene_todo.md
@@ -29,7 +29,7 @@ You may close them using the "Development" section of the PR, or create new issu
 - [x] `validate_user_range` — walks current page table (CR3) page-by-page checking PRESENT / USER_ACCESSIBLE / writable flags
 - [x] Updated `copy_user_string` to use `UserSlice`
 - [x] Updated Linux compat copy functions to use `UserSlice`
-- [ ] Unify native and Linux ABI copy under one implementation (low priority, both already use `UserSlice`)
+- [x] Unify native and Linux ABI copy under one implementation (low priority, both already use `UserSlice`)
 
 ### P0-3. `&'static mut` and mutable global ownership
 - [x] `with_frame_allocator` guard API (replaces raw `get_frame_allocator_mut`)

--- a/fullerene-kernel/src/linux/runtime.rs
+++ b/fullerene-kernel/src/linux/runtime.rs
@@ -11,7 +11,9 @@ use super::types::*;
 use alloc::boxed::Box;
 use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
-use petroleum::common::memory::UserSlice;
+use petroleum::common::logging::SystemError;
+
+use crate::user_memory::{self, UserCopyError};
 
 /// Dispatch mode for the process: which runtime handles its syscalls.
 pub enum DispatchMode {
@@ -307,60 +309,101 @@ pub fn fs_errno_result(err: &genome::fs::FsError) -> u64 {
 }
 
 /// Convert string from raw user pointer.
+///
+/// # Safety
+///
+/// The current process address space must remain stable while the string is
+/// validated and copied.
 pub unsafe fn copy_user_string(ptr: u64, max_len: usize) -> Result<alloc::string::String, i32> {
-    if ptr == 0 || max_len == 0 {
-        return Err(EFAULT);
-    }
-    let ptr = ptr as *mut u8;
-    let mut buf = alloc::vec::Vec::with_capacity(max_len.min(256));
-    let mut offset = 0;
-    while offset < max_len {
-        let current = unsafe { ptr.add(offset) };
-        if offset == 0 || ((current as usize) & 0xFFF) == 0 {
-            let bytes_left_in_page = 4096 - ((current as usize) & 0xFFF);
-            let remaining = (max_len - offset).min(bytes_left_in_page);
-            let _ = UserSlice::new(current, remaining, false).map_err(|_| EFAULT)?;
-        }
-        let byte = unsafe { core::ptr::read_volatile(current) };
-        if byte == 0 {
-            break;
-        }
-        buf.push(byte);
-        offset += 1;
-    }
-    alloc::string::String::from_utf8(buf).map_err(|_| EINVAL)
+    unsafe { user_memory::copy_c_string(ptr as *const u8, max_len) }.map_err(linux_user_copy_error)
 }
 
-/// Copy data from user space to kernel (capped to prevent memory-exhaustion DoS).
-const MAX_USER_COPY: usize = 65536;
+fn linux_user_copy_error(error: UserCopyError) -> i32 {
+    match error {
+        UserCopyError::System(SystemError::MemOutOfMemory | SystemError::SyscallOutOfMemory) => {
+            ENOMEM
+        }
+        UserCopyError::InvalidUtf8 | UserCopyError::MissingNul => EINVAL,
+        UserCopyError::System(_) => EFAULT,
+    }
+}
+
+/// Copy data from user space to kernel with a hard memory-exhaustion limit.
+const MAX_USER_COPY: usize = 64 * 1024;
+
+fn checked_user_copy_len(count: usize) -> Result<usize, i32> {
+    if count > MAX_USER_COPY {
+        Err(E2BIG)
+    } else {
+        Ok(count)
+    }
+}
+
+/// Copy bytes from a user pointer into kernel-owned memory.
+///
+/// Returns `E2BIG` rather than truncating when `count` exceeds
+/// [`MAX_USER_COPY`].
+///
+/// # Safety
+///
+/// The current process address space must remain stable while the buffer is
+/// validated and copied.
 pub unsafe fn copy_from_user(buf: u64, count: usize) -> Result<alloc::vec::Vec<u8>, i32> {
-    let limit = count.min(MAX_USER_COPY);
     if buf == 0 {
         return Err(EFAULT);
     }
-    let slice = UserSlice::new(buf as *mut u8, limit, false).map_err(|_| EFAULT)?;
-    let mut data = alloc::vec![0; limit];
-    unsafe { slice.copy_from_user(&mut data) }.map_err(|_| EFAULT)?;
-    Ok(data)
+    let len = checked_user_copy_len(count)?;
+    unsafe { user_memory::copy_bytes_from_user(buf as *const u8, len) }
+        .map_err(linux_user_copy_error)
 }
 
 /// Copy data to user space.
+///
+/// # Safety
+///
+/// The current process address space must remain stable while the destination
+/// is validated and written.
 pub unsafe fn copy_to_user(buf: u64, data: &[u8]) -> Result<(), i32> {
     if buf == 0 {
         return Err(EFAULT);
     }
-    let slice = UserSlice::new(buf as *mut u8, data.len(), true).map_err(|_| EFAULT)?;
-    unsafe { slice.copy_to_user(data) }.map_err(|_| EFAULT)
+    unsafe { user_memory::copy_bytes_to_user(buf as *mut u8, data) }.map_err(linux_user_copy_error)
 }
 
 /// Copy an arbitrary sized value to user space.
+///
+/// # Safety
+///
+/// The current process address space must remain stable while the destination
+/// is validated and written.
 pub unsafe fn copy_val_to_user<T: Copy>(buf: u64, val: &T) -> Result<(), i32> {
     if buf == 0 {
         return Err(EFAULT);
     }
-    let size = core::mem::size_of::<T>();
-    let slice = UserSlice::new(buf as *mut u8, size, true).map_err(|_| EFAULT)?;
-    let src = val as *const T as *const u8;
-    let tmp = unsafe { core::slice::from_raw_parts(src, size) };
-    unsafe { slice.copy_to_user(tmp) }.map_err(|_| EFAULT)
+    unsafe { user_memory::copy_value_to_user(buf as *mut T, val) }.map_err(linux_user_copy_error)
+}
+
+#[cfg(test)]
+mod user_copy_tests {
+    use super::*;
+
+    #[test]
+    fn linux_copy_limit_rejects_instead_of_truncating() {
+        assert_eq!(checked_user_copy_len(MAX_USER_COPY), Ok(MAX_USER_COPY));
+        assert_eq!(checked_user_copy_len(MAX_USER_COPY + 1), Err(E2BIG));
+    }
+
+    #[test]
+    fn linux_user_copy_errors_keep_errno_meaning() {
+        assert_eq!(linux_user_copy_error(UserCopyError::InvalidUtf8), EINVAL);
+        assert_eq!(linux_user_copy_error(UserCopyError::MissingNul), EINVAL);
+        assert_eq!(
+            linux_user_copy_error(UserCopyError::System(SystemError::MemOutOfMemory)),
+            ENOMEM
+        );
+        assert_eq!(
+            linux_user_copy_error(UserCopyError::System(SystemError::PermissionDenied)),
+            EFAULT
+        );
+    }
 }

--- a/fullerene-kernel/src/main.rs
+++ b/fullerene-kernel/src/main.rs
@@ -189,6 +189,7 @@ pub mod slab;
 pub mod syscall;
 pub mod task;
 pub mod linux;
+mod user_memory;
 pub mod vdso;
 
 // ── Host-target main (enables `cargo check` on Linux) ──

--- a/fullerene-kernel/src/syscall/interface.rs
+++ b/fullerene-kernel/src/syscall/interface.rs
@@ -1,5 +1,7 @@
 use alloc::string::String;
-use petroleum::common::memory::UserSlice;
+use petroleum::common::logging::SystemError;
+
+use crate::user_memory::{self, UserCopyError};
 
 #[cfg(test)]
 use fullerene_abi::syscall_errors;
@@ -80,8 +82,8 @@ impl From<petroleum::common::logging::SystemError> for SyscallError {
 
 /// Helper function to safely copy a null-terminated string from user space.
 ///
-/// Uses `UserSlice` for validated access.  The entire max_len range is
-/// validated first, then bytes are scanned for a NUL terminator.
+/// Uses the shared user-memory implementation for page-wise validation and
+/// copies into a kernel-owned buffer before decoding UTF-8.
 ///
 /// Returns the string if successful, or an error if validation fails.
 ///
@@ -90,34 +92,14 @@ impl From<petroleum::common::logging::SystemError> for SyscallError {
 /// The caller must ensure the user pages are mapped.  Page faults during
 /// copy are caught by the kernel's page fault handler.
 pub unsafe fn copy_user_string(ptr: *const u8, max_len: usize) -> Result<String, SyscallError> {
-    if ptr.is_null() || max_len == 0 {
-        return Err(SyscallError::InvalidArgument);
-    }
-
-    let mut buf = alloc::vec::Vec::with_capacity(max_len.min(256));
-    let mut offset = 0;
-
-    while offset < max_len {
-        let current = ptr.wrapping_add(offset);
-
-        // Validate page on first access or when crossing a page boundary,
-        // so a valid NUL-terminated string near an unmapped page works.
-        if offset == 0 || ((current as usize) & 0xFFF) == 0 {
-            let bytes_left_in_page = 4096 - ((current as usize) & 0xFFF);
-            let remaining = (max_len - offset).min(bytes_left_in_page);
-            let _ = UserSlice::new(current as *mut u8, remaining, false)
-                .map_err(|_| SyscallError::InvalidArgument)?;
+    unsafe { user_memory::copy_c_string(ptr, max_len) }.map_err(|error| match error {
+        UserCopyError::System(SystemError::MemOutOfMemory | SystemError::SyscallOutOfMemory) => {
+            SyscallError::OutOfMemory
         }
-
-        let byte = unsafe { core::ptr::read_volatile(current) };
-        if byte == 0 {
-            break;
+        UserCopyError::System(_) | UserCopyError::InvalidUtf8 | UserCopyError::MissingNul => {
+            SyscallError::InvalidArgument
         }
-        buf.push(byte);
-        offset += 1;
-    }
-
-    String::from_utf8(buf).map_err(|_| SyscallError::InvalidArgument)
+    })
 }
 
 #[cfg(test)]

--- a/fullerene-kernel/src/user_memory.rs
+++ b/fullerene-kernel/src/user_memory.rs
@@ -1,0 +1,165 @@
+//! Shared user-memory copy primitives for all syscall ABIs.
+//!
+//! ABI modules are responsible for translating [`UserCopyError`] into their
+//! public error representation.  This module owns validation and copying so
+//! native and compatibility ABIs cannot drift into different safety models.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+use petroleum::common::logging::SystemError;
+use petroleum::common::memory::{UserPtr, UserSlice};
+
+const PAGE_SIZE: usize = 4096;
+
+/// Failure produced while copying data across the user/kernel boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum UserCopyError {
+    /// Address validation, permission checking, or allocation failed.
+    System(SystemError),
+    /// A user-provided C string was not valid UTF-8.
+    InvalidUtf8,
+    /// No NUL terminator was found within the caller-provided limit.
+    MissingNul,
+}
+
+impl From<SystemError> for UserCopyError {
+    fn from(error: SystemError) -> Self {
+        Self::System(error)
+    }
+}
+
+fn bytes_until_page_end(address: usize) -> usize {
+    PAGE_SIZE - (address & (PAGE_SIZE - 1))
+}
+
+fn decode_c_string(mut bytes: Vec<u8>) -> Result<String, UserCopyError> {
+    let nul = bytes
+        .iter()
+        .position(|byte| *byte == 0)
+        .ok_or(UserCopyError::MissingNul)?;
+    bytes.truncate(nul);
+    String::from_utf8(bytes).map_err(|_| UserCopyError::InvalidUtf8)
+}
+
+/// Copy a bounded NUL-terminated UTF-8 string from user memory.
+///
+/// Validation is performed one page at a time.  Consequently, a string whose
+/// terminator is the final byte of a mapped page does not require the next page
+/// to be mapped merely because `max_len` extends into it.
+///
+/// # Safety
+///
+/// The caller must keep the current process address space stable for the
+/// duration of the copy.  In particular, the referenced pages must not be
+/// concurrently unmapped after validation.
+pub(crate) unsafe fn copy_c_string(
+    ptr: *const u8,
+    max_len: usize,
+) -> Result<String, UserCopyError> {
+    if ptr.is_null() || max_len == 0 {
+        return Err(UserCopyError::System(SystemError::InvalidArgument));
+    }
+
+    let mut bytes = Vec::new();
+    let mut offset = 0;
+    while offset < max_len {
+        let current = ptr.wrapping_add(offset);
+        let chunk_len = (max_len - offset).min(bytes_until_page_end(current as usize));
+        bytes
+            .try_reserve_exact(chunk_len)
+            .map_err(|_| UserCopyError::System(SystemError::MemOutOfMemory))?;
+
+        let chunk_start = bytes.len();
+        bytes.resize(chunk_start + chunk_len, 0);
+        let user = UserSlice::new(current as *mut u8, chunk_len, false)?;
+        unsafe { user.copy_from_user(&mut bytes[chunk_start..])? };
+
+        if bytes[chunk_start..].contains(&0) {
+            return decode_c_string(bytes);
+        }
+        offset += chunk_len;
+    }
+
+    Err(UserCopyError::MissingNul)
+}
+
+/// Copy `len` bytes from user memory into a kernel-owned buffer.
+///
+/// # Safety
+///
+/// The caller must keep the current process address space stable for the
+/// duration of the copy.
+pub(crate) unsafe fn copy_bytes_from_user(
+    ptr: *const u8,
+    len: usize,
+) -> Result<Vec<u8>, UserCopyError> {
+    let mut bytes = Vec::new();
+    bytes
+        .try_reserve_exact(len)
+        .map_err(|_| UserCopyError::System(SystemError::MemOutOfMemory))?;
+    bytes.resize(len, 0);
+
+    let user = UserSlice::new(ptr as *mut u8, len, false)?;
+    unsafe { user.copy_from_user(&mut bytes)? };
+    Ok(bytes)
+}
+
+/// Copy kernel-owned bytes into user memory.
+///
+/// # Safety
+///
+/// The caller must keep the current process address space stable for the
+/// duration of the copy.
+pub(crate) unsafe fn copy_bytes_to_user(ptr: *mut u8, bytes: &[u8]) -> Result<(), UserCopyError> {
+    let user = UserSlice::new(ptr, bytes.len(), true)?;
+    unsafe { user.copy_to_user(bytes)? };
+    Ok(())
+}
+
+/// Copy one `Copy` value into user memory with alignment-independent access.
+///
+/// # Safety
+///
+/// The caller must keep the current process address space stable for the
+/// duration of the copy.
+pub(crate) unsafe fn copy_value_to_user<T: Copy>(
+    ptr: *mut T,
+    value: &T,
+) -> Result<(), UserCopyError> {
+    let user = UserPtr::new_mut(ptr)?;
+    unsafe { user.copy_to_user(*value)? };
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    #[test]
+    fn page_chunk_stops_at_the_current_page_boundary() {
+        assert_eq!(bytes_until_page_end(0x1000), PAGE_SIZE);
+        assert_eq!(bytes_until_page_end(0x1fff), 1);
+        assert_eq!(bytes_until_page_end(0x2123), PAGE_SIZE - 0x123);
+    }
+
+    #[test]
+    fn c_string_decoder_stops_at_nul() {
+        assert_eq!(
+            decode_c_string(b"fullerene\0ignored".to_vec()),
+            Ok(String::from("fullerene"))
+        );
+    }
+
+    #[test]
+    fn c_string_decoder_rejects_invalid_utf8_and_missing_nul() {
+        assert_eq!(
+            decode_c_string(vec![0xff, 0]),
+            Err(UserCopyError::InvalidUtf8)
+        );
+        assert_eq!(
+            decode_c_string(b"unterminated".to_vec()),
+            Err(UserCopyError::MissingNul)
+        );
+    }
+}

--- a/fullerene-kernel/src/user_memory.rs
+++ b/fullerene-kernel/src/user_memory.rs
@@ -74,8 +74,9 @@ pub(crate) unsafe fn copy_c_string(
         let user = UserSlice::new(current as *mut u8, chunk_len, false)?;
         unsafe { user.copy_from_user(&mut bytes[chunk_start..])? };
 
-        if bytes[chunk_start..].contains(&0) {
-            return decode_c_string(bytes);
+        if let Some(nul_idx) = bytes[chunk_start..].iter().position(|&b| b == 0) {
+            bytes.truncate(chunk_start + nul_idx);
+            return String::from_utf8(bytes).map_err(|_| UserCopyError::InvalidUtf8);
         }
         offset += chunk_len;
     }


### PR DESCRIPTION
# Pull Request

## Overview

- Add one kernel-internal `user_memory` implementation for native and Linux ABI copy operations.
- Validate C strings page-by-page, copy into kernel-owned memory, and reject invalid UTF-8 or missing NUL terminators.
- Route Linux byte and typed-value copy helpers through the shared implementation with ABI-specific errno mapping.
- Reject Linux copy-in requests above 64 KiB with `E2BIG` instead of silently truncating them.
- Mark the P0-2 TODO complete.

- **Related Issue(s):** #265
- **Related PR(s):** None

Closes #265

## Type of Changes

- [ ] **New feature** (adds functionality)
- [x] **Refactoring** (code changes that neither fix a bug nor add a feature)
- [x] **Bug fix** (resolves an issue)
- [ ] **CI/Build settings** (changes related to CI, build process, dependencies)
- [x] **Documentation** (updates to documentation)
- [ ] **Code style** (formatting, linting, etc.)
- [x] **Tests** (adding or modifying tests)

## Testing Instructions

### Build verification

```sh
cargo check -p fullerene-kernel --locked
cargo test -p fullerene-kernel --locked
cargo build -Z build-std=core,alloc --package fullerene-kernel --target x86_64-unknown-uefi --locked
```

Verified results:

- Host kernel check: passed.
- Kernel tests: 26 passed, 0 failed.
- UEFI kernel build: passed.
- `git diff --check`: passed.
- Full Clippy with `-D warnings` remains blocked by pre-existing workspace warnings outside this change.
- UEFI `--tests` check remains blocked by pre-existing missing `alloc::vec` imports in `contexts/vfs.rs` tests; host tests cover the new cases.

### Manual Testing

No UI or hardware behavior changed.

## Checklist

- [x] **Code Quality**: Code follows project style guidelines and best practices
- [x] **Tests**: All existing host kernel tests pass; focused tests added
- [x] **Documentation**: Safety contracts and TODO state updated
- [x] **Breaking Changes**: Behavior change is documented below
- [x] **Dependencies**: No dependencies added
- [x] **Security**: User pointers remain validated through `UserSlice` / `UserPtr`
- [x] **Performance**: Copies remain bounded; C strings stop at the terminating page

## Additional Notes

Linux copy-in requests larger than 64 KiB now return `E2BIG` rather than returning a truncated buffer. Bounded C-string copies now require a NUL terminator within `max_len`.

### Breaking Changes

- [ ] No
- [x] Yes — oversized Linux copy-in and unterminated C-string inputs now fail explicitly.
