### PR TITLE
fix: make trace buffer multi-CPU safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,6 +1246,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 name = "resonance"
 version = "0.1.0"
 dependencies = [
+ "spin 0.12.0",
  "x86_64 0.15.4",
 ]
 

--- a/docs/fullerene_todo.md
+++ b/docs/fullerene_todo.md
@@ -38,7 +38,7 @@ You may close them using the "Development" section of the PR, or create new issu
 - [x] **VDSO read-only**: removed async ring-buffer (slot state machine, `VdsoFuture`, `poll_all_vdso_rings`). VDSO page now only contains read-only metadata (`time_us`, `uptime_us`, `pid`), mapped without `WRITABLE` in user page tables.
 - [x] `FramebufferGuard` / `with_framebuffer` closure API ([#267](https://github.com/p14c31355/fullerene/issues/267))
 - [x] Solvent cursor fast path: use `FramebufferGuard` instead of raw address ([#269](https://github.com/p14c31355/fullerene/issues/269))
-- [ ] Trace buffer: fix for multi-CPU safety or document single-core assumption
+- [x] Trace buffer: fix for multi-CPU safety or document single-core assumption ([#271](https://github.com/p14c31355/fullerene/issues/271))
 - [ ] Boot-only globals: convert to `Once` or immutable after init
 
 ### P0-4. Block cache boundary checks & eviction

--- a/resonance/Cargo.toml
+++ b/resonance/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
+spin = { workspace = true, features = ["spin_mutex"] }
 x86_64 = { workspace = true, features = [
   "instructions",
 ] }

--- a/resonance/src/tracing.rs
+++ b/resonance/src/tracing.rs
@@ -3,16 +3,15 @@
 //! Records timestamped events (function entry/exit, IRQ, exception, syscall)
 //! in a fixed-size ring buffer accessible via the `trace` shell command.
 //!
-//! # Safety: single-core assumption
+//! # Concurrency
 //!
-//! The ring buffer uses a single `static mut TRACE_BUFFER` protected only
-//! by an atomic head index.  This is safe ONLY under the current
-//! single‑core / single‑CPU assumption.  On a multi‑CPU system, concurrent
-//! `record()` calls from different cores would race on both the head index
-//! and the buffer slots, causing lost/corrupted events.
+//! All ring state is owned by one spin lock. Kernel builds disable local
+//! interrupts before taking that lock, preventing an IRQ from interrupting a
+//! lock holder and re-entering [`record`] on the same CPU. Writers on other
+//! CPUs serialize through the same lock.
 //!
-//! To add multi‑CPU support, replace `TRACE_BUFFER` with per‑CPU buffers
-//! or a lock‑free MPSC queue and make `TRACE_HEAD` per‑CPU.
+//! Recording from NMI context is unsupported: an NMI can interrupt a CPU that
+//! already owns the lock and cannot safely spin waiting for itself.
 //!
 //! # Usage
 //!
@@ -21,13 +20,13 @@
 //! trace_event!("syscall", "write fd=1 len=12");
 //! ```
 
-use core::sync::atomic::{AtomicUsize, Ordering};
+use spin::Mutex;
 
 /// Maximum number of trace events stored in the ring buffer.
 const TRACE_CAPACITY: usize = 1024;
 
 /// A single trace event.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct TraceEvent {
     /// Monotonically increasing sequence number (for ordering / reorder detection).
     pub seq: u64,
@@ -59,65 +58,158 @@ impl TraceEvent {
     }
 }
 
-// ── Ring buffer ───────────────────────────────────────────────────
-
-/// Pre-allocated trace buffer (BSS, zero initialised).
-static mut TRACE_BUFFER: [TraceEvent; TRACE_CAPACITY] = [TraceEvent {
+const EMPTY_EVENT: TraceEvent = TraceEvent {
     seq: 0,
     tick: 0,
     category: [0u8; 8],
     message: [0u8; 32],
-}; TRACE_CAPACITY];
+};
 
-/// Write index (atomic, monotonically increasing).
-static TRACE_HEAD: AtomicUsize = AtomicUsize::new(0);
+struct TraceBuffer {
+    events: [TraceEvent; TRACE_CAPACITY],
+    next_index: usize,
+    len: usize,
+    next_sequence: u64,
+}
 
-/// Global sequence counter (monotonically increasing, never wraps).
-static TRACE_SEQ: AtomicUsize = AtomicUsize::new(0);
+impl TraceBuffer {
+    const fn new() -> Self {
+        Self {
+            events: [EMPTY_EVENT; TRACE_CAPACITY],
+            next_index: 0,
+            len: 0,
+            next_sequence: 0,
+        }
+    }
 
-// ── Public API ────────────────────────────────────────────────────
+    fn record(&mut self, tick: u64, category: &str, message: &str) {
+        let sequence = self.next_sequence;
+        self.next_sequence = self.next_sequence.wrapping_add(1);
+        self.events[self.next_index] = TraceEvent::new(sequence, tick, category, message);
+        self.next_index = (self.next_index + 1) % TRACE_CAPACITY;
+        self.len = self.len.saturating_add(1).min(TRACE_CAPACITY);
+    }
+
+    fn snapshot(&self) -> alloc::vec::Vec<TraceEvent> {
+        let mut result = alloc::vec::Vec::with_capacity(self.len);
+        if self.len < TRACE_CAPACITY {
+            result.extend_from_slice(&self.events[..self.len]);
+        } else {
+            result.extend_from_slice(&self.events[self.next_index..]);
+            result.extend_from_slice(&self.events[..self.next_index]);
+        }
+        result
+    }
+
+    fn clear(&mut self) {
+        self.next_index = 0;
+        self.len = 0;
+    }
+}
+
+static TRACE_BUFFER: Mutex<TraceBuffer> = Mutex::new(TraceBuffer::new());
+
+fn with_trace_buffer<R>(f: impl FnOnce(&mut TraceBuffer) -> R) -> R {
+    #[cfg(target_os = "uefi")]
+    {
+        x86_64::instructions::interrupts::without_interrupts(|| f(&mut TRACE_BUFFER.lock()))
+    }
+    #[cfg(not(target_os = "uefi"))]
+    {
+        f(&mut TRACE_BUFFER.lock())
+    }
+}
 
 /// Record a trace event.
 ///
-/// This is lock-free and interruption-safe — suitable for use inside
-/// IRQ handlers and exception handlers.  The sequence number helps
-/// detect reorder or loss in a future multi‑CPU implementation.
+/// This is allocation-free and safe for normal IRQ/exception handlers. It
+/// must not be called from NMI context because the interrupted CPU may already
+/// own the trace lock.
 pub fn record(tick: u64, category: &str, message: &str) {
-    let idx = TRACE_HEAD.fetch_add(1, Ordering::Relaxed) % TRACE_CAPACITY;
-    let seq = TRACE_SEQ.fetch_add(1, Ordering::Relaxed) as u64;
-    unsafe {
-        TRACE_BUFFER[idx] = TraceEvent::new(seq, tick, category, message);
-    }
+    with_trace_buffer(|buffer| buffer.record(tick, category, message));
 }
 
 /// Return all trace events in chronological order as an owned vector.
 ///
-/// The returned `Vec` is a snapshot — safe to hold across interrupt
-/// boundaries because it owns its data.
+/// The returned `Vec` is safe to hold across interrupt boundaries because it
+/// owns its data and is copied while the trace lock is held.
 pub fn snapshot() -> alloc::vec::Vec<TraceEvent> {
-    x86_64::instructions::interrupts::without_interrupts(|| unsafe {
-        let head = TRACE_HEAD.load(Ordering::Relaxed);
-        if head == 0 {
-            return alloc::vec::Vec::new();
-        }
-        let mut result = alloc::vec::Vec::new();
-        if head <= TRACE_CAPACITY {
-            result.extend_from_slice(&TRACE_BUFFER[..head]);
-        } else {
-            let start = head % TRACE_CAPACITY;
-            result.extend_from_slice(&TRACE_BUFFER[start..]);
-            result.extend_from_slice(&TRACE_BUFFER[..start]);
-        }
-        result
-    })
+    with_trace_buffer(|buffer| buffer.snapshot())
 }
 
-/// Clear all trace events.
+/// Clear all trace events without reusing sequence numbers.
 pub fn clear() {
-    TRACE_HEAD.store(0, Ordering::Relaxed);
+    with_trace_buffer(TraceBuffer::clear);
 }
 
 /// Return the number of events currently stored.
 pub fn len() -> usize {
-    TRACE_HEAD.load(Ordering::Relaxed).min(TRACE_CAPACITY)
+    with_trace_buffer(|buffer| buffer.len)
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use super::*;
+    use std::thread;
+
+    static TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn snapshot_keeps_chronological_order_after_wrap() {
+        let _test = TEST_LOCK.lock().unwrap();
+        clear();
+        for tick in 0..TRACE_CAPACITY + 5 {
+            record(tick as u64, "test", "wrapped");
+        }
+
+        let events = snapshot();
+        assert_eq!(events.len(), TRACE_CAPACITY);
+        assert_eq!(events.first().unwrap().tick, 5);
+        assert_eq!(events.last().unwrap().tick, (TRACE_CAPACITY + 4) as u64);
+        assert!(events.windows(2).all(|pair| pair[1].seq == pair[0].seq + 1));
+    }
+
+    #[test]
+    fn clear_empties_events_without_reusing_sequence_numbers() {
+        let _test = TEST_LOCK.lock().unwrap();
+        clear();
+        record(1, "test", "before clear");
+        let previous_sequence = snapshot()[0].seq;
+
+        clear();
+        assert_eq!(len(), 0);
+        assert!(snapshot().is_empty());
+        record(2, "test", "after clear");
+        assert!(snapshot()[0].seq > previous_sequence);
+    }
+
+    #[test]
+    fn concurrent_writers_publish_complete_ordered_events() {
+        let _test = TEST_LOCK.lock().unwrap();
+        clear();
+        let writers: alloc::vec::Vec<_> = (0..4)
+            .map(|writer| {
+                thread::spawn(move || {
+                    for event in 0..400 {
+                        record(writer * 400 + event, "worker", "concurrent event");
+                    }
+                })
+            })
+            .collect();
+        for writer in writers {
+            writer.join().unwrap();
+        }
+
+        let events = snapshot();
+        assert_eq!(events.len(), TRACE_CAPACITY);
+        assert!(events.windows(2).all(|pair| pair[1].seq == pair[0].seq + 1));
+        assert!(events.iter().all(|event| &event.category[..6] == b"worker"));
+        assert!(
+            events
+                .iter()
+                .all(|event| &event.message[..16] == b"concurrent event")
+        );
+    }
 }


### PR DESCRIPTION
# Pull Request

## Overview

- Replace the atomic index plus non-atomic `static mut` event array with a lock-owned `TraceBuffer`.
- Disable local interrupts before acquiring the trace lock on UEFI builds, preventing same-CPU IRQ re-entry.
- Serialize writers from different CPUs through the same lock.
- Route `record`, `snapshot`, `clear`, and `len` through one ownership boundary.
- Preserve chronological ring snapshots and sequence monotonicity across wrap and clear.
- Document that NMI-context recording is unsupported.
- Mark the P0-3 trace-buffer TODO complete.

Closes #271

## Type of Changes

- [x] **Refactoring** (code changes that neither fix a bug nor add a feature)
- [x] **Bug fix** (resolves an issue)
- [x] **Documentation** (updates to documentation)
- [x] **Tests** (adding or modifying tests)

## Testing Instructions

- `cargo test -p resonance --locked` — 14 passed
- `cargo test -p fullerene-kernel --locked` — 26 passed
- `cargo clippy -p resonance --locked --no-deps -- -D warnings` — passed
- `cargo build -Z build-std=core,alloc --package fullerene-kernel --target x86_64-unknown-uefi --locked` — passed (one pre-existing dead-code warning)
- `cargo fmt --all -- --check` — passed

## Checklist

- [x] **Code Quality**: All trace state has one explicit owner
- [x] **Tests**: Ring wrap, clear semantics, and four concurrent writers covered
- [x] **Documentation**: IRQ/SMP/NMI behavior documented
- [x] **Breaking Changes**: Existing public trace API preserved
- [x] **Dependencies**: Reuses the workspace `spin` dependency
- [x] **Security**: Removes the mutable-global data race
- [x] **Performance**: Recording remains allocation-free with a short fixed-size critical section

### Breaking Changes

- [x] No

---