### PR TITLE
feat: scope framebuffer access with a guard

### DIFF
--- a/docs/fullerene_todo.md
+++ b/docs/fullerene_todo.md
@@ -36,7 +36,7 @@ You may close them using the "Development" section of the PR, or create new issu
 - [x] Frame allocator access made `unsafe` with doc comment
 - [x] **SchedulerContext**: moved all scheduling state (process list, schedule index, tick counter, NMI recovery RSP/RIP) into a single `pub static SCHEDULER` with explicit lock hierarchy. Replaced old `ProcessManager` global and scattered `AtomicU64` statics in `scheduler.rs`.
 - [x] **VDSO read-only**: removed async ring-buffer (slot state machine, `VdsoFuture`, `poll_all_vdso_rings`). VDSO page now only contains read-only metadata (`time_us`, `uptime_us`, `pid`), mapped without `WRITABLE` in user page tables.
-- [ ] `FramebufferGuard` / `with_framebuffer` closure API
+- [x] `FramebufferGuard` / `with_framebuffer` closure API ([#267](https://github.com/p14c31355/fullerene/issues/267))
 - [ ] Solvent cursor fast path: use `FramebufferGuard` instead of raw address
 - [ ] Trace buffer: fix for multi-CPU safety or document single-core assumption
 - [ ] Boot-only globals: convert to `Once` or immutable after init

--- a/fullerene-kernel/src/contexts/framebuffer.rs
+++ b/fullerene-kernel/src/contexts/framebuffer.rs
@@ -207,6 +207,7 @@ impl FramebufferContext {
         }
         let info = self.info()?;
         if info.address == 0
+            || info.address % 4 != 0
             || info.width == 0
             || info.height == 0
             || info.bytes_per_pixel() != 4

--- a/fullerene-kernel/src/contexts/framebuffer.rs
+++ b/fullerene-kernel/src/contexts/framebuffer.rs
@@ -3,6 +3,7 @@ use alloc::boxed::Box;
 use core::fmt::Write;
 use nitrogen::virtio::gpu::VirtioGpu;
 use petroleum::common::EfiGraphicsPixelFormat;
+use petroleum::graphics::FramebufferGuard;
 use petroleum::graphics::color::FramebufferInfo;
 use petroleum::graphics::framebuffer::UefiFramebufferWriter;
 use petroleum::graphics::framebuffer_mapper::{CacheMode, FramebufferMapper};
@@ -200,22 +201,32 @@ impl FramebufferContext {
     pub fn stride(&self) -> u32 {
         self.info().map(|i| i.stride).unwrap_or(0)
     }
-    pub fn base_ptr(&self) -> *mut u32 {
-        self.info()
-            .map(|i| i.address as *mut u32)
-            .unwrap_or(core::ptr::null_mut())
-    }
-    pub fn pixels_mut(&mut self) -> Option<&mut [u32]> {
+    fn guard(&mut self) -> Option<FramebufferGuard<'_>> {
         if self.bpp != 32 {
             return None;
         }
         let info = self.info()?;
-        Some(unsafe {
-            core::slice::from_raw_parts_mut(
-                info.address as *mut u32,
-                (info.stride as usize / 4) * info.height as usize,
-            )
-        })
+        if info.address == 0
+            || info.width == 0
+            || info.height == 0
+            || info.bytes_per_pixel() != 4
+            || info.stride % 4 != 0
+        {
+            return None;
+        }
+        let stride_pixels = info.stride / 4;
+        if stride_pixels < info.width {
+            return None;
+        }
+        let len = usize::try_from(stride_pixels)
+            .ok()?
+            .checked_mul(info.height as usize)?;
+        // SAFETY: renderer construction only succeeds after this virtual
+        // address has been verified as a writable mapping. The layout checks
+        // above prove `len` covers exactly its complete 32-bpp scan lines,
+        // and `&mut self` supplies exclusive access to the renderer state.
+        let pixels = unsafe { core::slice::from_raw_parts_mut(info.address as *mut u32, len) };
+        FramebufferGuard::try_new(pixels, info.width, info.height, stride_pixels)
     }
     pub fn write_str(&mut self, s: &str) {
         if let Some(ref mut r) = self.renderer {
@@ -261,37 +272,43 @@ impl FramebufferContext {
     }
 }
 
-/// Execute a closure with safe, lifetime-limited access to the framebuffer.
+/// Execute a closure with exclusive, lifetime-limited framebuffer access.
 ///
-/// The `FramebufferGuard` prevents the `&'static mut` aliasing bug by
-/// constraining the pixel slice lifetime to the closure scope.  Access
-/// is serialized through the kernel mutex.
+/// The kernel mutex remains locked for the entire closure, so renderer state
+/// and framebuffer pixels have one ownership boundary. The higher-ranked
+/// closure prevents the mutable pixel slice from escaping as a return value.
 ///
-/// This is intentionally named differently from the `define_context!`-generated
-/// `with_framebuffer` (which provides `&FramebufferContext` directly) to avoid
-/// name collisions.
-pub fn with_framebuffer_guard<F, R>(f: F) -> Option<R>
+/// ```compile_fail
+/// let pixels = fullerene_kernel::contexts::framebuffer::with_framebuffer(
+///     |framebuffer| framebuffer.pixels_mut(),
+/// );
+/// ```
+pub fn with_framebuffer<F, R>(f: F) -> Option<R>
 where
-    F: FnOnce(&mut petroleum::graphics::FramebufferGuard) -> R,
+    F: for<'fb> FnOnce(&mut FramebufferGuard<'fb>) -> R,
 {
-    // Use the boot framebuffer's direct-map alias for the pixel slice.
-    // On some real hardware, the renderer's stored virtual address may
-    // point to a dynamic WC mapping that triggers machine checks on bulk
-    // writes.  The boot framebuffer uses the well-known higher-half direct
-    // mapping, which is verified during probe and matches the UEFI GOP
-    // scanout address exactly.
-    let bfb = crate::graphics::discovery::direct_boot_framebuffer()?;
-    let ptr = bfb.address() as *mut u32;
-    let stride_pixels = bfb.stride_pixels();
-    let len = (stride_pixels as usize) * bfb.height() as usize;
-    let pixels = unsafe { core::slice::from_raw_parts_mut(ptr, len) };
-    let mut guard = petroleum::graphics::FramebufferGuard::new(
-        pixels,
-        bfb.width(),
-        bfb.height(),
-        stride_pixels,
-    );
+    let mut kernel = super::kernel::get_kernel().lock();
+    let context = kernel.as_mut()?;
+    let mut guard = if let Some(boot_framebuffer) =
+        crate::graphics::discovery::direct_boot_framebuffer()
+    {
+        let stride = boot_framebuffer.stride_pixels();
+        let len = usize::try_from(stride)
+            .ok()?
+            .checked_mul(boot_framebuffer.height() as usize)?;
+        // SAFETY: `direct_boot_framebuffer` validates the mapping address,
+        // dimensions, 32-bpp format, stride, and total pixel count. The
+        // kernel mutex held above supplies the exclusive access guarantee.
+        let pixels =
+            unsafe { core::slice::from_raw_parts_mut(boot_framebuffer.address() as *mut u32, len) };
+        FramebufferGuard::try_new(
+            pixels,
+            boot_framebuffer.width(),
+            boot_framebuffer.height(),
+            stride,
+        )?
+    } else {
+        context.framebuffer.guard()?
+    };
     Some(f(&mut guard))
 }
-
-crate::define_context!(FramebufferContext, framebuffer, FRAMEBUFFER);

--- a/fullerene-kernel/src/gui.rs
+++ b/fullerene-kernel/src/gui.rs
@@ -173,25 +173,6 @@ pub fn init() {
 /// over the desktop on every frame.
 static BOOT_PROGRESS_DONE: AtomicBool = AtomicBool::new(false);
 
-/// Fallback: render directly to the boot framebuffer when KernelContext renderer is unavailable.
-fn render_fallback(label: &[u8]) {
-    crate::boot_stage::draw_boot_label(label);
-    if let Some(bfb) = crate::graphics::discovery::direct_boot_framebuffer() {
-        if bfb.address() != 0 {
-            let len = (bfb.stride_pixels() as usize)
-                .checked_mul(bfb.height() as usize)
-                .unwrap_or(0);
-            let pixels = unsafe { core::slice::from_raw_parts_mut(bfb.address() as *mut u32, len) };
-            solvent::render(&mut petroleum::graphics::FramebufferGuard::new(
-                pixels,
-                bfb.width(),
-                bfb.height(),
-                bfb.stride_pixels(),
-            ));
-        }
-    }
-}
-
 /// Signal present and flush GPU after rendering.
 fn finish_frame() {
     crate::contexts::kernel::with_kernel_mut(|k| {
@@ -213,8 +194,8 @@ pub fn render() {
         solvent::set_render_progress_fn(|_| {});
     }
 
-    if crate::contexts::framebuffer::with_framebuffer_guard(|fb| solvent::render(fb)).is_none() {
-        render_fallback(b"RENDER: guard failed, fallback");
+    if crate::contexts::framebuffer::with_framebuffer(|fb| solvent::render(fb)).is_none() {
+        crate::boot_stage::draw_boot_label(b"RENDER: framebuffer unavailable");
     }
 
     BOOT_PROGRESS_DONE.store(true, Ordering::Release);
@@ -236,9 +217,8 @@ pub fn render() {
 pub fn runtime_tick(now: u64) {
     solvent::tick_core(now);
     if solvent::consume_frame_due() {
-        if crate::contexts::framebuffer::with_framebuffer_guard(|fb| solvent::render(fb)).is_none()
-        {
-            render_fallback(b"RENDER: guard failed, fallback");
+        if crate::contexts::framebuffer::with_framebuffer(|fb| solvent::render(fb)).is_none() {
+            crate::boot_stage::draw_boot_label(b"RENDER: framebuffer unavailable");
         }
         finish_frame();
     }

--- a/petroleum/src/graphics/mod.rs
+++ b/petroleum/src/graphics/mod.rs
@@ -11,13 +11,23 @@ pub struct FramebufferGuard<'a> {
 }
 
 impl<'a> FramebufferGuard<'a> {
-    pub fn new(pixels: &'a mut [u32], width: u32, height: u32, stride: u32) -> Self {
-        Self {
+    /// Build a guard after validating the framebuffer layout.
+    ///
+    /// `stride` is expressed in pixels and may be larger than `width` when
+    /// scan lines include padding. The backing slice must cover every scan
+    /// line described by `stride` and `height`.
+    pub fn try_new(pixels: &'a mut [u32], width: u32, height: u32, stride: u32) -> Option<Self> {
+        let required_pixels = usize::try_from(stride).ok()?.checked_mul(height as usize)?;
+        if width == 0 || height == 0 || stride < width || pixels.len() < required_pixels {
+            return None;
+        }
+
+        Some(Self {
             pixels,
             width,
             height,
             stride,
-        }
+        })
     }
 
     pub fn pixels(&self) -> &[u32] {
@@ -38,6 +48,32 @@ impl<'a> FramebufferGuard<'a> {
 
     pub fn stride(&self) -> u32 {
         self.stride
+    }
+}
+
+#[cfg(test)]
+mod framebuffer_guard_tests {
+    use super::FramebufferGuard;
+
+    #[test]
+    fn exposes_validated_metadata_and_mutable_pixels() {
+        let mut pixels = [0u32; 12];
+        let mut guard = FramebufferGuard::try_new(&mut pixels, 3, 2, 4).unwrap();
+
+        assert_eq!(guard.width(), 3);
+        assert_eq!(guard.height(), 2);
+        assert_eq!(guard.stride(), 4);
+        guard.pixels_mut()[5] = 0x00ab_cdef;
+        assert_eq!(guard.pixels()[5], 0x00ab_cdef);
+    }
+
+    #[test]
+    fn rejects_invalid_layouts() {
+        let mut pixels = [0u32; 8];
+
+        assert!(FramebufferGuard::try_new(&mut pixels, 0, 2, 4).is_none());
+        assert!(FramebufferGuard::try_new(&mut pixels, 5, 2, 4).is_none());
+        assert!(FramebufferGuard::try_new(&mut pixels, 4, 3, 4).is_none());
     }
 }
 

--- a/petroleum/src/graphics/mod.rs
+++ b/petroleum/src/graphics/mod.rs
@@ -63,6 +63,7 @@ mod framebuffer_guard_tests {
         assert_eq!(guard.width(), 3);
         assert_eq!(guard.height(), 2);
         assert_eq!(guard.stride(), 4);
+        assert_eq!(guard.pixels().len(), 8);
         guard.pixels_mut()[5] = 0x00ab_cdef;
         assert_eq!(guard.pixels()[5], 0x00ab_cdef);
     }


### PR DESCRIPTION
# Pull Request

## Overview

- Replace provisional raw framebuffer access with a kernel-mutex-scoped `with_framebuffer` closure API.
- Validate 32-bpp framebuffer dimensions, stride, and backing length before constructing `FramebufferGuard`.
- Remove public raw pointer/slice accessors and route both normal and boot framebuffer rendering through the guard.
- Add guard mutation and invalid-layout tests.
- Mark the P0-3 framebuffer guard TODO complete.

Closes #267

## Type of Changes

- [x] **New feature** (adds functionality)
- [x] **Refactoring** (code changes that neither fix a bug nor add a feature)
- [x] **Documentation** (updates to documentation)
- [x] **Tests** (adding or modifying tests)

## Testing Instructions

- `cargo test -p fullerene-kernel --locked` — 26 passed
- `cargo test -p petroleum --locked` — 31 passed
- `cargo build -Z build-std=core,alloc --package fullerene-kernel --target x86_64-unknown-uefi --locked` — passed (one pre-existing dead-code warning)

## Checklist

- [x] **Code Quality**: Code follows project style guidelines and best practices
- [x] **Tests**: All existing tests pass; new tests added
- [x] **Documentation**: API docs and TODO updated
- [x] **Breaking Changes**: Removed only unused provisional framebuffer accessors
- [x] **Dependencies**: No dependencies added
- [x] **Security**: Mutable framebuffer aliasing is constrained by the kernel lock and closure lifetime
- [x] **Performance**: No additional pixel copies; one existing kernel mutex spans rendering

### Breaking Changes

- [x] No

---