### PR TITLE
Remove static string Result errors across the workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1455,6 +1455,7 @@ dependencies = [
  "bonder",
  "carrier",
  "chronoline",
+ "genome",
  "lattice",
  "log",
  "minipng",
@@ -1776,6 +1777,7 @@ name = "wasi_runtime"
 version = "0.1.0"
 dependencies = [
  "carrier",
+ "genome",
  "wasmi",
 ]
 

--- a/bonder/src/dhcp.rs
+++ b/bonder/src/dhcp.rs
@@ -265,23 +265,23 @@ impl DhcpClient {
     }
 
     /// Parse a DHCP response.
-    pub fn parse_response(&mut self, data: &[u8]) -> Result<DhcpMessageType, &'static str> {
+    pub fn parse_response(&mut self, data: &[u8]) -> Result<DhcpMessageType, crate::NetError> {
         if data.len() < DhcpHeader::SIZE + 4 {
-            return Err("Response too short");
+            return Err(crate::NetError::Protocol);
         }
 
         let header = unsafe { core::ptr::read_unaligned(data.as_ptr() as *const DhcpHeader) };
         let magic = header.magic;
         if magic != DHCP_MAGIC_COOKIE {
-            return Err("Invalid magic cookie");
+            return Err(crate::NetError::Protocol);
         }
         let op = header.op;
         if op != 2 {
-            return Err("Not a BOOTREPLY");
+            return Err(crate::NetError::Protocol);
         }
         let xid = header.xid;
         if xid != self.xid.to_be_bytes() {
-            return Err("Transaction ID mismatch");
+            return Err(crate::NetError::Protocol);
         }
 
         let mut offset = DhcpHeader::SIZE;
@@ -342,7 +342,7 @@ impl DhcpClient {
             offset += 2 + opt_len;
         }
 
-        let msg_type = msg_type.ok_or("No DHCP message type option")?;
+        let msg_type = msg_type.ok_or(crate::NetError::Protocol)?;
 
         match msg_type {
             DhcpMessageType::Offer | DhcpMessageType::Ack => {

--- a/bonder/src/lib.rs
+++ b/bonder/src/lib.rs
@@ -66,4 +66,8 @@ pub enum NetError {
     NotInitialized,
     /// Invalid parameter (null MAC, unspecified IP, etc.)
     InvalidParameter,
+    /// A received network-control message was malformed or inconsistent.
+    Protocol,
+    /// Authentication or message-integrity verification failed.
+    AuthenticationFailed,
 }

--- a/bonder/src/wpa.rs
+++ b/bonder/src/wpa.rs
@@ -188,9 +188,9 @@ impl WpaSupplicant {
     }
 
     /// Handle EAPOL-Key Message 1 (from AP).
-    pub fn handle_message_1(&mut self, frame: &[u8]) -> Result<Vec<u8>, &'static str> {
+    pub fn handle_message_1(&mut self, frame: &[u8]) -> Result<Vec<u8>, crate::NetError> {
         if frame.len() < 4 + 97 {
-            return Err("EAPOL-Key frame too short");
+            return Err(crate::NetError::Protocol);
         }
         let body = &frame[4..];
 
@@ -199,7 +199,7 @@ impl WpaSupplicant {
         // Extract ANonce (bytes 13-44 relative to key descriptor)
         let anonce_start = 13;
         if anonce_start + 32 > body.len() {
-            return Err("Frame too short for ANonce");
+            return Err(crate::NetError::Protocol);
         }
         self.anonce
             .copy_from_slice(&body[anonce_start..anonce_start + 32]);
@@ -273,9 +273,9 @@ impl WpaSupplicant {
     }
 
     /// Handle EAPOL-Key Message 3 (from AP, contains GTK).
-    pub fn handle_message_3(&mut self, frame: &[u8]) -> Result<Vec<u8>, &'static str> {
+    pub fn handle_message_3(&mut self, frame: &[u8]) -> Result<Vec<u8>, crate::NetError> {
         if frame.len() < 4 + 97 {
-            return Err("EAPOL-Key Message 3 too short");
+            return Err(crate::NetError::Protocol);
         }
 
         // Verify MIC: zero the MIC field in a copy, compute, compare
@@ -290,7 +290,7 @@ impl WpaSupplicant {
             }
         }
         if !mic_verified {
-            return Err("MIC verification failed");
+            return Err(crate::NetError::AuthenticationFailed);
         }
 
         let body = &frame[4..];
@@ -298,7 +298,7 @@ impl WpaSupplicant {
         let key_data_len = u16::from_be_bytes([body[93], body[94]]);
         let key_data_end = 95 + key_data_len as usize;
         if body.len() < key_data_end {
-            return Err("Frame too short for key data");
+            return Err(crate::NetError::Protocol);
         }
 
         // Parse Key Data Descriptors to extract GTK

--- a/docs/fullerene_todo.md
+++ b/docs/fullerene_todo.md
@@ -56,10 +56,10 @@ You may close them using the "Development" section of the PR, or create new issu
 
 ### P1-1. Typed errors (replace `&'static str`)
 - [x] `BlockError` (done as part of P0-4)
-- [x] `FsError` in `genome` crate (FileNotFound, FileExists, PermissionDenied, InvalidFileDescriptor, InvalidSeek, DiskFull, NotADirectory, DirectoryNotEmpty, IsADirectory, InvalidPath, NotSupported, InvalidInput)
+- [x] `FsError` in `genome` crate (FileNotFound, FileExists, PermissionDenied, InvalidFileDescriptor, InvalidSeek, DiskFull, NotADirectory, DirectoryNotEmpty, IsADirectory, InvalidPath, NotSupported, InvalidInput, Io)
 - [x] `DriverError`, `MemoryError` in respective crates ([#275](https://github.com/p14c31355/fullerene/issues/275))
 - [x] `From` impls to convert to `SyscallError` / Linux errno ([#275](https://github.com/p14c31355/fullerene/issues/275))
-- [ ] Remove `Result<..., &'static str>` usage (~200+ sites across kernel/nitrogen/genome)
+- [x] Remove `Result<..., &'static str>` usage (~200+ sites across kernel/nitrogen/genome) ([#277](https://github.com/p14c31355/fullerene/issues/277))
 
 ### P1-2. Syscall ABI crate (`fullerene-abi`)
 - [ ] Extract syscall numbers, error codes, `#[repr(C)]` DTOs into leaf crate

--- a/fullerene-kernel/src/contexts/memory/mod.rs
+++ b/fullerene-kernel/src/contexts/memory/mod.rs
@@ -48,22 +48,26 @@ impl MemoryContext {
 
     // ── High-level VM operations (preferred) ─────────────────
 
-    pub fn map_framebuffer_vm(&mut self, phys: u64, size: u64) -> Result<u64, &'static str> {
+    pub fn map_framebuffer_vm(
+        &mut self,
+        phys: u64,
+        size: u64,
+    ) -> Result<u64, petroleum::MemoryError> {
         self.vm_mut()?.map_framebuffer(phys, size, None)
     }
 
-    pub fn map_heap_vm(&mut self, phys: u64, size: u64) -> Result<u64, &'static str> {
+    pub fn map_heap_vm(&mut self, phys: u64, size: u64) -> Result<u64, petroleum::MemoryError> {
         self.vm_mut()?.map_heap(phys, size)
     }
 
     pub fn direct_map_physical_vm(
         &mut self,
         map: &[petroleum::page_table::memory_map::MemoryMapDescriptor],
-    ) -> Result<(), &'static str> {
+    ) -> Result<(), petroleum::MemoryError> {
         self.vm_mut()?.direct_map_physical(map)
     }
 
-    pub fn clone_for_process_vm(&mut self) -> Result<VirtualMemoryContext, &'static str> {
+    pub fn clone_for_process_vm(&mut self) -> Result<VirtualMemoryContext, petroleum::MemoryError> {
         self.vm_mut()?.clone_for_process()
     }
 
@@ -79,35 +83,48 @@ impl MemoryContext {
         self.vm.as_ref()
     }
 
-    fn vm_mut(&mut self) -> Result<&mut VirtualMemoryContext, &'static str> {
-        self.vm.as_mut().ok_or("VM not initialised")
+    fn vm_mut(&mut self) -> Result<&mut VirtualMemoryContext, petroleum::MemoryError> {
+        self.vm
+            .as_mut()
+            .ok_or(petroleum::MemoryError::NotInitialized)
     }
 
     // ── Legacy operations (backward-compatible) ──────────────
 
-    pub fn allocate_frame(&mut self) -> Result<usize, &'static str> {
-        self.mgr()?.allocate_frame().map_err(|_| "FrameAllocFailed")
+    pub fn allocate_frame(&mut self) -> Result<usize, petroleum::MemoryError> {
+        self.mgr()?
+            .allocate_frame()
+            .map_err(|_| petroleum::MemoryError::FrameAllocationFailed)
     }
-    pub fn free_frame(&mut self, phys: usize) -> Result<(), &'static str> {
-        self.mgr()?.free_frame(phys).map_err(|_| "FreeFailed")
+    pub fn free_frame(&mut self, phys: usize) -> Result<(), petroleum::MemoryError> {
+        self.mgr()?
+            .free_frame(phys)
+            .map_err(|_| petroleum::MemoryError::UnmappingFailed)
     }
-    pub fn allocate_contiguous(&mut self, n: usize) -> Result<usize, &'static str> {
+    pub fn allocate_contiguous(&mut self, n: usize) -> Result<usize, petroleum::MemoryError> {
         self.mgr()?
             .allocate_contiguous_frames(n)
-            .map_err(|_| "ContiguousAllocFailed")
+            .map_err(|_| petroleum::MemoryError::FrameAllocationFailed)
     }
     pub fn map_page(
         &mut self,
         v: usize,
         p: usize,
         f: x86_64::structures::paging::PageTableFlags,
-    ) -> Result<(), &'static str> {
-        self.mgr()?.safe_map_page(v, p, f).map_err(|_| "MapFailed")
+    ) -> Result<(), petroleum::MemoryError> {
+        self.mgr()?
+            .safe_map_page(v, p, f)
+            .map_err(|_| petroleum::MemoryError::MappingFailed)
     }
-    pub fn map_mmio(&mut self, phys: usize, virt: usize, size: usize) -> Result<(), &'static str> {
+    pub fn map_mmio(
+        &mut self,
+        phys: usize,
+        virt: usize,
+        size: usize,
+    ) -> Result<(), petroleum::MemoryError> {
         self.mgr()?
             .map_mmio_region(phys, virt, size)
-            .map_err(|_| "MMIOMapFailed")
+            .map_err(|_| petroleum::MemoryError::MappingFailed)
     }
     pub unsafe fn extend_heap(&self, additional: usize) -> Result<(), ()> {
         unsafe { crate::heap::extend_kernel_heap(additional) }
@@ -115,8 +132,10 @@ impl MemoryContext {
     pub fn heap_stats(&self) -> petroleum::HeapStats {
         petroleum::heap_stats()
     }
-    fn mgr(&mut self) -> Result<&mut UnifiedMemoryManager, &'static str> {
-        self.manager.as_mut().ok_or("Not init")
+    fn mgr(&mut self) -> Result<&mut UnifiedMemoryManager, petroleum::MemoryError> {
+        self.manager
+            .as_mut()
+            .ok_or(petroleum::MemoryError::NotInitialized)
     }
 }
 

--- a/fullerene-kernel/src/contexts/settings_persist.rs
+++ b/fullerene-kernel/src/contexts/settings_persist.rs
@@ -76,8 +76,8 @@ fn parse_bool(s: &str) -> Option<bool> {
 ///
 /// Returns `(sensitivity, brightness_x100, top_panel_enabled, window_corner_rounded)` so the
 /// caller can sync to solvent.
-pub fn load_settings(
-    read_fn: impl FnOnce(&str) -> Result<Vec<u8>, &'static str>,
+pub fn load_settings<E>(
+    read_fn: impl FnOnce(&str) -> Result<Vec<u8>, E>,
 ) -> (f32, u32, bool, bool) {
     let data = match read_fn("/etc/settings.toml") {
         Ok(data) => data,

--- a/fullerene-kernel/src/drivers/exfat.rs
+++ b/fullerene-kernel/src/drivers/exfat.rs
@@ -38,6 +38,21 @@ impl ExFatDevice {
         IoError::new_static(kind, message)
     }
 
+    fn block_error(error: genome::block::BlockError) -> IoError {
+        match error {
+            genome::block::BlockError::BufferTooSmall { .. }
+            | genome::block::BlockError::LbaOverflow => {
+                Self::error(ErrorKind::InvalidInput, "invalid block I/O request")
+            }
+            genome::block::BlockError::SectorNotFound => {
+                Self::error(ErrorKind::NotFound, "block sector not found")
+            }
+            genome::block::BlockError::Device => {
+                Self::error(ErrorKind::Other, "block device I/O failed")
+            }
+        }
+    }
+
     fn lba(position: u64) -> Result<u32, IoError> {
         u32::try_from(position / SECTOR_SIZE as u64)
             .map_err(|_| Self::error(ErrorKind::InvalidInput, "exFAT LBA overflow"))
@@ -62,7 +77,7 @@ impl ExFatDevice {
         }
         device
             .read_sectors(lba, count, buf)
-            .map_err(|message| Self::error(ErrorKind::Other, message))?;
+            .map_err(Self::block_error)?;
         if count == 1 {
             let mut cache = self.cache.lock();
             if cache.len() < METADATA_CACHE_SECTORS {
@@ -87,7 +102,7 @@ impl ExFatDevice {
             .ok_or_else(|| Self::error(ErrorKind::InvalidInput, "exFAT write buffer too small"))?;
         device
             .write_sectors(lba, count, buf)
-            .map_err(|message| Self::error(ErrorKind::Other, message))?;
+            .map_err(Self::block_error)?;
         let mut cache = self.cache.lock();
         for (index, sector) in buf
             .chunks_exact(SECTOR_SIZE)
@@ -646,10 +661,13 @@ mod tests {
             lba: u32,
             count: u16,
             buf: &mut [u8],
-        ) -> Result<(), &'static str> {
+        ) -> Result<(), genome::block::BlockError> {
             let (start, len) = Self::range(lba, count)?;
             if buf.len() < len {
-                return Err("test read buffer too small");
+                return Err(genome::block::BlockError::BufferTooSmall {
+                    required: len,
+                    provided: buf.len(),
+                });
             }
             self.read_calls.fetch_add(1, Ordering::Relaxed);
             self.reads.fetch_add(count as usize, Ordering::Relaxed);
@@ -657,10 +675,18 @@ mod tests {
             Ok(())
         }
 
-        fn write_sectors(&mut self, lba: u32, count: u16, buf: &[u8]) -> Result<(), &'static str> {
+        fn write_sectors(
+            &mut self,
+            lba: u32,
+            count: u16,
+            buf: &[u8],
+        ) -> Result<(), genome::block::BlockError> {
             let (start, len) = Self::range(lba, count)?;
             if buf.len() < len {
-                return Err("test write buffer too small");
+                return Err(genome::block::BlockError::BufferTooSmall {
+                    required: len,
+                    provided: buf.len(),
+                });
             }
             self.image.lock()[start..start + len].copy_from_slice(&buf[..len]);
             Ok(())
@@ -684,11 +710,11 @@ mod tests {
             }
         }
 
-        fn range(lba: u32, count: u16) -> Result<(usize, usize), &'static str> {
+        fn range(lba: u32, count: u16) -> Result<(usize, usize), genome::block::BlockError> {
             let start = lba as usize * SECTOR_SIZE;
             let len = count as usize * SECTOR_SIZE;
             if start.checked_add(len).is_none_or(|end| end > IMAGE_SIZE) {
-                return Err("test LBA out of range");
+                return Err(genome::block::BlockError::LbaOverflow);
             }
             Ok((start, len))
         }

--- a/fullerene-kernel/src/drivers/fat.rs
+++ b/fullerene-kernel/src/drivers/fat.rs
@@ -212,9 +212,7 @@ impl<D: BlockDevice> BlockCache<D> {
         if let Some(idx) = self.lookup(lba) {
             self.entries[idx].0 = None;
         }
-        self.inner
-            .write_sectors(lba, 1, buf)
-            .map_err(BlockError::Device)
+        self.inner.write_sectors(lba, 1, buf)
     }
 
     pub fn sector_size(&self) -> u32 {
@@ -226,15 +224,18 @@ impl<D: BlockDevice> BlockCache<D> {
 }
 
 impl<D: BlockDevice> BlockDevice for BlockCache<D> {
-    fn read_sectors(&mut self, lba: u32, count: u16, buf: &mut [u8]) -> Result<(), &'static str> {
+    fn read_sectors(&mut self, lba: u32, count: u16, buf: &mut [u8]) -> Result<(), BlockError> {
         let count = count as usize;
-        let needed = count.checked_mul(self.bps).ok_or("count * bps overflow")?;
+        let needed = count.checked_mul(self.bps).ok_or(BlockError::LbaOverflow)?;
         if buf.len() < needed {
-            return Err("buffer too small for multi-sector read");
+            return Err(BlockError::BufferTooSmall {
+                required: needed,
+                provided: buf.len(),
+            });
         }
         let end_lba = (lba as u64) + (count as u64);
         if end_lba > self.inner.total_sectors() || end_lba > u32::MAX as u64 {
-            return Err("LBA range exceeds device capacity or 32-bit limit");
+            return Err(BlockError::LbaOverflow);
         }
         let mut index = 0;
         while index < count {
@@ -268,15 +269,18 @@ impl<D: BlockDevice> BlockDevice for BlockCache<D> {
         }
         Ok(())
     }
-    fn write_sectors(&mut self, lba: u32, count: u16, buf: &[u8]) -> Result<(), &'static str> {
+    fn write_sectors(&mut self, lba: u32, count: u16, buf: &[u8]) -> Result<(), BlockError> {
         let count = count as usize;
-        let needed = count.checked_mul(self.bps).ok_or("count * bps overflow")?;
+        let needed = count.checked_mul(self.bps).ok_or(BlockError::LbaOverflow)?;
         if buf.len() < needed {
-            return Err("buffer too small for multi-sector write");
+            return Err(BlockError::BufferTooSmall {
+                required: needed,
+                provided: buf.len(),
+            });
         }
         let end_lba = (lba as u64) + (count as u64);
         if end_lba > self.inner.total_sectors() || end_lba > u32::MAX as u64 {
-            return Err("LBA range exceeds device capacity or 32-bit limit");
+            return Err(BlockError::LbaOverflow);
         }
         for index in 0..count {
             if let Some(slot) = self.lookup(lba + index as u32) {
@@ -299,11 +303,17 @@ pub struct PartitionBlockDevice {
 }
 
 impl BlockDevice for PartitionBlockDevice {
-    fn read_sectors(&mut self, lba: u32, count: u16, buf: &mut [u8]) -> Result<(), &'static str> {
-        self.inner.read_sectors(lba + self.offset, count, buf)
+    fn read_sectors(&mut self, lba: u32, count: u16, buf: &mut [u8]) -> Result<(), BlockError> {
+        let lba = lba
+            .checked_add(self.offset)
+            .ok_or(BlockError::LbaOverflow)?;
+        self.inner.read_sectors(lba, count, buf)
     }
-    fn write_sectors(&mut self, lba: u32, count: u16, buf: &[u8]) -> Result<(), &'static str> {
-        self.inner.write_sectors(lba + self.offset, count, buf)
+    fn write_sectors(&mut self, lba: u32, count: u16, buf: &[u8]) -> Result<(), BlockError> {
+        let lba = lba
+            .checked_add(self.offset)
+            .ok_or(BlockError::LbaOverflow)?;
+        self.inner.write_sectors(lba, count, buf)
     }
     fn sector_size(&self) -> u32 {
         self.inner.sector_size()
@@ -319,7 +329,7 @@ impl BlockDevice for PartitionBlockDevice {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FatBlockError {
-    Device(&'static str),
+    Device(BlockError),
     UnexpectedEof,
     WriteZero,
 }
@@ -327,7 +337,7 @@ pub enum FatBlockError {
 impl core::fmt::Display for FatBlockError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            FatBlockError::Device(msg) => write!(f, "device error: {}", msg),
+            FatBlockError::Device(error) => write!(f, "device error: {}", error),
             FatBlockError::UnexpectedEof => write!(f, "unexpected eof"),
             FatBlockError::WriteZero => write!(f, "write zero"),
         }
@@ -474,7 +484,7 @@ impl FatFileSystem {
 
     fn map_err<T>(r: Result<T, FatError>) -> Result<T, FsError> {
         r.map_err(|e| match e {
-            fatfs::Error::Io(FatBlockError::Device(_)) => FsError::InvalidInput,
+            fatfs::Error::Io(FatBlockError::Device(error)) => error.into(),
             fatfs::Error::NotFound => FsError::FileNotFound,
             fatfs::Error::AlreadyExists => FsError::FileExists,
             fatfs::Error::NotEnoughSpace => FsError::DiskFull,

--- a/fullerene-kernel/src/drivers/registry.rs
+++ b/fullerene-kernel/src/drivers/registry.rs
@@ -22,7 +22,7 @@ use core::sync::atomic::{AtomicBool, Ordering};
 use spin::Mutex;
 
 #[cfg(any(not(nitrogen_no_usb), not(nitrogen_no_storage)))]
-use genome::block::BlockDevice;
+use genome::block::{BlockDevice, BlockError};
 #[cfg(any(not(nitrogen_no_usb), not(nitrogen_no_storage)))]
 use nitrogen::DriverContext;
 #[cfg(not(nitrogen_no_usb))]
@@ -154,7 +154,7 @@ struct UsbHostCtl;
 
 #[cfg(not(nitrogen_no_usb))]
 impl UsbHostDriver for UsbHostCtl {
-    fn init(&mut self) -> Result<(), &'static str> {
+    fn init(&mut self) -> Result<(), nitrogen::DriverError> {
         nitrogen::debug::set_hint_callback(crate::boot_stage::draw_step_hint);
         init_usb_ctx(nitrogen::usb::context::USBContext::new(
             &crate::driver_context_impl::KernelDriverContext,
@@ -193,7 +193,7 @@ struct SdCardStorageCtl;
 
 #[cfg(not(nitrogen_no_storage))]
 impl StorageDriver for SdCardStorageCtl {
-    fn init(&mut self) -> Result<(), &'static str> {
+    fn init(&mut self) -> Result<(), nitrogen::DriverError> {
         crate::boot_stage::draw_boot_label(b"SD CARD");
         nitrogen::storage::rtsx::init(&crate::driver_context_impl::KernelDriverContext);
         if nitrogen::storage::rtsx::is_present() {
@@ -203,11 +203,21 @@ impl StorageDriver for SdCardStorageCtl {
         }
         Ok(())
     }
-    fn read_blocks(&self, _lba: u64, _count: usize, _buf: &mut [u8]) -> Result<(), &'static str> {
-        Err("not a single block device")
+    fn read_blocks(
+        &self,
+        _lba: u64,
+        _count: usize,
+        _buf: &mut [u8],
+    ) -> Result<(), nitrogen::DriverError> {
+        Err(nitrogen::DriverError::NotSupported)
     }
-    fn write_blocks(&self, _lba: u64, _count: usize, _buf: &[u8]) -> Result<(), &'static str> {
-        Err("not a single block device")
+    fn write_blocks(
+        &self,
+        _lba: u64,
+        _count: usize,
+        _buf: &[u8],
+    ) -> Result<(), nitrogen::DriverError> {
+        Err(nitrogen::DriverError::NotSupported)
     }
     fn block_size(&self) -> u32 {
         0
@@ -261,7 +271,7 @@ unsafe impl Send for UsbBlockDevice {}
 
 #[cfg(not(nitrogen_no_usb))]
 impl BlockDevice for UsbBlockDevice {
-    fn read_sectors(&mut self, lba: u32, count: u16, buf: &mut [u8]) -> Result<(), &'static str> {
+    fn read_sectors(&mut self, lba: u32, count: u16, buf: &mut [u8]) -> Result<(), BlockError> {
         with_ctx(|ctx| {
             ctx.bot_read(
                 self.ctrl_type,
@@ -278,8 +288,9 @@ impl BlockDevice for UsbBlockDevice {
                 &mut self.tag,
             )
         })
+        .map_err(|_| BlockError::Device)
     }
-    fn write_sectors(&mut self, lba: u32, count: u16, buf: &[u8]) -> Result<(), &'static str> {
+    fn write_sectors(&mut self, lba: u32, count: u16, buf: &[u8]) -> Result<(), BlockError> {
         with_ctx(|ctx| {
             ctx.bot_write(
                 self.ctrl_type,
@@ -296,6 +307,7 @@ impl BlockDevice for UsbBlockDevice {
                 &mut self.tag,
             )
         })
+        .map_err(|_| BlockError::Device)
     }
     fn sector_size(&self) -> u32 {
         self.block_size
@@ -575,11 +587,11 @@ unsafe impl Send for SdBlockDev {}
 
 #[cfg(not(nitrogen_no_storage))]
 impl BlockDevice for SdBlockDev {
-    fn read_sectors(&mut self, lba: u32, count: u16, buf: &mut [u8]) -> Result<(), &'static str> {
-        nitrogen::storage::rtsx::read_sectors(lba, count, buf)
+    fn read_sectors(&mut self, lba: u32, count: u16, buf: &mut [u8]) -> Result<(), BlockError> {
+        nitrogen::storage::rtsx::read_sectors(lba, count, buf).map_err(|_| BlockError::Device)
     }
-    fn write_sectors(&mut self, lba: u32, count: u16, buf: &[u8]) -> Result<(), &'static str> {
-        nitrogen::storage::rtsx::write_sectors(lba, count, buf)
+    fn write_sectors(&mut self, lba: u32, count: u16, buf: &[u8]) -> Result<(), BlockError> {
+        nitrogen::storage::rtsx::write_sectors(lba, count, buf).map_err(|_| BlockError::Device)
     }
     fn sector_size(&self) -> u32 {
         self.block_size

--- a/fullerene-kernel/src/graphics/text.rs
+++ b/fullerene-kernel/src/graphics/text.rs
@@ -112,7 +112,7 @@ pub fn _print(args: fmt::Arguments) {
 
 // Fallback graphics initialization for when framebuffer config is not available
 #[inline(always)]
-pub fn init_fallback_graphics() -> Result<(), &'static str> {
+pub fn init_fallback_graphics() -> Result<(), petroleum::SystemError> {
     #[cfg(target_os = "uefi")]
     {
         let vga_config = petroleum::common::VgaFramebufferConfig {

--- a/fullerene-kernel/src/gui.rs
+++ b/fullerene-kernel/src/gui.rs
@@ -21,32 +21,12 @@ use core::sync::atomic::{AtomicBool, Ordering};
 use petroleum::graphics::Renderer;
 use solvent;
 
-use genome::fs::FsError;
-
 // Re-export solvent types used by other kernel modules
 pub use solvent::{
     LatticeTerminal, MOUSE_STATE, MouseState, chrono_tick, consume_frame_due, cursor_update_due,
     is_initialized, poll_mouse_state, process_events, push_key_event, set_render_fn, tick_core,
     write_terminal,
 };
-
-/// Convert an FsError to a static string for the solvent callback boundary.
-fn fs_err_str(e: FsError) -> &'static str {
-    match e {
-        FsError::FileNotFound => "file not found",
-        FsError::FileExists => "file exists",
-        FsError::PermissionDenied => "permission denied",
-        FsError::InvalidFileDescriptor => "bad fd",
-        FsError::InvalidSeek => "invalid seek",
-        FsError::DiskFull => "disk full",
-        FsError::NotADirectory => "not a directory",
-        FsError::DirectoryNotEmpty => "directory not empty",
-        FsError::IsADirectory => "is a directory",
-        FsError::InvalidPath => "invalid path",
-        FsError::NotSupported => "not supported",
-        FsError::InvalidInput => "invalid input",
-    }
-}
 
 /// Initialise the GUI subsystem via Solvent runtime.
 pub fn init() {
@@ -55,7 +35,7 @@ pub fn init() {
         heap_extend: Some(|additional| unsafe { crate::heap::extend_kernel_heap(additional) }),
         wall_clock: Some(read_cmos_time),
         vfs_readdir: Some(|path| {
-            let entries = crate::contexts::vfs::readdir(path).map_err(fs_err_str)?;
+            let entries = crate::contexts::vfs::readdir(path)?;
             let mut result = alloc::vec::Vec::new();
             for vn in entries {
                 result.push(solvent::VfsEntry {
@@ -67,7 +47,7 @@ pub fn init() {
             Ok(result)
         }),
         vfs_read: Some(|path| {
-            let fd = crate::contexts::vfs::open(path, 0).map_err(fs_err_str)?;
+            let fd = crate::contexts::vfs::open(path, 0)?;
             let mut buf = alloc::vec::Vec::new();
             let mut tmp = [0u8; 4096];
             loop {
@@ -76,25 +56,21 @@ pub fn init() {
                     Ok(n) => buf.extend_from_slice(&tmp[..n]),
                     Err(e) => {
                         let _ = crate::contexts::vfs::close(fd.fd);
-                        return Err(fs_err_str(e));
+                        return Err(e);
                     }
                 }
             }
             let _ = crate::contexts::vfs::close(fd.fd);
             Ok(buf)
         }),
-        vfs_write: Some(|path, data| {
-            crate::contexts::vfs::replace_file(path, data).map_err(fs_err_str)
-        }),
+        vfs_write: Some(|path, data| crate::contexts::vfs::replace_file(path, data)),
         vfs_copy: Some(|source, destination, is_dir| {
-            crate::contexts::vfs::copy_path(source, destination, is_dir).map_err(fs_err_str)
+            crate::contexts::vfs::copy_path(source, destination, is_dir)
         }),
         vfs_move: Some(|source, destination, is_dir| {
-            crate::contexts::vfs::move_path(source, destination, is_dir).map_err(fs_err_str)
+            crate::contexts::vfs::move_path(source, destination, is_dir)
         }),
-        vfs_remove: Some(|path, is_dir| {
-            crate::contexts::vfs::remove_path(path, is_dir).map_err(fs_err_str)
-        }),
+        vfs_remove: Some(|path, is_dir| crate::contexts::vfs::remove_path(path, is_dir)),
         process_list: Some(|| {
             let mut result = alloc::vec::Vec::new();
             crate::process::SCHEDULER.with_list(|list| {

--- a/fullerene-kernel/src/init.rs
+++ b/fullerene-kernel/src/init.rs
@@ -264,7 +264,7 @@ pub fn init_common(_physical_memory_offset: x86_64::VirtAddr) {
             petroleum::write_serial_bytes(0x3F8, 0x3FD, b"[step] devfs start\n");
             let _ = crate::contexts::vfs::mkdir("/dev");
             crate::contexts::vfs::mount("", "/dev", "devfs")
-                .map_err(|_| "Failed to mount DevFS")?;
+                .map_err(|_| petroleum::SystemError::DeviceError)?;
             petroleum::serial::serial_log(format_args!("DevFS mounted at /dev\n"));
             petroleum::write_serial_bytes(0x3F8, 0x3FD, b"[step] devfs done\n");
             Ok(())
@@ -406,7 +406,7 @@ pub fn init_common(_physical_memory_offset: x86_64::VirtAddr) {
             petroleum::write_serial_bytes(0x3F8, 0x3FD, b"[step] device_mgr start\n");
             crate::boot_stage::draw_boot_label(b"DEVICE MANAGER");
             crate::hardware::device_manager::init_device_manager()
-                .map_err(|_| "Failed to initialize device manager")?;
+                .map_err(|_| petroleum::SystemError::DeviceError)?;
             petroleum::serial::serial_log(format_args!("Device manager initialised\n"));
             petroleum::write_serial_bytes(0x3F8, 0x3FD, b"[step] device_mgr done\n");
             Ok(())

--- a/fullerene-kernel/src/initramfs.rs
+++ b/fullerene-kernel/src/initramfs.rs
@@ -129,7 +129,7 @@ fn parse_entry(data: &[u8], offset: usize) -> Option<(CpioHeader, usize, usize)>
 /// Creates directories with `crate::contexts::vfs::mkdir` and files with
 /// `crate::fs::write_entire_file`.  The caller is responsible for
 /// ensuring the VFS is initialised before calling this function.
-pub fn unpack(archive: &[u8]) -> Result<usize, &'static str> {
+pub fn unpack(archive: &[u8]) -> Result<usize, genome::FsError> {
     let mut count = 0usize;
     let mut offset = 0usize;
 
@@ -157,10 +157,9 @@ pub fn unpack(archive: &[u8]) -> Result<usize, &'static str> {
                 .filter(|&end| end <= archive.len())
                 .unwrap_or(body_start);
             let body = archive.get(body_start..body_end).unwrap_or(&[]);
-            if let Ok(parent) = parent_of(path) {
-                if !parent.is_empty() && !crate::contexts::vfs::exists(parent) {
-                    let _ = crate::contexts::vfs::mkdir(parent);
-                }
+            let parent = parent_of(path);
+            if !parent.is_empty() && !crate::contexts::vfs::exists(parent) {
+                let _ = crate::contexts::vfs::mkdir(parent);
             }
             if crate::contexts::vfs::exists(path) {
                 let _ = crate::fs::remove(path);
@@ -180,15 +179,15 @@ pub fn unpack(archive: &[u8]) -> Result<usize, &'static str> {
 }
 
 /// Return the parent directory of `path`, or empty string if root.
-fn parent_of(path: &str) -> Result<&str, &'static str> {
+fn parent_of(path: &str) -> &str {
     match path.rfind('/') {
         Some(pos) => {
             if pos == 0 {
-                Ok("/")
+                "/"
             } else {
-                Ok(&path[..pos])
+                &path[..pos]
             }
         }
-        None => Ok(""),
+        None => "",
     }
 }

--- a/fullerene-kernel/src/linux/launch.rs
+++ b/fullerene-kernel/src/linux/launch.rs
@@ -26,7 +26,7 @@ pub fn launch_linux_from_data(data: &[u8], name: &'static str) -> Result<Process
 }
 
 /// Launch BusyBox shell from embedded initramfs data.
-pub fn launch_busybox() -> Result<ProcessId, &'static str> {
+pub fn launch_busybox() -> Result<ProcessId, LoadError> {
     // Look for busybox in standard locations
     let locations = [
         "/bin/busybox",
@@ -40,11 +40,11 @@ pub fn launch_busybox() -> Result<ProcessId, &'static str> {
     for path in &locations {
         if crate::contexts::vfs::exists(path) {
             log::info!("Found BusyBox at {}", path);
-            return launch_linux_binary(path).map_err(|_| "Failed to load BusyBox");
+            return launch_linux_binary(path);
         }
     }
 
-    Err("BusyBox not found in filesystem")
+    Err(LoadError::FileNotFound)
 }
 
 /// Initialize the initramfs: creates basic Linux filesystem structure

--- a/fullerene-kernel/src/linux/runtime.rs
+++ b/fullerene-kernel/src/linux/runtime.rs
@@ -276,6 +276,7 @@ impl From<genome::fs::FsError> for LinuxErrno {
             FsError::DirectoryNotEmpty => ENOTEMPTY,
             FsError::IsADirectory => EISDIR,
             FsError::NotSupported => ENOTSUP,
+            FsError::Io => EIO,
         })
     }
 }
@@ -284,7 +285,7 @@ impl From<genome::block::BlockError> for LinuxErrno {
     fn from(error: genome::block::BlockError) -> Self {
         use genome::block::BlockError;
         Self(match error {
-            BlockError::Device(_) => EIO,
+            BlockError::Device => EIO,
             BlockError::BufferTooSmall { .. } => EINVAL,
             BlockError::LbaOverflow => EOVERFLOW,
             BlockError::SectorNotFound => ENOENT,
@@ -324,6 +325,7 @@ impl From<petroleum::MemoryError> for LinuxErrno {
             MemoryError::AddressOverflow => EOVERFLOW,
             MemoryError::AlreadyMapped => EEXIST,
             MemoryError::PermissionDenied => EACCES,
+            MemoryError::NotInitialized => EFAULT,
         })
     }
 }
@@ -499,6 +501,11 @@ mod user_copy_tests {
         assert_eq!(
             LinuxErrno::from(genome::fs::FsError::NotSupported).get(),
             ENOTSUP
+        );
+        assert_eq!(LinuxErrno::from(genome::fs::FsError::Io).get(), EIO);
+        assert_eq!(
+            LinuxErrno::from(petroleum::MemoryError::NotInitialized).get(),
+            EFAULT
         );
     }
 }

--- a/fullerene-kernel/src/loader.rs
+++ b/fullerene-kernel/src/loader.rs
@@ -201,6 +201,7 @@ pub enum LoadError {
     UnsupportedArchitecture,
     MappingFailed,
     AddressAlreadyMapped,
+    FileNotFound,
 }
 
 impl From<LoadError> for petroleum::common::logging::SystemError {
@@ -211,6 +212,7 @@ impl From<LoadError> for petroleum::common::logging::SystemError {
             LoadError::AddressAlreadyMapped => {
                 petroleum::common::logging::SystemError::MappingFailed
             }
+            LoadError::FileNotFound => petroleum::common::logging::SystemError::FileNotFound,
             LoadError::MappingFailed => petroleum::common::logging::SystemError::MappingFailed,
             LoadError::NotExecutable | LoadError::UnsupportedArchitecture => {
                 petroleum::common::logging::SystemError::LoadFailed

--- a/fullerene-kernel/src/shell.rs
+++ b/fullerene-kernel/src/shell.rs
@@ -38,17 +38,14 @@ fn wasm_yield_now() {
     kernel_syscall(22, 0, 0, 0);
 }
 
-fn wasm_read_entire_file(path: &str) -> Result<alloc::vec::Vec<u8>, &'static str> {
-    crate::fs::read_entire_file(path).map_err(|e| match e {
-        crate::fs::FsError::FileNotFound => "file not found",
-        _ => "read failed",
-    })
+fn wasm_read_entire_file(path: &str) -> Result<alloc::vec::Vec<u8>, genome::FsError> {
+    crate::fs::read_entire_file(path)
 }
 
 fn wasm_read_directory(
     path: &str,
-) -> Result<alloc::vec::Vec<(alloc::string::String, u8)>, &'static str> {
-    let entries = crate::contexts::vfs::readdir(path).map_err(|_| "readdir failed")?;
+) -> Result<alloc::vec::Vec<(alloc::string::String, u8)>, genome::FsError> {
+    let entries = crate::contexts::vfs::readdir(path)?;
     Ok(entries
         .iter()
         .map(|e| {
@@ -96,11 +93,8 @@ macro_rules! launch_cmd {
 
 /// Read the entire contents of a file at `path`. Returns the raw bytes.
 /// Limited to MAX_FILE_SIZE to prevent unbounded memory growth.
-fn read_entire_file(path: &str) -> Result<alloc::vec::Vec<u8>, &'static str> {
-    crate::fs::read_entire_file(path).map_err(|e| match e {
-        crate::fs::FsError::FileNotFound => "file not found",
-        _ => "read failed",
-    })
+fn read_entire_file(path: &str) -> Result<alloc::vec::Vec<u8>, genome::FsError> {
+    crate::fs::read_entire_file(path)
 }
 
 /// Initialize the shell subsystem (formerly keyboard init, etc.)

--- a/fullerene-kernel/src/syscall/interface.rs
+++ b/fullerene-kernel/src/syscall/interface.rs
@@ -134,6 +134,7 @@ impl From<genome::fs::FsError> for SyscallError {
             FsError::DirectoryNotEmpty => Self::DirectoryNotEmpty,
             FsError::IsADirectory => Self::IsADirectory,
             FsError::NotSupported => Self::NotSupported,
+            FsError::Io => Self::Io,
         }
     }
 }
@@ -142,7 +143,7 @@ impl From<genome::block::BlockError> for SyscallError {
     fn from(error: genome::block::BlockError) -> Self {
         use genome::block::BlockError;
         match error {
-            BlockError::Device(_) => Self::Io,
+            BlockError::Device => Self::Io,
             BlockError::BufferTooSmall { .. } => Self::InvalidArgument,
             BlockError::LbaOverflow => Self::Overflow,
             BlockError::SectorNotFound => Self::FileNotFound,
@@ -183,6 +184,7 @@ impl From<petroleum::MemoryError> for SyscallError {
             MemoryError::AddressOverflow => Self::Overflow,
             MemoryError::AlreadyMapped => Self::AlreadyExists,
             MemoryError::PermissionDenied => Self::PermissionDenied,
+            MemoryError::NotInitialized => Self::AddressFault,
         }
     }
 }
@@ -314,6 +316,14 @@ mod tests {
         assert_eq!(
             SyscallError::from(petroleum::SystemError::WouldBlock),
             SyscallError::WouldBlock
+        );
+        assert_eq!(
+            SyscallError::from(genome::fs::FsError::Io),
+            SyscallError::Io
+        );
+        assert_eq!(
+            SyscallError::from(petroleum::MemoryError::NotInitialized),
+            SyscallError::AddressFault
         );
     }
 }

--- a/fullerene-kernel/src/vdso.rs
+++ b/fullerene-kernel/src/vdso.rs
@@ -35,10 +35,10 @@ pub fn create_vdso_page(
     process_pt: &mut impl PageTableHelper,
     frame_allocator: &mut impl FrameAllocator<Size4KiB>,
     pid: u64,
-) -> Result<VdsoPageRef, &'static str> {
+) -> Result<VdsoPageRef, petroleum::MemoryError> {
     let frame = frame_allocator
         .allocate_frame()
-        .ok_or("VDSO: out of frames")?;
+        .ok_or(petroleum::MemoryError::FrameAllocationFailed)?;
     let phys_addr = frame.start_address();
 
     let phys_offset = petroleum::PHYSICAL_MEMORY_OFFSET.load(Ordering::Relaxed) as u64;
@@ -63,7 +63,7 @@ pub fn create_vdso_page(
             if let Some(m) = mgr.as_mut() {
                 let _ = m.free_frame(frame.start_address().as_u64() as usize);
             }
-            "VDSO: map_page failed"
+            petroleum::MemoryError::MappingFailed
         })?;
 
     petroleum::debug_log_no_alloc!(

--- a/genome/src/block.rs
+++ b/genome/src/block.rs
@@ -2,7 +2,7 @@ use core::fmt;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BlockError {
-    Device(&'static str),
+    Device,
     BufferTooSmall { required: usize, provided: usize },
     LbaOverflow,
     SectorNotFound,
@@ -11,7 +11,7 @@ pub enum BlockError {
 impl fmt::Display for BlockError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            BlockError::Device(msg) => write!(f, "device error: {}", msg),
+            BlockError::Device => write!(f, "block device error"),
             BlockError::BufferTooSmall { required, provided } => {
                 write!(f, "buffer too small: need {} got {}", required, provided)
             }
@@ -21,24 +21,18 @@ impl fmt::Display for BlockError {
     }
 }
 
-impl From<&'static str> for BlockError {
-    fn from(e: &'static str) -> Self {
-        BlockError::Device(e)
-    }
-}
-
 pub trait BlockDevice: Send {
-    fn read_sectors(&mut self, lba: u32, count: u16, buf: &mut [u8]) -> Result<(), &'static str>;
-    fn write_sectors(&mut self, lba: u32, count: u16, buf: &[u8]) -> Result<(), &'static str>;
+    fn read_sectors(&mut self, lba: u32, count: u16, buf: &mut [u8]) -> Result<(), BlockError>;
+    fn write_sectors(&mut self, lba: u32, count: u16, buf: &[u8]) -> Result<(), BlockError>;
     fn sector_size(&self) -> u32;
     fn total_sectors(&self) -> u64;
 }
 
 impl BlockDevice for alloc::boxed::Box<dyn BlockDevice> {
-    fn read_sectors(&mut self, lba: u32, count: u16, buf: &mut [u8]) -> Result<(), &'static str> {
+    fn read_sectors(&mut self, lba: u32, count: u16, buf: &mut [u8]) -> Result<(), BlockError> {
         (**self).read_sectors(lba, count, buf)
     }
-    fn write_sectors(&mut self, lba: u32, count: u16, buf: &[u8]) -> Result<(), &'static str> {
+    fn write_sectors(&mut self, lba: u32, count: u16, buf: &[u8]) -> Result<(), BlockError> {
         (**self).write_sectors(lba, count, buf)
     }
     fn sector_size(&self) -> u32 {

--- a/genome/src/fs.rs
+++ b/genome/src/fs.rs
@@ -16,6 +16,7 @@ pub enum FsError {
     InvalidPath,
     NotSupported,
     InvalidInput,
+    Io,
 }
 
 impl core::fmt::Display for FsError {
@@ -33,25 +34,18 @@ impl core::fmt::Display for FsError {
             FsError::InvalidPath => write!(f, "invalid path"),
             FsError::NotSupported => write!(f, "operation not supported"),
             FsError::InvalidInput => write!(f, "invalid input"),
+            FsError::Io => write!(f, "filesystem I/O error"),
         }
     }
 }
 
-impl From<&'static str> for FsError {
-    fn from(e: &'static str) -> Self {
-        match e {
-            "not found" | "mount point not found" => FsError::FileNotFound,
-            "not a directory" | "mount point not a directory" => FsError::NotADirectory,
-            "not a file" | "mount point is a file" => FsError::IsADirectory,
-            "bad fd" => FsError::InvalidFileDescriptor,
-            "inode not found" => FsError::FileNotFound,
-            "directory not empty" => FsError::DirectoryNotEmpty,
-            "invalid path" => FsError::InvalidPath,
-            "no free clusters" => FsError::DiskFull,
-            "create failed" | "open failed after create" => FsError::FileExists,
-            "mkdir failed" => FsError::PermissionDenied,
-            "vfs not init" | "only tmpfs is supported" => FsError::PermissionDenied,
-            _ => FsError::InvalidInput,
+impl From<crate::block::BlockError> for FsError {
+    fn from(error: crate::block::BlockError) -> Self {
+        match error {
+            crate::block::BlockError::BufferTooSmall { .. }
+            | crate::block::BlockError::LbaOverflow => Self::InvalidInput,
+            crate::block::BlockError::SectorNotFound => Self::FileNotFound,
+            crate::block::BlockError::Device => Self::Io,
         }
     }
 }

--- a/genome/src/lib.rs
+++ b/genome/src/lib.rs
@@ -4,3 +4,6 @@ extern crate alloc;
 pub mod block;
 pub mod fs;
 pub mod vfs;
+
+pub use block::BlockError;
+pub use fs::FsError;

--- a/lattice/src/font.rs
+++ b/lattice/src/font.rs
@@ -111,25 +111,46 @@ struct PsfFont {
     height: u32,
 }
 
+/// Failures encountered while validating a PSF2 font.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FontError {
+    HeaderTooShort,
+    InvalidMagic,
+    UnsupportedDimensions,
+    SizeOverflow,
+    TruncatedBitmap,
+}
+
+impl core::fmt::Display for FontError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(match self {
+            Self::HeaderTooShort => "PSF2 header is truncated",
+            Self::InvalidMagic => "invalid PSF2 magic",
+            Self::UnsupportedDimensions => "PSF2 glyphs must be 8x16",
+            Self::SizeOverflow => "PSF2 bitmap size overflow",
+            Self::TruncatedBitmap => "PSF2 bitmap is truncated",
+        })
+    }
+}
+
 /// Try to load a PSF2 font from raw bytes.
 ///
 /// Returns `Ok(())` on success — subsequent calls to [`glyph()`] will
-/// use the PSF glyphs.  Returns `Err(&str)` with a human‑readable
-/// error if the data is not valid PSF2 or the glyph dimensions don't
-/// match 8×16.
+/// use the PSF glyphs. Returns a [`FontError`] if the data is malformed
+/// or the glyph dimensions do not match 8×16.
 ///
 /// # Safety
 ///
 /// The caller must ensure `data` remains valid for the lifetime of the
 /// kernel (it is stored as `&'static [u8]`).
-pub fn load_psf2(data: &'static [u8]) -> Result<(), &'static str> {
+pub fn load_psf2(data: &'static [u8]) -> Result<(), FontError> {
     if data.len() < PSF2_HEADER_SIZE as usize {
-        return Err("PSF2 data too short for header");
+        return Err(FontError::HeaderTooShort);
     }
 
     let magic = u32::from_le_bytes([data[0], data[1], data[2], data[3]]);
     if magic != PSF2_MAGIC {
-        return Err("not a PSF2 font (bad magic)");
+        return Err(FontError::InvalidMagic);
     }
 
     let _header_size = u32::from_le_bytes([data[8], data[9], data[10], data[11]]);
@@ -141,16 +162,20 @@ pub fn load_psf2(data: &'static [u8]) -> Result<(), &'static str> {
 
     // We require 8×16 for compatibility with the embedded font.
     if width != 8 || height != 16 {
-        return Err("PSF2 font must be 8×16");
+        return Err(FontError::UnsupportedDimensions);
     }
 
     let header_size = u32::from_le_bytes([data[8], data[9], data[10], data[11]]);
-    let bitmap_size = (glyph_count as usize).saturating_mul(glyph_bytes as usize);
+    let bitmap_size = (glyph_count as usize)
+        .checked_mul(glyph_bytes as usize)
+        .ok_or(FontError::SizeOverflow)?;
     let bitmap_start = header_size as usize;
-    let bitmap_end = bitmap_start.saturating_add(bitmap_size);
+    let bitmap_end = bitmap_start
+        .checked_add(bitmap_size)
+        .ok_or(FontError::SizeOverflow)?;
 
     if data.len() < bitmap_end {
-        return Err("PSF2 data truncated (bitmap exceeds data)");
+        return Err(FontError::TruncatedBitmap);
     }
 
     let bitmap: &'static [u8] = &data[bitmap_start..bitmap_end];
@@ -571,4 +596,18 @@ pub fn render_text_ttf(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn psf2_validation_preserves_failure_categories() {
+        static SHORT: [u8; 4] = [0; 4];
+        static BAD_MAGIC: [u8; PSF2_HEADER_SIZE as usize] = [0; PSF2_HEADER_SIZE as usize];
+
+        assert_eq!(load_psf2(&SHORT), Err(FontError::HeaderTooShort));
+        assert_eq!(load_psf2(&BAD_MAGIC), Err(FontError::InvalidMagic));
+    }
 }

--- a/nitrogen/src/driver_api.rs
+++ b/nitrogen/src/driver_api.rs
@@ -7,24 +7,25 @@ use core::cmp::Reverse;
 /// Block-device interface for mass-storage controllers
 /// (NVMe, AHCI, SATA, IDE, SD/MMC, USB mass storage, etc.).
 pub trait StorageDriver: Send {
-    fn init(&mut self) -> Result<(), &'static str>;
-    fn read_blocks(&self, lba: u64, count: usize, buf: &mut [u8]) -> Result<(), &'static str>;
-    fn write_blocks(&self, lba: u64, count: usize, buf: &[u8]) -> Result<(), &'static str>;
+    fn init(&mut self) -> Result<(), crate::DriverError>;
+    fn read_blocks(&self, lba: u64, count: usize, buf: &mut [u8])
+    -> Result<(), crate::DriverError>;
+    fn write_blocks(&self, lba: u64, count: usize, buf: &[u8]) -> Result<(), crate::DriverError>;
     fn block_size(&self) -> u32;
     fn total_blocks(&self) -> u64;
 }
 
 /// Network interface controller (Ethernet, Wi-Fi, etc.).
 pub trait NetworkDriver: Send {
-    fn init(&mut self) -> Result<(), &'static str>;
-    fn send(&self, buf: &[u8]) -> Result<(), &'static str>;
-    fn receive(&self, buf: &mut [u8]) -> Result<usize, &'static str>;
+    fn init(&mut self) -> Result<(), crate::DriverError>;
+    fn send(&self, buf: &[u8]) -> Result<(), crate::DriverError>;
+    fn receive(&self, buf: &mut [u8]) -> Result<usize, crate::DriverError>;
     fn mac_address(&self) -> [u8; 6];
 }
 
 /// Display / GPU controller (VGA-compatible, VirtIO-GPU, etc.).
 pub trait DisplayDriver: Send {
-    fn init(&mut self) -> Result<(), &'static str>;
+    fn init(&mut self) -> Result<(), crate::DriverError>;
     fn framebuffer(&self) -> &[u8];
     fn resolution(&self) -> (usize, usize);
     fn stride(&self) -> usize;
@@ -33,13 +34,13 @@ pub trait DisplayDriver: Send {
 
 /// Audio controller (HDA, AC97, USB audio, etc.).
 pub trait AudioDriver: Send {
-    fn init(&mut self) -> Result<(), &'static str>;
-    fn play(&self, buf: &[u8]) -> Result<(), &'static str>;
+    fn init(&mut self) -> Result<(), crate::DriverError>;
+    fn play(&self, buf: &[u8]) -> Result<(), crate::DriverError>;
 }
 
 /// USB host controller (EHCI, XHCI, OHCI, UHCI).
 pub trait UsbHostDriver: Send {
-    fn init(&mut self) -> Result<(), &'static str>;
+    fn init(&mut self) -> Result<(), crate::DriverError>;
     fn poll(&self);
 }
 
@@ -62,7 +63,7 @@ impl DriverBox {
     ///
     /// This is the **attach** step in the probe → priority → attach →
     /// driver-manager pipeline.
-    pub fn attach(&mut self) -> Result<(), &'static str> {
+    pub fn attach(&mut self) -> Result<(), crate::DriverError> {
         match self {
             DriverBox::Storage(d) => d.init(),
             DriverBox::Network(d) => d.init(),

--- a/nitrogen/src/iommu/mod.rs
+++ b/nitrogen/src/iommu/mod.rs
@@ -208,15 +208,15 @@ impl IommuEngine {
 static GLOBAL_IOMMU: Mutex<Option<IommuEngine>> = Mutex::new(None);
 static IOMMU_INITIALIZED: AtomicBool = AtomicBool::new(false);
 
-pub fn init(rsdp_phys: u64) -> Result<(), &'static str> {
+pub fn init(rsdp_phys: u64) -> Result<(), crate::DriverError> {
     if IOMMU_INITIALIZED.load(core::sync::atomic::Ordering::Relaxed) {
         log::info!("IOMMU: already initialized, re-init skipped");
         return Ok(());
     }
 
-    let dmar = acpi::dmar::parse_dmar(rsdp_phys).ok_or("failed to parse DMAR table")?;
+    let dmar = acpi::dmar::parse_dmar(rsdp_phys).ok_or(crate::DriverError::Protocol)?;
     if dmar.drhd_units.is_empty() {
-        return Err("IOMMU: no DRHD units found");
+        return Err(crate::DriverError::DeviceNotFound);
     }
 
     let drhd = &dmar.drhd_units[0];
@@ -232,10 +232,10 @@ pub fn init(rsdp_phys: u64) -> Result<(), &'static str> {
 
     let mmio_virt = {
         let guard = MEM.lock();
-        let cbs = guard.as_ref().ok_or("IOMMU: MemCallbacks not set")?;
+        let cbs = guard.as_ref().ok_or(crate::DriverError::NotReady)?;
         // Map VT-d MMIO region as uncached (required by VT-d spec)
-        let virt =
-            (cbs.map_mmio)(mmio_base as usize, 4096).map_err(|_| "IOMMU: MMIO mapping failed")?;
+        let virt = (cbs.map_mmio)(mmio_base as usize, 4096)
+            .map_err(|_| crate::DriverError::MmioMappingFailed)?;
         virt as *mut u8
     };
     let regs = VtdRegisters::new(mmio_virt);
@@ -253,27 +253,27 @@ pub fn init(rsdp_phys: u64) -> Result<(), &'static str> {
     );
 
     let mut engine =
-        IommuEngine::new(regs, iova_bits).map_err(|_| "IOMMU engine creation failed")?;
+        IommuEngine::new(regs, iova_bits).map_err(|_| crate::DriverError::DeviceFault)?;
     engine
         .setup_pass_through_all()
-        .map_err(|_| "IOMMU pass-through setup failed")?;
+        .map_err(|_| crate::DriverError::DeviceFault)?;
 
     if engine.registers.gsts() & vtd::GSTS_TES != 0 {
         log::info!("IOMMU: already enabled by firmware");
     }
 
     if !engine.registers.write_buffer_flush() {
-        return Err("IOMMU: write buffer flush failed");
+        return Err(crate::DriverError::DeviceFault);
     }
     engine.registers.set_rtaddr(engine.root_table.root_phys());
     engine.registers.set_root_table_ptr();
     if !engine.registers.wait_for_root_table_ptr() {
-        return Err("IOMMU: root table pointer setup timed out");
+        return Err(crate::DriverError::TimedOut);
     }
 
     engine.registers.enable_translation();
     if !engine.registers.wait_for_translation_enable() {
-        return Err("IOMMU: translation enable timed out");
+        return Err(crate::DriverError::TimedOut);
     }
 
     // TODO: Support multiple DRHD remapping units. Currently only the first

--- a/nitrogen/src/iwlwifi/device.rs
+++ b/nitrogen/src/iwlwifi/device.rs
@@ -601,17 +601,17 @@ impl IwlWifiDevice {
 
     /// Common firmware upload and CPU start sequence shared by load_firmware and start_firmware.
     /// Does NOT wait for alive signal - caller must handle that if needed.
-    fn upload_firmware_and_start_cpu(&mut self, fw_data: &[u8]) -> Result<(), &'static str> {
+    fn upload_firmware_and_start_cpu(&mut self, fw_data: &[u8]) -> Result<(), crate::DriverError> {
         debug::print("iwlwifi", "fw: check_header");
         if fw_data.len() < FW_HEADER_SIZE {
-            return Err("Firmware data too short");
+            return Err(crate::DriverError::InvalidArgument);
         }
 
         self.fw_state = FwState::Loading;
 
         let gp = self
             .safe_read32(CSR_GP_CNTRL)
-            .ok_or("Device unresponsive")?;
+            .ok_or(crate::DriverError::DeviceNotFound)?;
         unsafe {
             core::ptr::write_volatile(self.mmio.add(CSR_GP_CNTRL as usize), gp & !0x04);
             core::ptr::write_volatile(self.mmio.add(CSR_RESET as usize), 0x00000080);
@@ -623,12 +623,12 @@ impl IwlWifiDevice {
 
         let zero: u32 = unsafe { core::ptr::read_unaligned(fw_ptr as *const u32) };
         if zero != 0 {
-            return Err("Invalid firmware header (zero != 0)");
+            return Err(crate::DriverError::Protocol);
         }
 
         let magic: u32 = unsafe { core::ptr::read_unaligned(fw_ptr.add(4) as *const u32) };
         if magic != IWL_FW_MAGIC {
-            return Err("Invalid firmware magic");
+            return Err(crate::DriverError::Protocol);
         }
 
         log::info!("iwlwifi: loading firmware payload...");
@@ -696,7 +696,7 @@ impl IwlWifiDevice {
         }
 
         if section_count == 0 {
-            return Err("No firmware sections uploaded");
+            return Err(crate::DriverError::Protocol);
         }
 
         debug::print("iwlwifi", "fw: upload_done");
@@ -718,7 +718,7 @@ impl IwlWifiDevice {
 
         let gp = self
             .safe_read32(CSR_GP_CNTRL)
-            .ok_or("Device unresponsive")?;
+            .ok_or(crate::DriverError::DeviceNotFound)?;
         unsafe {
             core::ptr::write_volatile(
                 self.mmio.add(CSR_GP_CNTRL as usize),
@@ -734,7 +734,7 @@ impl IwlWifiDevice {
     }
 
     /// Load firmware binary into the device.
-    pub fn load_firmware(&mut self, fw_data: &[u8]) -> Result<(), &'static str> {
+    pub fn load_firmware(&mut self, fw_data: &[u8]) -> Result<(), crate::DriverError> {
         self.upload_firmware_and_start_cpu(fw_data)?;
 
         debug::print("iwlwifi", "fw: wait_alive");
@@ -771,7 +771,7 @@ impl IwlWifiDevice {
     }
 
     /// Upload a single firmware section to the device SRAM via HBUS direct writes.
-    fn upload_section(&mut self, target_addr: u32, data: &[u8]) -> Result<(), &'static str> {
+    fn upload_section(&mut self, target_addr: u32, data: &[u8]) -> Result<(), crate::DriverError> {
         let dwords = data.len() / 4;
         let extra = data.len() % 4;
 
@@ -800,7 +800,7 @@ impl IwlWifiDevice {
     }
 
     /// Wait for the firmware "alive" response with a TSC-based timeout.
-    fn wait_for_alive(&mut self) -> Result<(), &'static str> {
+    fn wait_for_alive(&mut self) -> Result<(), crate::DriverError> {
         let start_tsc = unsafe { core::arch::x86_64::_rdtsc() };
         let timeout_tsc: u64 = 5_000_000_000;
         let mut last_pci_check: u64 = 0;
@@ -816,13 +816,13 @@ impl IwlWifiDevice {
             if now.wrapping_sub(last_pci_check) >= pci_check_interval {
                 last_pci_check = now;
                 if !self.health.is_device_present() {
-                    return Err("Device disappeared from PCI bus during alive wait");
+                    return Err(crate::DriverError::DeviceNotFound);
                 }
             }
 
             let int_cause = match self.safe_read32(CSR_INT) {
                 Some(v) => v,
-                None => return Err("Device unresponsive (PCI master abort)"),
+                None => return Err(crate::DriverError::DeviceNotFound),
             };
             if int_cause != 0 {
                 if (int_cause & 0x01) != 0 {
@@ -836,7 +836,7 @@ impl IwlWifiDevice {
                     unsafe {
                         core::ptr::write_volatile(self.mmio.add(CSR_INT as usize), int_cause);
                     }
-                    return Err("Firmware error");
+                    return Err(crate::DriverError::Protocol);
                 }
                 unsafe {
                     core::ptr::write_volatile(self.mmio.add(CSR_INT as usize), int_cause);
@@ -845,7 +845,7 @@ impl IwlWifiDevice {
 
             let ucode_gp1 = match self.safe_read32(CSR_UCODE_GP1) {
                 Some(v) => v,
-                None => return Err("Device unresponsive (PCI master abort)"),
+                None => return Err(crate::DriverError::DeviceNotFound),
             };
             if (ucode_gp1 & 0x01) == 0 {
                 self.fw_state = FwState::Alive;
@@ -856,14 +856,14 @@ impl IwlWifiDevice {
         }
 
         self.fw_state = FwState::Error;
-        Err("Timeout waiting for firmware alive")
+        Err(crate::DriverError::TimedOut)
     }
 
     /// Start firmware upload and CPU boot without waiting for alive.
-    pub fn start_firmware(&mut self, fw_data: &[u8]) -> Result<(), &'static str> {
+    pub fn start_firmware(&mut self, fw_data: &[u8]) -> Result<(), crate::DriverError> {
         self.health
             .recover()
-            .map_err(|_| "Device not accessible for firmware upload")?;
+            .map_err(|_| crate::DriverError::DeviceNotFound)?;
 
         self.upload_firmware_and_start_cpu(fw_data)?;
 
@@ -877,24 +877,24 @@ impl IwlWifiDevice {
     }
 
     /// Check if firmware has signaled alive (non-blocking poll).
-    pub fn check_alive_nonblocking(&mut self, start_tsc: u64) -> Result<bool, &'static str> {
+    pub fn check_alive_nonblocking(&mut self, start_tsc: u64) -> Result<bool, crate::DriverError> {
         let now = unsafe { core::arch::x86_64::_rdtsc() };
         let elapsed = now.wrapping_sub(start_tsc);
         const TIMEOUT_TSC: u64 = 5_000_000_000;
 
         if elapsed >= TIMEOUT_TSC {
             self.fw_state = FwState::Error;
-            return Err("Timeout waiting for firmware alive");
+            return Err(crate::DriverError::TimedOut);
         }
 
         if !self.health.is_device_present() {
             self.fw_state = FwState::Error;
-            return Err("Device not accessible for MMIO");
+            return Err(crate::DriverError::DeviceNotFound);
         }
 
         let int_cause = match self.safe_read32(CSR_INT) {
             Some(v) => v,
-            None => return Err("Device unresponsive (PCI master abort)"),
+            None => return Err(crate::DriverError::DeviceNotFound),
         };
         if (int_cause & (1 << 0)) != 0 {
             unsafe {
@@ -910,7 +910,7 @@ impl IwlWifiDevice {
                 core::ptr::write_volatile(self.mmio.add(CSR_INT as usize), int_cause);
             }
             self.fw_state = FwState::Error;
-            return Err("Firmware error");
+            return Err(crate::DriverError::Protocol);
         }
         if int_cause != 0 {
             unsafe {
@@ -920,7 +920,7 @@ impl IwlWifiDevice {
 
         let ucode_gp1 = match self.safe_read32(CSR_UCODE_GP1) {
             Some(v) => v,
-            None => return Err("Device unresponsive (PCI master abort)"),
+            None => return Err(crate::DriverError::DeviceNotFound),
         };
         if (ucode_gp1 & 0x01) == 0 {
             unsafe {

--- a/nitrogen/src/iwlwifi/io.rs
+++ b/nitrogen/src/iwlwifi/io.rs
@@ -23,15 +23,15 @@ impl IwlWifiDevice {
         opcode: u8,
         group: u8,
         data: &[u8],
-    ) -> Result<(), &'static str> {
+    ) -> Result<(), crate::DriverError> {
         let total_len = core::mem::size_of::<HcmdHeader>() + data.len();
         if total_len > MAX_FRAME_SIZE {
-            return Err("HCMD too large");
+            return Err(crate::DriverError::InvalidArgument);
         }
 
         self.health
             .pre_mmio_access()
-            .map_err(|_| "device not accessible")?;
+            .map_err(|_| crate::DriverError::DeviceNotFound)?;
 
         let hcmd_header = HcmdHeader {
             opcode,
@@ -43,7 +43,7 @@ impl IwlWifiDevice {
 
         let used = self.tx_head.wrapping_sub(self.tx_tail);
         if used >= TX_QUEUE_SIZE {
-            return Err("TX ring full");
+            return Err(crate::DriverError::Busy);
         }
         let desc_idx = self.tx_head % TX_QUEUE_SIZE;
         let desc_ptr = self.tx_dma_ring.virt() as *mut TxDmaDesc;
@@ -81,14 +81,13 @@ impl IwlWifiDevice {
         Ok(())
     }
 
-    pub fn send_init_commands(&mut self) -> Result<(), &'static str> {
+    pub fn send_init_commands(&mut self) -> Result<(), crate::DriverError> {
         let ant_cfg: [u8; 8] = [0x03, 0x03, 0, 0, 0, 0, 0, 0];
         self.send_hcmd(
             LegacyCmd::TxAntConfig as u8,
             GroupId::Legacy as u8,
             &ant_cfg,
-        )
-        .map_err(|_| "TX antenna config failed")?;
+        )?;
         log::info!("iwlwifi: TX antenna config sent");
 
         let mut rxon = [0u8; 36];
@@ -98,8 +97,7 @@ impl IwlWifiDevice {
         rxon[12..18].copy_from_slice(&mac);
         rxon[22] = 100;
         rxon[23] = 0;
-        self.send_hcmd(LegacyCmd::Rxon as u8, GroupId::Legacy as u8, &rxon)
-            .map_err(|_| "RXON config failed")?;
+        self.send_hcmd(LegacyCmd::Rxon as u8, GroupId::Legacy as u8, &rxon)?;
         log::info!("iwlwifi: RXON config sent");
 
         self.fw_state = FwState::Ready;
@@ -111,9 +109,9 @@ impl IwlWifiDevice {
 // ── Scanning ──────────────────────
 
 impl IwlWifiDevice {
-    pub fn start_scan(&mut self) -> Result<(), &'static str> {
+    pub fn start_scan(&mut self) -> Result<(), crate::DriverError> {
         if self.fw_state != FwState::Ready {
-            return Err("Firmware not ready");
+            return Err(crate::DriverError::NotReady);
         }
 
         self.wifi_conn.start_scan();
@@ -195,14 +193,18 @@ impl IwlWifiDevice {
 // ── Connection management ─────────
 
 impl IwlWifiDevice {
-    pub fn connect(&mut self, ssid: &Ssid, password: Option<&str>) -> Result<(), &'static str> {
+    pub fn connect(
+        &mut self,
+        ssid: &Ssid,
+        password: Option<&str>,
+    ) -> Result<(), crate::DriverError> {
         if self.fw_state != FwState::Ready {
-            return Err("Firmware not ready");
+            return Err(crate::DriverError::NotReady);
         }
 
         let ap = match self.scan_results.iter().find(|a| a.ssid == *ssid) {
             Some(a) => a.clone(),
-            None => return Err("AP not found in scan results"),
+            None => return Err(crate::DriverError::DeviceNotFound),
         };
 
         self.wifi_conn.connect(ssid, password);
@@ -250,7 +252,7 @@ impl IwlWifiDevice {
         log::info!("iwlwifi: disconnected");
     }
 
-    pub fn send_raw_80211_frame(&mut self, frame: &[u8]) -> Result<(), &'static str> {
+    pub fn send_raw_80211_frame(&mut self, frame: &[u8]) -> Result<(), crate::DriverError> {
         self.tx_queue.push_back(frame.to_vec());
         self.process_tx_queue();
         Ok(())
@@ -631,19 +633,19 @@ impl crate::wifi::WifiDriver for IwlWifiDevice {
         self.ip_address
     }
 
-    fn load_firmware(&mut self, fw_data: &[u8]) -> Result<(), &'static str> {
+    fn load_firmware(&mut self, fw_data: &[u8]) -> Result<(), crate::DriverError> {
         IwlWifiDevice::load_firmware(self, fw_data)
     }
 
-    fn start_firmware(&mut self, fw_data: &[u8]) -> Result<(), &'static str> {
+    fn start_firmware(&mut self, fw_data: &[u8]) -> Result<(), crate::DriverError> {
         IwlWifiDevice::start_firmware(self, fw_data)
     }
 
-    fn check_alive_nonblocking(&mut self, start_tsc: u64) -> Result<bool, &'static str> {
+    fn check_alive_nonblocking(&mut self, start_tsc: u64) -> Result<bool, crate::DriverError> {
         IwlWifiDevice::check_alive_nonblocking(self, start_tsc)
     }
 
-    fn send_init_commands(&mut self) -> Result<(), &'static str> {
+    fn send_init_commands(&mut self) -> Result<(), crate::DriverError> {
         IwlWifiDevice::send_init_commands(self)
     }
 }

--- a/nitrogen/src/mmio.rs
+++ b/nitrogen/src/mmio.rs
@@ -551,10 +551,10 @@ impl DmaRegion {
         &mut self,
         ctx: &dyn DriverContext,
         device_id: u16,
-    ) -> Result<u64, &'static str> {
+    ) -> Result<u64, crate::DriverError> {
         let iova = ctx
             .dma_map(device_id, self.phys, self.len)
-            .map_err(|_| "dma_map failed")?;
+            .map_err(|_| crate::DriverError::DmaMappingFailed)?;
         self.dma_iova = iova;
         self.mapped = true;
         Ok(iova)

--- a/nitrogen/src/ps2/mouse.rs
+++ b/nitrogen/src/ps2/mouse.rs
@@ -97,15 +97,15 @@ fn mouse_port_present() -> bool {
 ///
 /// # Errors
 ///
-/// Returns an error string if any PS/2 controller command fails (e.g. the
-/// mouse does not respond) or if the mouse port is not present.
-pub fn init_mouse() -> Result<(), &'static str> {
+/// Returns a typed driver error if a PS/2 controller command fails or if the
+/// mouse port is not present.
+pub fn init_mouse() -> Result<(), crate::DriverError> {
     // Safety check: verify the mouse port exists before attempting init.
     // On many modern laptops (including InsydeH2O-based systems), the PS/2
     // mouse port may be absent.  Probing it anyway can hang the system.
     if !mouse_port_present() {
         log::info!("[nitrogen] PS/2 mouse port not present — skipping init");
-        return Err("Mouse port not present");
+        return Err(crate::DriverError::DeviceNotFound);
     }
 
     let mut mouse = Ps2MouseInner::new();
@@ -124,7 +124,7 @@ pub fn init_mouse() -> Result<(), &'static str> {
         }
         Err(e) => {
             log::error!("[nitrogen] PS/2 mouse: init() FAILED: {}", e);
-            Err(e)
+            Err(crate::DriverError::DeviceFault)
         }
     }
 }

--- a/nitrogen/src/storage/rtsx.rs
+++ b/nitrogen/src/storage/rtsx.rs
@@ -172,7 +172,7 @@ impl RtsxController {
             | u32::from(value)
     }
 
-    fn read_reg(&self, address: u16) -> Result<u8, &'static str> {
+    fn read_reg(&self, address: u16) -> Result<u8, crate::DriverError> {
         self.mmio.write32(
             RTSX_HAIMR,
             HAIMR_START | (u32::from(address & 0x3FFF) << 16),
@@ -186,11 +186,11 @@ impl RtsxController {
             }
         }) {
             Some(v) => Ok(v),
-            None => Err("RTSX internal register read timed out"),
+            None => Err(crate::DriverError::TimedOut),
         }
     }
 
-    fn write_reg(&self, address: u16, mask: u8, value: u8) -> Result<(), &'static str> {
+    fn write_reg(&self, address: u16, mask: u8, value: u8) -> Result<(), crate::DriverError> {
         self.mmio.write32(
             RTSX_HAIMR,
             HAIMR_START
@@ -211,14 +211,14 @@ impl RtsxController {
                 if result as u8 == value {
                     Ok(())
                 } else {
-                    Err("RTSX internal register write failed")
+                    Err(crate::DriverError::DeviceFault)
                 }
             }
-            None => Err("RTSX internal register write timed out"),
+            None => Err(crate::DriverError::TimedOut),
         }
     }
 
-    fn write_regs(&self, writes: &[(u16, u8, u8)]) -> Result<(), &'static str> {
+    fn write_regs(&self, writes: &[(u16, u8, u8)]) -> Result<(), crate::DriverError> {
         writes
             .iter()
             .try_for_each(|&(register, mask, value)| self.write_reg(register, mask, value))
@@ -228,16 +228,16 @@ impl RtsxController {
         self.mmio.read32(RTSX_BIPR) & SD_EXIST != 0
     }
 
-    fn prepare_device(&mut self) -> Result<(), &'static str> {
+    fn prepare_device(&mut self) -> Result<(), crate::DriverError> {
         if !self.device.prepare_mmio() {
-            return Err("RTSX PCI command or power transition failed");
+            return Err(crate::DriverError::DeviceFault);
         }
         self.health
             .pre_mmio_access()
-            .map_err(|_| "RTSX device is not safely accessible")
+            .map_err(|_| crate::DriverError::DeviceNotFound)
     }
 
-    fn init_hardware(&mut self) -> Result<(), &'static str> {
+    fn init_hardware(&mut self) -> Result<(), crate::DriverError> {
         crate::debug::hint(b"sd_pci");
         self.prepare_device()?;
         self.data_path =
@@ -246,7 +246,7 @@ impl RtsxController {
         self.mmio.write32(RTSX_BIER, 0);
         crate::debug::hint(b"sd_bier");
         if !self.card_present() {
-            return Err("no SD card inserted");
+            return Err(crate::DriverError::DeviceNotFound);
         }
         crate::debug::hint(b"sd_card");
 
@@ -274,7 +274,7 @@ impl RtsxController {
         Ok(())
     }
 
-    fn set_command(&self, command: u8, argument: u32) -> Result<(), &'static str> {
+    fn set_command(&self, command: u8, argument: u32) -> Result<(), crate::DriverError> {
         let bytes = argument.to_be_bytes();
         self.write_reg(SD_CMD0, 0xFF, SD_CMD_START | command)?;
         bytes
@@ -283,18 +283,18 @@ impl RtsxController {
             .try_for_each(|(index, &byte)| self.write_reg(SD_CMD1 + index as u16, 0xFF, byte))
     }
 
-    fn wait_transfer(&self, required: u8) -> Result<(), &'static str> {
+    fn wait_transfer(&self, required: u8) -> Result<(), crate::DriverError> {
         match crate::timing::poll_timeout_us(500_000, || match self.read_reg(SD_TRANSFER) {
             Ok(state) => {
                 if state & SD_TRANSFER_ERR != 0 {
-                    Some(Err("SD transfer failed"))
+                    Some(Err(crate::DriverError::Protocol))
                 } else if state & required == required {
                     Some(Ok(()))
                 } else {
                     None
                 }
             }
-            Err(_) => Some(Err("SD transfer register read error")),
+            Err(_) => Some(Err(crate::DriverError::DeviceFault)),
         }) {
             Some(Ok(())) => Ok(()),
             Some(Err(e)) => {
@@ -303,12 +303,12 @@ impl RtsxController {
             }
             None => {
                 self.stop_transfer();
-                Err("SD transfer timed out")
+                Err(crate::DriverError::TimedOut)
             }
         }
     }
 
-    fn command(&self, command: u8, argument: u32, response: u8) -> Result<u32, &'static str> {
+    fn command(&self, command: u8, argument: u32, response: u8) -> Result<u32, crate::DriverError> {
         self.set_command(command, argument)?;
         self.write_regs(&[
             (SD_CFG2, 0xFF, response),
@@ -325,7 +325,7 @@ impl RtsxController {
             *byte = self.read_reg(SD_CMD1 + index as u16)?;
         }
         if self.read_reg(SD_STAT1)? & 0x80 != 0 && response != SD_RSP_R3 {
-            return Err("SD response CRC error");
+            return Err(crate::DriverError::Protocol);
         }
         Ok(u32::from_be_bytes(bytes))
     }
@@ -336,15 +336,15 @@ impl RtsxController {
         command: u8,
         argument: u32,
         response: u8,
-    ) -> Result<u32, &'static str> {
+    ) -> Result<u32, crate::DriverError> {
         let r1 = self.command(CMD55_APP_CMD, u32::from(rca) << 16, SD_RSP_R1)?;
         if r1 & (1 << 5) == 0 {
-            return Err("card rejected APP_CMD");
+            return Err(crate::DriverError::Protocol);
         }
         self.command(command, argument, response)
     }
 
-    fn long_response(&self) -> Result<[u8; 16], &'static str> {
+    fn long_response(&self) -> Result<[u8; 16], crate::DriverError> {
         let mut raw = [0; 17];
         for (index, byte) in raw[..16].iter_mut().enumerate() {
             *byte = self.read_reg(PPBUF_BASE2 + index as u16)?;
@@ -355,7 +355,7 @@ impl RtsxController {
         Ok(response)
     }
 
-    fn set_data_len(&self) -> Result<(), &'static str> {
+    fn set_data_len(&self) -> Result<(), crate::DriverError> {
         self.write_regs(&[
             (SD_BYTE_CNT_L, 0xFF, 0),
             (SD_BYTE_CNT_H, 0xFF, 2),
@@ -364,18 +364,18 @@ impl RtsxController {
         ])
     }
 
-    fn run_host_commands(&mut self, count: usize) -> Result<(), &'static str> {
+    fn run_host_commands(&mut self, count: usize) -> Result<(), crate::DriverError> {
         let bytes = count
             .checked_mul(size_of::<u32>())
             .filter(|&bytes| bytes != 0 && bytes <= HOST_COMMAND_BUFFER_SIZE)
-            .ok_or("RTSX host command overflow")?;
+            .ok_or(crate::DriverError::InvalidArgument)?;
         let iova = {
             let commands = self
                 .host_commands
                 .as_ref()
-                .ok_or("RTSX host command buffer unavailable")?;
+                .ok_or(crate::DriverError::OutOfMemory)?;
             commands.flush_for_device();
-            u32::try_from(commands.dma_iova()).map_err(|_| "RTSX command address exceeds 32-bit")?
+            u32::try_from(commands.dma_iova()).map_err(|_| crate::DriverError::DmaMappingFailed)?
         };
 
         self.mmio.write32(RTSX_BIPR, TRANS_OK_INT | TRANS_FAIL_INT);
@@ -389,11 +389,11 @@ impl RtsxController {
         let result = crate::timing::poll_timeout_us(250_000, || {
             let status = self.mmio.read32(RTSX_BIPR);
             (status & TRANS_FAIL_INT != 0)
-                .then_some(Err("RTSX host command failed"))
+                .then_some(Err(crate::DriverError::DeviceFault))
                 .or_else(|| (status & TRANS_OK_INT != 0).then_some(Ok(())))
         });
         self.mmio.write32(RTSX_BIPR, TRANS_OK_INT | TRANS_FAIL_INT);
-        let result = result.unwrap_or(Err("RTSX host command timed out"));
+        let result = result.unwrap_or(Err(crate::DriverError::TimedOut));
         if result.is_err() {
             self.stop_transfer();
         }
@@ -418,22 +418,28 @@ impl RtsxController {
         self.mmio.write32(RTSX_BIPR, TRANS_OK_INT | TRANS_FAIL_INT);
     }
 
-    fn run_register_commands(&mut self, commands: &[RegisterCommand]) -> Result<(), &'static str> {
+    fn run_register_commands(
+        &mut self,
+        commands: &[RegisterCommand],
+    ) -> Result<(), crate::DriverError> {
         self.load_register_commands(commands)?;
         self.run_host_commands(commands.len())
     }
 
-    fn load_register_commands(&mut self, commands: &[RegisterCommand]) -> Result<(), &'static str> {
+    fn load_register_commands(
+        &mut self,
+        commands: &[RegisterCommand],
+    ) -> Result<(), crate::DriverError> {
         commands
             .len()
             .checked_mul(size_of::<u32>())
             .filter(|&bytes| bytes != 0 && bytes <= HOST_COMMAND_BUFFER_SIZE)
-            .ok_or("RTSX host command overflow")?;
+            .ok_or(crate::DriverError::InvalidArgument)?;
         {
             let command_buffer = self
                 .host_commands
                 .as_mut()
-                .ok_or("RTSX host command buffer unavailable")?;
+                .ok_or(crate::DriverError::OutOfMemory)?;
             for (slot, &(kind, address, mask, value)) in command_buffer
                 .as_mut_slice()
                 .chunks_exact_mut(size_of::<u32>())
@@ -445,14 +451,14 @@ impl RtsxController {
         Ok(())
     }
 
-    fn dma_iova(region: &Option<DmaRegion>) -> Result<u32, &'static str> {
+    fn dma_iova(region: &Option<DmaRegion>) -> Result<u32, crate::DriverError> {
         u32::try_from(
             region
                 .as_ref()
-                .ok_or("RTSX DMA buffer unavailable")?
+                .ok_or(crate::DriverError::DmaMappingFailed)?
                 .dma_iova(),
         )
-        .map_err(|_| "RTSX DMA address exceeds 32-bit")
+        .map_err(|_| crate::DriverError::DmaMappingFailed)
     }
 
     fn data_dma_control(device_to_host: bool) -> u32 {
@@ -469,7 +475,7 @@ impl RtsxController {
         &mut self,
         commands: &[RegisterCommand],
         device_to_host: bool,
-    ) -> Result<(), &'static str> {
+    ) -> Result<(), crate::DriverError> {
         self.load_register_commands(commands)?;
         let bytes = (commands.len() * size_of::<u32>()) as u32;
         let command_iova = Self::dma_iova(&self.host_commands)?;
@@ -477,12 +483,12 @@ impl RtsxController {
 
         self.host_commands
             .as_ref()
-            .ok_or("RTSX host command buffer unavailable")?
+            .ok_or(crate::DriverError::OutOfMemory)?
             .flush_for_device();
         if device_to_host {
             self.data_buffer
                 .as_ref()
-                .ok_or("RTSX data buffer unavailable")?
+                .ok_or(crate::DriverError::OutOfMemory)?
                 .flush_for_device();
         }
 
@@ -499,10 +505,10 @@ impl RtsxController {
         let result = crate::timing::poll_timeout_us(1_000_000, || {
             let status = self.mmio.read32(RTSX_BIPR);
             (status & TRANS_FAIL_INT != 0)
-                .then_some(Err("RTSX data DMA failed"))
+                .then_some(Err(crate::DriverError::DeviceFault))
                 .or_else(|| (status & TRANS_OK_INT != 0).then_some(Ok(())))
         })
-        .unwrap_or(Err("RTSX data DMA timed out"));
+        .unwrap_or(Err(crate::DriverError::TimedOut));
         self.mmio.write32(RTSX_BIPR, TRANS_OK_INT | TRANS_FAIL_INT);
         if result.is_err() {
             self.stop_transfer();
@@ -615,14 +621,14 @@ impl RtsxController {
         Self::data_dma_commands(DMA_TO_CARD, SD_WRITE_CONFIG, SD_TM_AUTO_WRITE_3)
     }
 
-    fn ppbuf_read_fast(&mut self, buffer: &mut [u8]) -> Result<(), &'static str> {
+    fn ppbuf_read_fast(&mut self, buffer: &mut [u8]) -> Result<(), crate::DriverError> {
         for (chunk_index, output) in buffer.chunks_mut(HOST_COMMAND_CHUNK).enumerate() {
             let first_register = PPBUF_BASE2 + (chunk_index * HOST_COMMAND_CHUNK) as u16;
             {
                 let command_buffer = self
                     .host_commands
                     .as_mut()
-                    .ok_or("RTSX host command buffer unavailable")?;
+                    .ok_or(crate::DriverError::OutOfMemory)?;
                 for (index, command) in command_buffer
                     .as_mut_slice()
                     .chunks_exact_mut(size_of::<u32>())
@@ -644,7 +650,7 @@ impl RtsxController {
             let command_buffer = self
                 .host_commands
                 .as_ref()
-                .ok_or("RTSX host command buffer unavailable")?;
+                .ok_or(crate::DriverError::OutOfMemory)?;
             command_buffer.flush_for_cpu();
             // AUTO_RESPONSE packs one byte per READ_REG at the start of the
             // command buffer; responses do not remain in their u32 slots.
@@ -654,21 +660,21 @@ impl RtsxController {
         Ok(())
     }
 
-    fn ppbuf_read_pio(&self, buffer: &mut [u8]) -> Result<(), &'static str> {
+    fn ppbuf_read_pio(&self, buffer: &mut [u8]) -> Result<(), crate::DriverError> {
         buffer.iter_mut().enumerate().try_for_each(|(index, byte)| {
             *byte = self.read_reg(PPBUF_BASE2 + index as u16)?;
             Ok(())
         })
     }
 
-    fn ppbuf_write_fast(&mut self, buffer: &[u8]) -> Result<(), &'static str> {
+    fn ppbuf_write_fast(&mut self, buffer: &[u8]) -> Result<(), crate::DriverError> {
         for (chunk_index, input) in buffer.chunks(HOST_COMMAND_CHUNK).enumerate() {
             let first_register = PPBUF_BASE2 + (chunk_index * HOST_COMMAND_CHUNK) as u16;
             {
                 let command_buffer = self
                     .host_commands
                     .as_mut()
-                    .ok_or("RTSX host command buffer unavailable")?;
+                    .ok_or(crate::DriverError::OutOfMemory)?;
                 for (index, (command, &value)) in command_buffer
                     .as_mut_slice()
                     .chunks_exact_mut(size_of::<u32>())
@@ -691,14 +697,14 @@ impl RtsxController {
         Ok(())
     }
 
-    fn ppbuf_write_pio(&self, buffer: &[u8]) -> Result<(), &'static str> {
+    fn ppbuf_write_pio(&self, buffer: &[u8]) -> Result<(), crate::DriverError> {
         buffer
             .iter()
             .enumerate()
             .try_for_each(|(index, &byte)| self.write_reg(PPBUF_BASE2 + index as u16, 0xFF, byte))
     }
 
-    fn read_sector_pio(&self, argument: u32, buffer: &mut [u8]) -> Result<(), &'static str> {
+    fn read_sector_pio(&self, argument: u32, buffer: &mut [u8]) -> Result<(), crate::DriverError> {
         self.set_command(CMD17_READ_SINGLE, argument)?;
         self.set_data_len()?;
         self.write_regs(&[
@@ -714,13 +720,13 @@ impl RtsxController {
         &mut self,
         argument: u32,
         buffer: &mut [u8],
-    ) -> Result<(), &'static str> {
+    ) -> Result<(), crate::DriverError> {
         self.run_register_commands(&Self::read_sector_commands(argument))?;
         self.wait_transfer(SD_TRANSFER_END)?;
         self.ppbuf_read_fast(buffer)
     }
 
-    fn write_sector_pio(&self, buffer: &[u8]) -> Result<(), &'static str> {
+    fn write_sector_pio(&self, buffer: &[u8]) -> Result<(), crate::DriverError> {
         self.ppbuf_write_pio(buffer)?;
         self.set_data_len()?;
         self.write_regs(&[
@@ -730,13 +736,13 @@ impl RtsxController {
         self.wait_transfer(SD_TRANSFER_END)
     }
 
-    fn write_sector_host_ppbuf(&mut self, buffer: &[u8]) -> Result<(), &'static str> {
+    fn write_sector_host_ppbuf(&mut self, buffer: &[u8]) -> Result<(), crate::DriverError> {
         self.ppbuf_write_fast(buffer)?;
         self.run_register_commands(&Self::write_sector_commands())?;
         self.wait_transfer(SD_TRANSFER_END)
     }
 
-    pub fn init_sd_card(&mut self) -> Result<(), &'static str> {
+    pub fn init_sd_card(&mut self) -> Result<(), crate::DriverError> {
         // A registered card is already in transfer state. Sending CMD0 and
         // ACMD41 again without a removal/power-cycle resets the protocol under
         // a live block device and is known to time out on RTS5249 hardware.
@@ -762,7 +768,7 @@ impl RtsxController {
             () => {
                 if unsafe { core::arch::x86_64::_rdtsc() }.wrapping_sub(start_tsc) >= duration_ticks
                 {
-                    return Err("SD init timed out");
+                    return Err(crate::DriverError::TimedOut);
                 }
             };
         }
@@ -784,7 +790,7 @@ impl RtsxController {
                 _ => None,
             }
         })
-        .ok_or("ACMD41 timed out")?;
+        .ok_or(crate::DriverError::TimedOut)?;
         let block_addressed = ocr & (1 << 30) != 0;
 
         self.command(CMD2_ALL_SEND_CID, 0, SD_RSP_R2)?;
@@ -794,7 +800,7 @@ impl RtsxController {
         let rca = (self.command(CMD3_SEND_RELATIVE_ADDR, 0, SD_RSP_R1)? >> 16) as u16;
         check_timeout!();
         if rca == 0 {
-            return Err("card returned RCA zero");
+            return Err(crate::DriverError::InvalidArgument);
         }
         self.command(CMD9_SEND_CSD, u32::from(rca) << 16, SD_RSP_R2)?;
         check_timeout!();
@@ -842,7 +848,7 @@ impl RtsxController {
         Ok(())
     }
 
-    fn parse_csd(csd: &[u8; 16], block_addressed: bool) -> Result<u64, &'static str> {
+    fn parse_csd(csd: &[u8; 16], block_addressed: bool) -> Result<u64, crate::DriverError> {
         if block_addressed {
             let c_size =
                 (u32::from(csd[7] & 0x3F) << 16) | (u32::from(csd[8]) << 8) | u32::from(csd[9]);
@@ -851,7 +857,7 @@ impl RtsxController {
 
         let block_len = 1u64
             .checked_shl(u32::from(csd[5] & 0x0F))
-            .ok_or("invalid CSD block length")?;
+            .ok_or(crate::DriverError::InvalidArgument)?;
         let c_size =
             (u32::from(csd[6] & 3) << 10) | (u32::from(csd[7]) << 2) | u32::from(csd[8] >> 6);
         let multiplier = 1u64 << (u32::from((csd[9] & 3) << 1 | csd[10] >> 7) + 2);
@@ -859,22 +865,24 @@ impl RtsxController {
             .checked_mul(multiplier)
             .and_then(|blocks| blocks.checked_mul(block_len))
             .map(|bytes| bytes / 512)
-            .ok_or("CSD capacity overflow")
+            .ok_or(crate::DriverError::InvalidArgument)
     }
 
-    fn card_address(&self, lba: u32) -> Result<u32, &'static str> {
+    fn card_address(&self, lba: u32) -> Result<u32, crate::DriverError> {
         match self
             .sd_card
             .as_ref()
-            .ok_or("no initialized card")?
+            .ok_or(crate::DriverError::NotReady)?
             .card_type
         {
-            SdCardType::Sdsc => lba.checked_mul(512).ok_or("LBA overflow"),
+            SdCardType::Sdsc => lba
+                .checked_mul(512)
+                .ok_or(crate::DriverError::InvalidArgument),
             SdCardType::Sdhc | SdCardType::Sdxc => Ok(lba),
         }
     }
 
-    fn read_sector(&mut self, lba: u32, buffer: &mut [u8]) -> Result<(), &'static str> {
+    fn read_sector(&mut self, lba: u32, buffer: &mut [u8]) -> Result<(), crate::DriverError> {
         let argument = self.card_address(lba)?;
         loop {
             match self.data_path {
@@ -883,7 +891,7 @@ impl RtsxController {
                         Ok(()) => {
                             self.data_buffer
                                 .as_ref()
-                                .ok_or("RTSX data buffer unavailable")?
+                                .ok_or(crate::DriverError::OutOfMemory)?
                                 .read_into(buffer);
                             return Ok(());
                         }
@@ -906,8 +914,12 @@ impl RtsxController {
         }
     }
 
-    fn write_sector(&mut self, lba: u32, buffer: &[u8]) -> Result<(), &'static str> {
-        let rca = self.sd_card.as_ref().ok_or("no initialized card")?.rca;
+    fn write_sector(&mut self, lba: u32, buffer: &[u8]) -> Result<(), crate::DriverError> {
+        let rca = self
+            .sd_card
+            .as_ref()
+            .ok_or(crate::DriverError::NotReady)?
+            .rca;
         let argument = self.card_address(lba)?;
         loop {
             self.command(CMD24_WRITE_SINGLE, argument, SD_RSP_R1)?;
@@ -915,7 +927,7 @@ impl RtsxController {
                 DataPath::Sdma => {
                     self.data_buffer
                         .as_mut()
-                        .ok_or("RTSX data buffer unavailable")?
+                        .ok_or(crate::DriverError::OutOfMemory)?
                         .write_from(buffer);
                     match self.run_data_dma(&Self::write_sector_dma_commands(), false) {
                         Ok(()) => break,
@@ -948,7 +960,7 @@ impl RtsxController {
         {
             return Ok(());
         }
-        Err("card programming timed out")
+        Err(crate::DriverError::TimedOut)
     }
 
     pub fn read_sectors(
@@ -956,17 +968,23 @@ impl RtsxController {
         lba: u32,
         count: u16,
         buffer: &mut [u8],
-    ) -> Result<(), &'static str> {
+    ) -> Result<(), crate::DriverError> {
         self.prepare_device()?;
         let bytes = usize::from(count)
             .checked_mul(512)
-            .ok_or("sector count overflow")?;
-        let destination = buffer.get_mut(..bytes).ok_or("read buffer too small")?;
+            .ok_or(crate::DriverError::InvalidArgument)?;
+        let destination = buffer
+            .get_mut(..bytes)
+            .ok_or(crate::DriverError::InvalidArgument)?;
         destination
             .chunks_exact_mut(512)
             .enumerate()
             .try_for_each(|(index, sector)| {
-                self.read_sector(lba.checked_add(index as u32).ok_or("LBA overflow")?, sector)
+                self.read_sector(
+                    lba.checked_add(index as u32)
+                        .ok_or(crate::DriverError::InvalidArgument)?,
+                    sector,
+                )
             })
     }
 
@@ -975,17 +993,23 @@ impl RtsxController {
         lba: u32,
         count: u16,
         buffer: &[u8],
-    ) -> Result<(), &'static str> {
+    ) -> Result<(), crate::DriverError> {
         self.prepare_device()?;
         let bytes = usize::from(count)
             .checked_mul(512)
-            .ok_or("sector count overflow")?;
-        let source = buffer.get(..bytes).ok_or("write buffer too small")?;
+            .ok_or(crate::DriverError::InvalidArgument)?;
+        let source = buffer
+            .get(..bytes)
+            .ok_or(crate::DriverError::InvalidArgument)?;
         source
             .chunks_exact(512)
             .enumerate()
             .try_for_each(|(index, sector)| {
-                self.write_sector(lba.checked_add(index as u32).ok_or("LBA overflow")?, sector)
+                self.write_sector(
+                    lba.checked_add(index as u32)
+                        .ok_or(crate::DriverError::InvalidArgument)?,
+                    sector,
+                )
             })
     }
 
@@ -1090,11 +1114,11 @@ pub fn init(context: &dyn DriverContext) {
     log::info!("RTSX: RTS5249 registered; SD initialization deferred");
 }
 
-pub fn init_sd_card() -> Result<(), &'static str> {
+pub fn init_sd_card() -> Result<(), crate::DriverError> {
     CONTROLLER
         .lock()
         .as_mut()
-        .ok_or("no RTS5249 controller")?
+        .ok_or(crate::DriverError::DeviceNotFound)?
         .init_sd_card()
 }
 
@@ -1105,19 +1129,19 @@ pub fn sd_card_info() -> Option<SdCardInfo> {
         .and_then(|controller| controller.sd_card.clone())
 }
 
-pub fn read_sectors(lba: u32, count: u16, buffer: &mut [u8]) -> Result<(), &'static str> {
+pub fn read_sectors(lba: u32, count: u16, buffer: &mut [u8]) -> Result<(), crate::DriverError> {
     CONTROLLER
         .lock()
         .as_mut()
-        .ok_or("no RTS5249 controller")?
+        .ok_or(crate::DriverError::DeviceNotFound)?
         .read_sectors(lba, count, buffer)
 }
 
-pub fn write_sectors(lba: u32, count: u16, buffer: &[u8]) -> Result<(), &'static str> {
+pub fn write_sectors(lba: u32, count: u16, buffer: &[u8]) -> Result<(), crate::DriverError> {
     CONTROLLER
         .lock()
         .as_mut()
-        .ok_or("no RTS5249 controller")?
+        .ok_or(crate::DriverError::DeviceNotFound)?
         .write_sectors(lba, count, buffer)
 }
 

--- a/nitrogen/src/usb/context.rs
+++ b/nitrogen/src/usb/context.rs
@@ -380,7 +380,7 @@ impl USBContext {
     }
 
     /// Enable USB hardware without invoking polling or filesystem policy.
-    pub fn enable(&mut self) -> Result<(), &'static str> {
+    pub fn enable(&mut self) -> Result<(), crate::DriverError> {
         if self.enabled {
             return Ok(());
         }
@@ -425,17 +425,17 @@ impl USBContext {
         block_size: u32,
         buf: &mut [u8],
         tag: &mut u32,
-    ) -> Result<(), &'static str> {
+    ) -> Result<(), crate::DriverError> {
         let host: &mut dyn HostController = match ctrl_type {
             "xHCI" => {
                 if ctrl_idx >= self.controllers.xhci.len() {
-                    return Err("xHCI controller index out of bounds");
+                    return Err(crate::DriverError::InvalidArgument);
                 }
                 &mut *self.controllers.xhci[ctrl_idx]
             }
             _ => {
                 if ctrl_idx >= self.controllers.ehci.len() {
-                    return Err("EHCI controller index out of bounds");
+                    return Err(crate::DriverError::InvalidArgument);
                 }
                 &mut *self.controllers.ehci[ctrl_idx]
             }
@@ -460,17 +460,17 @@ impl USBContext {
         block_size: u32,
         buf: &[u8],
         tag: &mut u32,
-    ) -> Result<(), &'static str> {
+    ) -> Result<(), crate::DriverError> {
         let host: &mut dyn HostController = match ctrl_type {
             "xHCI" => {
                 if ctrl_idx >= self.controllers.xhci.len() {
-                    return Err("xHCI controller index out of bounds");
+                    return Err(crate::DriverError::InvalidArgument);
                 }
                 &mut *self.controllers.xhci[ctrl_idx]
             }
             _ => {
                 if ctrl_idx >= self.controllers.ehci.len() {
-                    return Err("EHCI controller index out of bounds");
+                    return Err(crate::DriverError::InvalidArgument);
                 }
                 &mut *self.controllers.ehci[ctrl_idx]
             }

--- a/nitrogen/src/usb/ehci/async_queue.rs
+++ b/nitrogen/src/usb/ehci/async_queue.rs
@@ -297,18 +297,18 @@ impl TransferContext {
     }
 
     /// Wait for a qTD to complete (active bit cleared).
-    pub fn wait_qtd(&self, qtd: &Qtd, timeout_us: u32) -> Result<(), &'static str> {
+    pub fn wait_qtd(&self, qtd: &Qtd, timeout_us: u32) -> Result<(), crate::DriverError> {
         for _ in 0..timeout_us {
             let token = unsafe { ptr::read_volatile(&qtd.token) };
             if token & QTD_ACTIVE == 0 {
                 if token & QTD_HALTED != 0 {
-                    return Err("qTD halted");
+                    return Err(crate::DriverError::Protocol);
                 }
                 return Ok(());
             }
             core::hint::spin_loop();
         }
-        Err("qTD timeout")
+        Err(crate::DriverError::TimedOut)
     }
 
     /// Reset all pools (reclaim all qH and qTD resources).

--- a/nitrogen/src/usb/ehci/context.rs
+++ b/nitrogen/src/usb/ehci/context.rs
@@ -59,11 +59,11 @@ pub struct EhciContext {
 // ============================================================================
 
 impl HostController for EhciContext {
-    fn reset(&mut self) -> Result<(), &'static str> {
+    fn reset(&mut self) -> Result<(), crate::DriverError> {
         self.reset()
     }
 
-    fn start(&mut self) -> Result<(), &'static str> {
+    fn start(&mut self) -> Result<(), crate::DriverError> {
         self.start()
     }
 
@@ -92,7 +92,7 @@ impl HostController for EhciContext {
         dev_addr: u8,
         setup: &UsbSetupPacket,
         buf: &mut [u8],
-    ) -> Result<usize, &'static str> {
+    ) -> Result<usize, crate::DriverError> {
         // Control transfers always go to endpoint 0
         self.control_transfer(dev_addr, 0, setup, buf)
     }
@@ -104,7 +104,7 @@ impl HostController for EhciContext {
         buf: &mut [u8],
         dir: UsbDirection,
         mps: u16,
-    ) -> Result<usize, &'static str> {
+    ) -> Result<usize, crate::DriverError> {
         self.bulk_transfer(dev_addr, endpoint, buf, dir, mps)
     }
 }
@@ -151,10 +151,10 @@ impl EhciContext {
     // ── Initialisation ─────────────────────────────────────────
 
     /// Reset the controller (HCRESET).
-    pub fn reset(&mut self) -> Result<(), &'static str> {
+    pub fn reset(&mut self) -> Result<(), crate::DriverError> {
         if !self.health.is_device_present() {
             log::error!("EHCI: device gone before reset");
-            return Err("EHCI device gone");
+            return Err(crate::DriverError::DeviceNotFound);
         }
         let op = &self.registers.op;
         crate::debug::hint(b"eh_rst");
@@ -172,14 +172,14 @@ impl EhciContext {
         .is_err()
             || aborted
         {
-            return Err("HCRESET timeout or device disconnected");
+            return Err(crate::DriverError::TimedOut);
         }
         crate::debug::hint(b"eh_rdy");
         Ok(())
     }
 
     /// Start the controller and enable the async schedule.
-    pub fn start(&mut self) -> Result<(), &'static str> {
+    pub fn start(&mut self) -> Result<(), crate::DriverError> {
         let op = &self.registers.op;
         crate::debug::hint(b"eh_alt");
         op.set_async_list_addr(self.transfer.schedule.head_phys as u32);
@@ -202,7 +202,7 @@ impl EhciContext {
         .is_err()
             || aborted
         {
-            return Err("EHCI start timeout or device disconnected");
+            return Err(crate::DriverError::TimedOut);
         }
 
         // Clear stale port-change status bits
@@ -348,7 +348,7 @@ impl EhciContext {
     /// and waiting for AAINT ensures the controller has flushed its cache
     /// and will no longer access the freed qH, qTDs, or staging buffers.
     /// Returns an error if AAINT does not arrive within the timeout.
-    fn wait_async_advance(&self, op: &EhciOperationalRegisters) -> Result<(), &'static str> {
+    fn wait_async_advance(&self, op: &EhciOperationalRegisters) -> Result<(), crate::DriverError> {
         // Clear any stale AAINT before ringing IAAD
         op.write_usbsts(USBSTS_AAINT);
         op.set_usbcmd_bits(USBCMD_IAAD);
@@ -362,7 +362,7 @@ impl EhciContext {
         })
         .is_err()
         {
-            return Err("async advance timeout");
+            return Err(crate::DriverError::TimedOut);
         }
         Ok(())
     }
@@ -379,15 +379,19 @@ impl EhciContext {
         endpoint: u8,
         setup: &UsbSetupPacket,
         buf: &mut [u8],
-    ) -> Result<usize, &'static str> {
+    ) -> Result<usize, crate::DriverError> {
         let is_in = (setup.bm_request_type & 0x80) != 0;
         let data_len = setup.w_length as usize;
         if data_len > 4096 {
-            return Err("control transfer data phase too large (> 4096 bytes)");
+            return Err(crate::DriverError::InvalidArgument);
         }
 
         // Allocate qH
-        let (qh, qh_phys) = self.transfer.qh_pool.allocate().ok_or("no qH")?;
+        let (qh, qh_phys) = self
+            .transfer
+            .qh_pool
+            .allocate()
+            .ok_or(crate::DriverError::OutOfMemory)?;
         let speed = self.device_speed(dev_addr);
 
         unsafe {
@@ -401,7 +405,7 @@ impl EhciContext {
             Some(val) => val,
             None => {
                 self.transfer.qh_pool.free(qh);
-                return Err("no setup qTD");
+                return Err(crate::DriverError::OutOfMemory);
             }
         };
 
@@ -412,7 +416,7 @@ impl EhciContext {
                 None => {
                     self.transfer.qtd_pool.free(qtd_setup);
                     self.transfer.qh_pool.free(qh);
-                    return Err("no data qTD");
+                    return Err(crate::DriverError::OutOfMemory);
                 }
             }
         } else {
@@ -427,7 +431,7 @@ impl EhciContext {
                     self.transfer.qtd_pool.free(d);
                 }
                 self.transfer.qh_pool.free(qh);
-                return Err("no status qTD");
+                return Err(crate::DriverError::OutOfMemory);
             }
         };
 
@@ -441,7 +445,7 @@ impl EhciContext {
                 }
                 self.transfer.qtd_pool.free(qtd_status);
                 self.transfer.qh_pool.free(qh);
-                return Err("no setup staging memory");
+                return Err(crate::DriverError::OutOfMemory);
             }
         };
         let setup_page_virt = self.driver_ctx.phys_to_virt(setup_page_phys) as *mut u8;
@@ -464,7 +468,7 @@ impl EhciContext {
                     }
                     self.transfer.qtd_pool.free(qtd_status);
                     self.transfer.qh_pool.free(qh);
-                    return Err("no data staging memory");
+                    return Err(crate::DriverError::OutOfMemory);
                 }
             }
         } else {
@@ -538,7 +542,7 @@ impl EhciContext {
 
         // Wait for completion
         let timeout = 5_000_000u32;
-        let mut result: Result<usize, &'static str> = Ok(0);
+        let mut result: Result<usize, crate::DriverError> = Ok(0);
 
         let r = self.transfer.wait_qtd(&qtd_setup, timeout);
         if r.is_err() {
@@ -601,11 +605,15 @@ impl EhciContext {
         buf: &mut [u8],
         dir: UsbDirection,
         max_packet: u16,
-    ) -> Result<usize, &'static str> {
+    ) -> Result<usize, crate::DriverError> {
         let len = buf.len().min(20480);
 
         // Allocate qH
-        let (qh, qh_phys) = self.transfer.qh_pool.allocate().ok_or("no qH")?;
+        let (qh, qh_phys) = self
+            .transfer
+            .qh_pool
+            .allocate()
+            .ok_or(crate::DriverError::OutOfMemory)?;
         let speed = self.device_speed(dev_addr);
         unsafe {
             ptr::write_volatile(
@@ -621,7 +629,7 @@ impl EhciContext {
             Some(val) => val,
             None => {
                 self.transfer.qh_pool.free(qh);
-                return Err("no qTD");
+                return Err(crate::DriverError::OutOfMemory);
             }
         };
 
@@ -632,7 +640,7 @@ impl EhciContext {
             Err(_) => {
                 self.transfer.qtd_pool.free(qtd);
                 self.transfer.qh_pool.free(qh);
-                return Err("no staging memory");
+                return Err(crate::DriverError::OutOfMemory);
             }
         };
         let staging_virt = self.driver_ctx.phys_to_virt(staging_phys) as *mut u8;

--- a/nitrogen/src/usb/host_controller.rs
+++ b/nitrogen/src/usb/host_controller.rs
@@ -32,7 +32,7 @@ pub trait HostController {
     ///
     /// xHCI controllers handle register configuration in their own `init()`
     /// method. EHCI controllers only need reset() and start().
-    fn initialize(&mut self) -> Result<(), &'static str> {
+    fn initialize(&mut self) -> Result<(), crate::DriverError> {
         self.reset()?;
         // Note: xHCI requires register and ring configuration between reset and start.
         // This is handled in XhciContext::init(), which is called by the concrete type.
@@ -41,10 +41,10 @@ pub trait HostController {
     }
 
     /// Hardware reset (HCRST / HCRESET).
-    fn reset(&mut self) -> Result<(), &'static str>;
+    fn reset(&mut self) -> Result<(), crate::DriverError>;
 
     /// Start the controller schedule (run/stop bit).
-    fn start(&mut self) -> Result<(), &'static str>;
+    fn start(&mut self) -> Result<(), crate::DriverError>;
 
     /// Scan all root-hub ports for newly-connected devices.
     /// Returns the number of new devices discovered during this call.
@@ -73,7 +73,7 @@ pub trait HostController {
         dev_addr: u8,
         setup: &UsbSetupPacket,
         buf: &mut [u8],
-    ) -> Result<usize, &'static str>;
+    ) -> Result<usize, crate::DriverError>;
 
     /// Perform a USB bulk transfer.
     ///
@@ -86,7 +86,7 @@ pub trait HostController {
         buf: &mut [u8],
         dir: UsbDirection,
         mps: u16,
-    ) -> Result<usize, &'static str>;
+    ) -> Result<usize, crate::DriverError>;
 }
 
 // ============================================================================

--- a/nitrogen/src/usb/hub.rs
+++ b/nitrogen/src/usb/hub.rs
@@ -17,14 +17,19 @@ use alloc::vec::Vec;
 /// Enumerate a newly connected device on the given port.
 ///
 /// `control_fn` is a callback that performs a control transfer:
-///   fn(dev_addr, endpoint, setup_packet, buffer) -> Result<usize, &'static str>
+///   fn(dev_addr, endpoint, setup_packet, buffer) -> Result<usize, crate::DriverError>
 /// `next_addr` is a mutable counter for assigning unique USB device addresses (1-127).
 ///
 /// Returns the fully enumerated UsbDevice, or an error.
 pub fn enumerate_device(
-    control_fn: &mut dyn FnMut(u8, u8, &UsbSetupPacket, &mut [u8]) -> Result<usize, &'static str>,
+    control_fn: &mut dyn FnMut(
+        u8,
+        u8,
+        &UsbSetupPacket,
+        &mut [u8],
+    ) -> Result<usize, crate::DriverError>,
     next_addr: &mut u8,
-) -> Result<UsbDevice, &'static str> {
+) -> Result<UsbDevice, crate::DriverError> {
     // Step 1: Get device descriptor (only first 8 bytes for max packet size)
     let mut desc_buf = [0u8; 64];
     let setup = UsbSetupPacket {
@@ -34,9 +39,9 @@ pub fn enumerate_device(
         w_index: 0,
         w_length: 64,
     };
-    let n = control_fn(0, 0, &setup, &mut desc_buf).map_err(|_| "GET_DESCRIPTOR failed")?;
+    let n = control_fn(0, 0, &setup, &mut desc_buf)?;
     if n < 8 {
-        return Err("descriptor too short");
+        return Err(crate::DriverError::Protocol);
     }
 
     // SAFETY: UsbDeviceDescriptor is #[repr(C, packed)]. desc_buf was filled by a
@@ -62,7 +67,7 @@ pub fn enumerate_device(
         w_index: 0,
         w_length: 0,
     };
-    control_fn(0, 0, &setup, &mut []).map_err(|_| "SET_ADDRESS failed")?;
+    control_fn(0, 0, &setup, &mut [])?;
 
     // Delay for address to take effect (USB2 spec §9.2.6.3 recommends 2ms)
     super::xhci::port::delay_ms(2);
@@ -76,8 +81,7 @@ pub fn enumerate_device(
         w_index: 0,
         w_length: 18,
     };
-    control_fn(assigned_addr, 0, &setup, &mut dev_desc_full)
-        .map_err(|_| "GET_DESCRIPTOR full failed")?;
+    control_fn(assigned_addr, 0, &setup, &mut dev_desc_full)?;
     // SAFETY: Same layout guarantee as above; dev_desc_full is exactly 18 bytes
     // (the full USB device descriptor per USB spec §9.6.1).
     let dev_desc: &UsbDeviceDescriptor =
@@ -92,8 +96,7 @@ pub fn enumerate_device(
         w_index: 0,
         w_length: 9,
     };
-    control_fn(assigned_addr, 0, &setup, &mut cfg_hdr_buf)
-        .map_err(|_| "GET_CONFIG_DESC hdr failed")?;
+    control_fn(assigned_addr, 0, &setup, &mut cfg_hdr_buf)?;
     // SAFETY: UsbConfigDescriptor is #[repr(C, packed)], the first 9 bytes of
     // every configuration descriptor match this layout per USB spec §9.6.3.
     let cfg_desc: &UsbConfigDescriptor =
@@ -109,8 +112,7 @@ pub fn enumerate_device(
         w_index: 0,
         w_length: total_len as u16,
     };
-    control_fn(assigned_addr, 0, &setup, &mut cfg_buf)
-        .map_err(|_| "GET_CONFIG_DESC full failed")?;
+    control_fn(assigned_addr, 0, &setup, &mut cfg_buf)?;
 
     // Step 6: Parse endpoints from the configuration descriptor
     let mut endpoints = Vec::new();
@@ -140,7 +142,7 @@ pub fn enumerate_device(
         w_index: 0,
         w_length: 0,
     };
-    control_fn(assigned_addr, 0, &setup, &mut []).map_err(|_| "SET_CONFIGURATION failed")?;
+    control_fn(assigned_addr, 0, &setup, &mut [])?;
 
     Ok(UsbDevice {
         address: assigned_addr,

--- a/nitrogen/src/usb/msd.rs
+++ b/nitrogen/src/usb/msd.rs
@@ -72,7 +72,7 @@ impl Csw {
 // ── Bulk callback type ────────────────────────────────────────
 // The caller provides a function that does a bulk transfer.
 pub type BulkXferFn =
-    dyn FnMut(u8, u8, &mut [u8], UsbDirection, u16) -> Result<usize, &'static str>;
+    dyn FnMut(u8, u8, &mut [u8], UsbDirection, u16) -> Result<usize, crate::DriverError>;
 
 // ── Mass Storage Device ───────────────────────────────────────
 
@@ -139,7 +139,7 @@ impl UsbMassStorage {
         cdb: &[u8],
         data: Option<&mut [u8]>,
         dir_in: bool,
-    ) -> Result<(), &'static str> {
+    ) -> Result<(), crate::DriverError> {
         let data_len = data.as_ref().map(|d| d.len() as u32).unwrap_or(0);
         let tag = self.tag;
         self.tag = self.tag.wrapping_add(1);
@@ -198,16 +198,16 @@ impl UsbMassStorage {
         // transfer of exactly 13 bytes (CSW size per BOT spec).
         let csw: &Csw = unsafe { &*(csw_buf.as_ptr() as *const Csw) };
         if csw.dCSWSignature != Csw::SIGNATURE {
-            return Err("bad CSW signature");
+            return Err(crate::DriverError::Protocol);
         }
         if csw.bCSWStatus != Csw::STATUS_SUCCESS {
-            return Err("CSW reported error");
+            return Err(crate::DriverError::Protocol);
         }
         Ok(())
     }
 
     /// Read block size and total blocks via READ_CAPACITY_10.
-    pub fn read_capacity(&mut self, xfer: &mut BulkXferFn) -> Result<(), &'static str> {
+    pub fn read_capacity(&mut self, xfer: &mut BulkXferFn) -> Result<(), crate::DriverError> {
         let cdb = ScsiReadCapacity10Cdb::new();
         // SAFETY: ScsiReadCapacity10Cdb is #[repr(C, packed)]. The CDB is exactly
         // 10 bytes per the SCSI READ_CAPACITY_10 spec.
@@ -230,10 +230,10 @@ impl UsbMassStorage {
         lba: u32,
         blocks: u16,
         buf: &mut [u8],
-    ) -> Result<(), &'static str> {
+    ) -> Result<(), crate::DriverError> {
         let expected = (blocks as u32) * self.block_size;
         if buf.len() < expected as usize {
-            return Err("buffer too small");
+            return Err(crate::DriverError::InvalidArgument);
         }
         let cdb = ScsiCdb10::read10(lba, blocks);
         // SAFETY: ScsiCdb10 is #[repr(C, packed)], exactly 10 bytes per SCSI READ_10 spec.
@@ -249,10 +249,10 @@ impl UsbMassStorage {
         lba: u32,
         blocks: u16,
         buf: &[u8],
-    ) -> Result<(), &'static str> {
+    ) -> Result<(), crate::DriverError> {
         let expected = (blocks as u32) * self.block_size;
         if buf.len() < expected as usize {
-            return Err("buffer too small");
+            return Err(crate::DriverError::InvalidArgument);
         }
         let cdb = ScsiCdb10::write10(lba, blocks);
         // SAFETY: ScsiCdb10 is #[repr(C, packed)], exactly 10 bytes per SCSI WRITE_10 spec.

--- a/nitrogen/src/usb/usb_bus.rs
+++ b/nitrogen/src/usb/usb_bus.rs
@@ -67,7 +67,7 @@ pub fn bot_exec_command(
     cdb: &[u8],
     data: Option<BotBuffer<'_>>,
     tag: &mut u32,
-) -> Result<usize, &'static str> {
+) -> Result<usize, crate::DriverError> {
     let t = *tag;
     *tag = tag.wrapping_add(1);
 
@@ -121,14 +121,14 @@ pub fn bot_exec_command(
 
     let sig = u32::from_le_bytes([csw_raw[0], csw_raw[1], csw_raw[2], csw_raw[3]]);
     if sig != CSW_SIGNATURE {
-        return Err("bad CSW signature");
+        return Err(crate::DriverError::Protocol);
     }
     let csw_tag = u32::from_le_bytes([csw_raw[4], csw_raw[5], csw_raw[6], csw_raw[7]]);
     if csw_tag != t {
-        return Err("CSW tag mismatch");
+        return Err(crate::DriverError::Protocol);
     }
     if csw_raw[12] != 0 {
-        return Err("CSW reported error");
+        return Err(crate::DriverError::Protocol);
     }
     // Compute actual bytes transferred (BOT spec §5.2.3).
     let requested = dlen as usize;
@@ -146,7 +146,7 @@ pub fn bot_read_capacity(
     ep_in: u8,
     ep_in_mps: u16,
     tag: &mut u32,
-) -> Result<(u32, u64), &'static str> {
+) -> Result<(u32, u64), crate::DriverError> {
     let mut response = [0u8; 8];
     let mut cdb = [0u8; 10];
     cdb[0] = 0x25;
@@ -162,12 +162,12 @@ pub fn bot_read_capacity(
         tag,
     )?;
     if actual != response.len() {
-        return Err("short READ CAPACITY response");
+        return Err(crate::DriverError::Protocol);
     }
     let last_lba = u32::from_be_bytes(response[..4].try_into().unwrap());
     let block_size = u32::from_be_bytes(response[4..].try_into().unwrap());
     if block_size == 0 || !block_size.is_power_of_two() || block_size > 1024 * 1024 {
-        return Err("invalid logical block size");
+        return Err(crate::DriverError::InvalidArgument);
     }
     Ok((block_size, u64::from(last_lba) + 1))
 }
@@ -185,10 +185,10 @@ pub fn bot_read_sectors(
     block_size: u32,
     buf: &mut [u8],
     tag: &mut u32,
-) -> Result<(), &'static str> {
+) -> Result<(), crate::DriverError> {
     let dlen = count as u32 * block_size;
     if buf.len() < dlen as usize {
-        return Err("buffer too small");
+        return Err(crate::DriverError::InvalidArgument);
     }
     let mut cdb = [0u8; 10];
     cdb[0] = 0x28; // READ_10
@@ -206,7 +206,7 @@ pub fn bot_read_sectors(
         tag,
     )?;
     if actual != dlen as usize {
-        return Err("short read");
+        return Err(crate::DriverError::Protocol);
     }
     Ok(())
 }
@@ -224,10 +224,10 @@ pub fn bot_write_sectors(
     block_size: u32,
     buf: &[u8],
     tag: &mut u32,
-) -> Result<(), &'static str> {
+) -> Result<(), crate::DriverError> {
     let dlen = count as u32 * block_size;
     if buf.len() < dlen as usize {
-        return Err("buffer too small");
+        return Err(crate::DriverError::InvalidArgument);
     }
     let mut cdb = [0u8; 10];
     cdb[0] = 0x2A; // WRITE_10
@@ -245,7 +245,7 @@ pub fn bot_write_sectors(
         tag,
     )?;
     if actual != dlen as usize {
-        return Err("short write");
+        return Err(crate::DriverError::Protocol);
     }
     Ok(())
 }
@@ -262,7 +262,7 @@ pub fn enumerate_mass_storage(
     host: &mut dyn HostController,
     dev_addr: u8,
     dev_idx: usize,
-) -> Result<(u8, u16, u8, u16), &'static str> {
+) -> Result<(u8, u16, u8, u16), crate::DriverError> {
     // Step 1: Get device descriptor (64 bytes for safety)
     let mut desc_buf = [0u8; 64];
     let setup = UsbSetupPacket {
@@ -274,12 +274,12 @@ pub fn enumerate_mass_storage(
     };
     let len = host.control_transfer(dev_addr, &setup, &mut desc_buf)?;
     if len < 18 {
-        return Err("descriptor too short");
+        return Err(crate::DriverError::Protocol);
     }
 
     let num_cfgs = desc_buf[17];
     if num_cfgs == 0 {
-        return Err("device has no configuration");
+        return Err(crate::DriverError::Protocol);
     }
 
     // Step 2: inspect the configuration before selecting it.
@@ -339,9 +339,9 @@ struct MassStorageConfig {
 fn parse_mass_storage_config(
     cfg_buf: &[u8],
     cfg_len: usize,
-) -> Result<MassStorageConfig, &'static str> {
+) -> Result<MassStorageConfig, crate::DriverError> {
     if cfg_len < 9 || cfg_buf.len() < 9 {
-        return Err("config too short");
+        return Err(crate::DriverError::InvalidArgument);
     }
     let total_len = u16::from_le_bytes([cfg_buf[2], cfg_buf[3]]) as usize;
     let mut offset: usize = 9;
@@ -388,7 +388,7 @@ fn parse_mass_storage_config(
         }
         offset += dlen;
     }
-    Err("no BOT mass-storage interface")
+    Err(crate::DriverError::NotSupported)
 }
 
 // EHCI-specific enumeration is in hub.rs (enumerate_device).

--- a/nitrogen/src/usb/xhci/context.rs
+++ b/nitrogen/src/usb/xhci/context.rs
@@ -250,14 +250,14 @@ impl XhciContext {
     /// A full HCRST after halting establishes the clean initial state used by
     /// the normal xHCI probe path. Port power and link training follow only
     /// after the controller data structures have been installed.
-    pub fn init(&mut self) -> Result<(), &'static str> {
+    pub fn init(&mut self) -> Result<(), crate::DriverError> {
         let hci_ver = self.registers.cap.hci_version;
         log::info!("xHCI: hci_version=0x{:04X}", hci_ver);
 
         // Phase 0: Verify device is still present before any MMIO.
         if !self.health.is_device_present() {
             log::error!("xHCI: device gone before init");
-            return Err("xHCI device gone");
+            return Err(crate::DriverError::DeviceNotFound);
         }
 
         // Match Linux's early handoff: wait until the controller accepts
@@ -268,7 +268,7 @@ impl XhciContext {
         })
         .is_err()
         {
-            return Err("controller not ready before init");
+            return Err(crate::DriverError::NotReady);
         }
 
         // Phase 1: Full HCRST.
@@ -284,7 +284,7 @@ impl XhciContext {
             })
             .is_err()
             {
-                return Err("controller failed to halt before HCRST");
+                return Err(crate::DriverError::DeviceFault);
             }
         }
 
@@ -360,12 +360,12 @@ impl XhciContext {
     }
 
     /// Reset the controller (HCRST) — public for `HostController` trait.
-    pub fn reset(&mut self) -> Result<(), &'static str> {
+    pub fn reset(&mut self) -> Result<(), crate::DriverError> {
         self.controller_reset()
     }
 
     /// Internal HCRST logic.
-    fn controller_reset(&mut self) -> Result<(), &'static str> {
+    fn controller_reset(&mut self) -> Result<(), crate::DriverError> {
         let op = &self.registers.op;
 
         let usbcmd = op.usbcmd();
@@ -392,13 +392,13 @@ impl XhciContext {
 
         if crate::timing::wait_timeout_us(500_000, || op.usbcmd() & USBCMD_HCRST == 0).is_err() {
             log::warn!("xHCI: HCRST did not clear");
-            return Err("HCRST timeout");
+            return Err(crate::DriverError::TimedOut);
         }
 
         // Wait for HCHalted
         if crate::timing::wait_timeout_us(500_000, || op.usbsts() & USBSTS_HCH != 0).is_err() {
             log::warn!("xHCI: controller did not halt after HCRST");
-            return Err("HCHalted timeout");
+            return Err(crate::DriverError::TimedOut);
         }
 
         // Wait for CNR (Controller Not Ready) to clear
@@ -406,7 +406,7 @@ impl XhciContext {
         // before accepting register writes (xHCI spec §5.4.2).
         if crate::timing::wait_timeout_us(500_000, || op.usbsts() & USBSTS_CNR == 0).is_err() {
             log::warn!("xHCI: CNR did not clear after HCRST");
-            return Err("CNR timeout");
+            return Err(crate::DriverError::TimedOut);
         }
 
         let sts_after = op.usbsts();
@@ -432,7 +432,7 @@ impl XhciContext {
 
     /// Allocate ERST (if needed) and configure runtime registers:
     /// ERSTSZ, ERSTBA, ERDP.
-    fn setup_erst(&mut self) -> Result<(), &'static str> {
+    fn setup_erst(&mut self) -> Result<(), crate::DriverError> {
         let rt = &self.registers.runtime;
         let ctx = self.driver_ctx;
         let erst_phys = if let Some(phys) = self.erst_phys {
@@ -440,7 +440,7 @@ impl XhciContext {
         } else {
             let phys = ctx
                 .allocate_contiguous_frames(1)
-                .map_err(|_| "no ERST page")?;
+                .map_err(|_| crate::DriverError::OutOfMemory)?;
             self.erst_phys = Some(phys);
             phys
         };
@@ -455,18 +455,18 @@ impl XhciContext {
     }
 
     /// Start the controller — public for `HostController` trait.
-    pub fn start(&mut self) -> Result<(), &'static str> {
+    pub fn start(&mut self) -> Result<(), crate::DriverError> {
         self.start_controller()
     }
 
     /// Start the controller (RS | HSEE) and wait for HCHalted to clear.
-    fn start_controller(&mut self) -> Result<(), &'static str> {
+    fn start_controller(&mut self) -> Result<(), crate::DriverError> {
         let op = &self.registers.op;
 
         op.set_usbcmd_bits(USBCMD_RS | USBCMD_HSEE);
         if crate::timing::wait_timeout_us(500_000, || op.usbsts() & USBSTS_HCH == 0).is_err() {
             log::error!("xHCI: controller failed to start (HCHalted)");
-            return Err("controller failed to start");
+            return Err(crate::DriverError::DeviceFault);
         }
 
         log::info!("xHCI: controller started");
@@ -694,7 +694,7 @@ impl XhciContext {
     // ── Slot management ────────────────────────────────────────
 
     /// Allocate a device slot.
-    pub fn enable_slot(&mut self) -> Result<u32, &'static str> {
+    pub fn enable_slot(&mut self) -> Result<u32, crate::DriverError> {
         let trb = Trb::new(trb_type::ENABLE_SLOT, self.rings.command.cycle);
         let flags = self.send_cmd(trb)?;
 
@@ -711,19 +711,28 @@ impl XhciContext {
     }
 
     /// Address a device.
-    pub fn address_device(&mut self, slot_id: u32, dev_idx: usize) -> Result<(), &'static str> {
+    pub fn address_device(
+        &mut self,
+        slot_id: u32,
+        dev_idx: usize,
+    ) -> Result<(), crate::DriverError> {
         let dev_addr = slot_id as u8;
 
         let port_index = self
             .devices
             .get(dev_idx)
-            .ok_or("bad device index")?
+            .ok_or(crate::DriverError::InvalidArgument)?
             .port_index;
-        let root_port = u8::try_from(port_index + 1).map_err(|_| "root port out of range")?;
+        let root_port =
+            u8::try_from(port_index + 1).map_err(|_| crate::DriverError::InvalidArgument)?;
         let speed_id = self.registers.op.portsc(port_index).speed() as u8;
 
         let ep0_ring_phys = {
-            let slot = self.device.slots.get(slot_id).ok_or("bad slot")?;
+            let slot = self
+                .device
+                .slots
+                .get(slot_id)
+                .ok_or(crate::DriverError::InvalidArgument)?;
             slot.ep0_ring.phys
         };
 
@@ -733,7 +742,11 @@ impl XhciContext {
         }
 
         let in_ctx_phys = {
-            let slot = self.device.slots.get(slot_id).ok_or("bad slot")?;
+            let slot = self
+                .device
+                .slots
+                .get(slot_id)
+                .ok_or(crate::DriverError::InvalidArgument)?;
             slot.in_ctx_phys
         };
 
@@ -762,13 +775,13 @@ impl XhciContext {
         slot_id: u32,
         ep_addr: u8,
         mps: u16,
-    ) -> Result<(), &'static str> {
+    ) -> Result<(), crate::DriverError> {
         let ep_num = (ep_addr & 0x0F) as usize;
         let is_in = (ep_addr & 0x80) != 0;
 
         // Allocate transfer ring
         let ctx = self.driver_ctx;
-        let bulk_ring = Ring::alloc(ctx, 64).ok_or("no ring")?;
+        let bulk_ring = Ring::alloc(ctx, 64).ok_or(crate::DriverError::OutOfMemory)?;
         let b_phys = bulk_ring.phys;
 
         // Context index: EP<N> Out = 2*N, EP<N> In = 2*N+1
@@ -781,7 +794,11 @@ impl XhciContext {
 
         // Get in_ctx_phys before borrowing slot mutably
         let in_ctx_phys = {
-            let slot = self.device.slots.get(slot_id).ok_or("bad slot")?;
+            let slot = self
+                .device
+                .slots
+                .get(slot_id)
+                .ok_or(crate::DriverError::InvalidArgument)?;
             slot.in_ctx_phys
         };
 
@@ -858,7 +875,7 @@ impl XhciContext {
     /// Enqueue a command TRB and wait for completion.
     /// Returns the event TRB flags on success, or an error if the
     /// event's completion code is not Success (xHCI spec §6.4.2.1).
-    fn send_cmd(&mut self, trb: Trb) -> Result<u32, &'static str> {
+    fn send_cmd(&mut self, trb: Trb) -> Result<u32, crate::DriverError> {
         self.rings.command.enqueue(trb);
         // Write barrier: ensure enqueued TRB is visible to the xHC
         // via DMA before ringing the doorbell (MMIO).  Without this,
@@ -872,13 +889,13 @@ impl XhciContext {
             trb_type::COMMAND_COMPLETION_EVENT,
         )?;
         if ev.completion_code() != COMP_SUCCESS {
-            return Err("command completion code not success");
+            return Err(crate::DriverError::Protocol);
         }
         Ok(ev.flags)
     }
 
     /// Wait for an event with timeout.
-    pub fn wait_event(&mut self, timeout: u32) -> Result<Trb, &'static str> {
+    pub fn wait_event(&mut self, timeout: u32) -> Result<Trb, crate::DriverError> {
         wait_event_type(
             &mut self.rings.event,
             &self.registers.runtime,
@@ -893,10 +910,10 @@ impl XhciContext {
 // ============================================================================
 
 impl HostController for XhciContext {
-    fn reset(&mut self) -> Result<(), &'static str> {
+    fn reset(&mut self) -> Result<(), crate::DriverError> {
         self.controller_reset()
     }
-    fn start(&mut self) -> Result<(), &'static str> {
+    fn start(&mut self) -> Result<(), crate::DriverError> {
         self.start_controller()
     }
     fn poll_ports(&mut self) -> usize {
@@ -919,7 +936,7 @@ impl HostController for XhciContext {
         dev_addr: u8,
         setup: &UsbSetupPacket,
         buf: &mut [u8],
-    ) -> Result<usize, &'static str> {
+    ) -> Result<usize, crate::DriverError> {
         self.control_transfer(dev_addr as u32, setup, buf)
     }
     fn bulk_transfer(
@@ -929,7 +946,7 @@ impl HostController for XhciContext {
         buf: &mut [u8],
         dir: UsbDirection,
         mps: u16,
-    ) -> Result<usize, &'static str> {
+    ) -> Result<usize, crate::DriverError> {
         self.bulk_transfer(dev_addr as u32, endpoint, buf, dir, mps)
     }
 }

--- a/nitrogen/src/usb/xhci/device.rs
+++ b/nitrogen/src/usb/xhci/device.rs
@@ -310,21 +310,23 @@ impl SlotManager {
         &mut self,
         ctx: &dyn DriverContext,
         slot_id: u32,
-    ) -> Result<(u32, &mut Slot), &'static str> {
+    ) -> Result<(u32, &mut Slot), crate::DriverError> {
         if slot_id == 0 || slot_id > self.max_slots {
-            return Err("invalid slot ID");
+            return Err(crate::DriverError::InvalidArgument);
         }
         if self.n_used >= self.max_slots {
-            return Err("no free slots");
+            return Err(crate::DriverError::OutOfMemory);
         }
         self.n_used += 1;
 
         // Allocate device and input context pages
         let (_dev_ctx_virt, dev_ctx_phys) =
-            DeviceContext::alloc(ctx).ok_or("no device ctx page")?;
-        let (_in_ctx_virt, in_ctx_phys) = InputContext::alloc(ctx).ok_or("no input ctx page")?;
+            DeviceContext::alloc(ctx).ok_or(crate::DriverError::OutOfMemory)?;
+        let (_in_ctx_virt, in_ctx_phys) =
+            InputContext::alloc(ctx).ok_or(crate::DriverError::OutOfMemory)?;
 
-        let slot = Slot::new(ctx, slot_id, dev_ctx_phys, in_ctx_phys).ok_or("no slot resources")?;
+        let slot = Slot::new(ctx, slot_id, dev_ctx_phys, in_ctx_phys)
+            .ok_or(crate::DriverError::OutOfMemory)?;
         self.slots.push(slot);
 
         Ok((slot_id, self.slots.last_mut().unwrap()))

--- a/nitrogen/src/usb/xhci/interrupt.rs
+++ b/nitrogen/src/usb/xhci/interrupt.rs
@@ -110,7 +110,7 @@ pub fn wait_event_type(
     rt: &RuntimeRegisters,
     timeout_us: u32,
     expected_type: u8,
-) -> Result<Trb, &'static str> {
+) -> Result<Trb, crate::DriverError> {
     for _ in 0..timeout_us {
         if let Some(ev) = ev_ring.pop() {
             rt.set_erdp(ev_ring.dequeue_ptr());
@@ -121,7 +121,7 @@ pub fn wait_event_type(
             core::hint::spin_loop();
         }
     }
-    Err("event timeout")
+    Err(crate::DriverError::TimedOut)
 }
 
 /// Process all pending events on the Event Ring, calling `handler` for each.

--- a/nitrogen/src/usb/xhci/port.rs
+++ b/nitrogen/src/usb/xhci/port.rs
@@ -185,17 +185,17 @@ impl PortContext {
 ///
 /// If CCS becomes 1 during or after PR (device connected), we also
 /// wait for PED.  The full wait is bounded to ~20 s per phase.
-pub fn port_reset(op: &OperationalRegisters, port: u32) -> Result<(), &'static str> {
+pub fn port_reset(op: &OperationalRegisters, port: u32) -> Result<(), crate::DriverError> {
     let ps_raw = op.portsc(port).0;
     if ps_raw & PORTSC_CCS == 0 {
-        return Err("disconnected");
+        return Err(crate::DriverError::DeviceNotFound);
     }
 
     op.write_portsc(port, (ps_raw & !PORTSC_RW1C_MASK) | PORTSC_PR);
 
     // USB2 reset completes within 50 ms; allow 100 ms for slow hardware.
     if crate::timing::wait_timeout_us(100_000, || op.portsc(port).0 & PORTSC_PR == 0).is_err() {
-        return Err("port reset timeout");
+        return Err(crate::DriverError::TimedOut);
     }
 
     match crate::timing::poll_timeout_us(100_000, || {
@@ -209,7 +209,7 @@ pub fn port_reset(op: &OperationalRegisters, port: u32) -> Result<(), &'static s
         }
     }) {
         Some(true) => Ok(()),
-        Some(false) | None => Err("port enable timeout"),
+        Some(false) | None => Err(crate::DriverError::TimedOut),
     }
 }
 
@@ -219,23 +219,23 @@ pub fn port_reset(op: &OperationalRegisters, port: u32) -> Result<(), &'static s
 /// performs link training.  This function waits for the link to stabilise
 /// before returning; if training stalls, a single explicit RxDetect kick
 /// is attempted as a fallback.  Returns the final PORTSC value on success.
-pub fn warm_port_reset(op: &OperationalRegisters, port: u32) -> Result<PortSc, &'static str> {
+pub fn warm_port_reset(op: &OperationalRegisters, port: u32) -> Result<PortSc, crate::DriverError> {
     let ps_raw = op.portsc(port).0;
     if ps_raw & PORTSC_CCS == 0 {
-        return Err("disconnected");
+        return Err(crate::DriverError::DeviceNotFound);
     }
     let v = ps_raw & !PORTSC_RW1C_MASK;
     op.write_portsc(port, v | PORTSC_WPR);
 
     // Poll for WPR completion (WPR bit cleared by hardware)
     if crate::timing::wait_timeout_us(100_000, || op.portsc(port).0 & PORTSC_WPR == 0).is_err() {
-        return Err("warm port reset timeout: WPR not cleared");
+        return Err(crate::DriverError::TimedOut);
     }
 
     // Wait for PR (Port Reset) to clear — the xHC signals reset
     // completion by clearing both WPR and PR (xHCI 1.2 §5.4.8).
     if crate::timing::wait_timeout_us(100_000, || op.portsc(port).0 & PORTSC_PR == 0).is_err() {
-        return Err("warm port reset timeout: PR not cleared");
+        return Err(crate::DriverError::TimedOut);
     }
 
     // Clear RW1C change bits (WRC, PRC, PLC) that the hardware set
@@ -260,7 +260,7 @@ pub fn warm_port_reset(op: &OperationalRegisters, port: u32) -> Result<PortSc, &
     if let Some(result) = crate::timing::poll_timeout_us(1_200_000, || {
         let ps = op.portsc(port);
         if !ps.ccs() {
-            Some(Err("disconnected"))
+            Some(Err(crate::DriverError::DeviceNotFound))
         } else if ps.ped() {
             Some(Ok(ps))
         } else {
@@ -269,7 +269,7 @@ pub fn warm_port_reset(op: &OperationalRegisters, port: u32) -> Result<PortSc, &
     }) {
         result
     } else {
-        Err("warm port reset: enable timeout")
+        Err(crate::DriverError::TimedOut)
     }
 }
 

--- a/nitrogen/src/usb/xhci/register.rs
+++ b/nitrogen/src/usb/xhci/register.rs
@@ -537,7 +537,10 @@ pub fn parse_port_protocols(
     bitmap
 }
 
-pub fn try_legacy_handoff(mmio_base: *mut u8, ext_cap_ptr: u16) -> Result<bool, &'static str> {
+pub fn try_legacy_handoff(
+    mmio_base: *mut u8,
+    ext_cap_ptr: u16,
+) -> Result<bool, crate::DriverError> {
     const BIOS_OWNED: u32 = 1 << 16;
     const OS_OWNED: u32 = 1 << 24;
     // Preserve reserved fields, disable SMI enables, and clear RW1C events.
@@ -550,7 +553,7 @@ pub fn try_legacy_handoff(mmio_base: *mut u8, ext_cap_ptr: u16) -> Result<bool, 
     while extended_cap_in_bounds(off, 8) {
         iters += 1;
         if iters > 64 {
-            return Err("circular capability list");
+            return Err(crate::DriverError::InvalidArgument);
         }
         let ec_id = m.read32(off * 4) as u8;
         if ec_id == 1 {

--- a/nitrogen/src/usb/xhci/transfer.rs
+++ b/nitrogen/src/usb/xhci/transfer.rs
@@ -18,22 +18,26 @@ impl XhciContext {
         slot_id: u32,
         setup: &UsbSetupPacket,
         buf: &mut [u8],
-    ) -> Result<usize, &'static str> {
+    ) -> Result<usize, crate::DriverError> {
         let is_in = (setup.bm_request_type & 0x80) != 0;
         let data_len = setup.w_length as usize;
         if data_len > buf.len() {
-            return Err("control buffer too small");
+            return Err(crate::DriverError::InvalidArgument);
         }
 
         let _ep0_cycle = {
-            let slot = self.device.slots.get(slot_id).ok_or("bad slot")?;
+            let slot = self
+                .device
+                .slots
+                .get(slot_id)
+                .ok_or(crate::DriverError::InvalidArgument)?;
             slot.ep0_ring.cycle
         };
 
         let staging_phys = if data_len > 0 {
             self.driver_ctx
                 .allocate_contiguous_frames((data_len + 4095) / 4096)
-                .map_err(|_| "no staging memory")?
+                .map_err(|_| crate::DriverError::OutOfMemory)?
         } else {
             0
         };
@@ -120,7 +124,7 @@ impl XhciContext {
                     self.deferred_free_list
                         .push((staging_phys, (data_len + 4095) / 4096));
                 }
-                Err("control transfer failed")
+                Err(crate::DriverError::Protocol)
             }
         }
     }
@@ -133,9 +137,9 @@ impl XhciContext {
         buf: &mut [u8],
         dir: UsbDirection,
         _mps: u16,
-    ) -> Result<usize, &'static str> {
+    ) -> Result<usize, crate::DriverError> {
         if buf.len() > 65536 {
-            return Err("bulk transfer too large");
+            return Err(crate::DriverError::InvalidArgument);
         }
         if buf.is_empty() {
             return Ok(0);
@@ -143,13 +147,23 @@ impl XhciContext {
         let len = buf.len();
 
         {
-            let slot = self.device.slots.get(slot_id).ok_or("bad slot")?;
+            let slot = self
+                .device
+                .slots
+                .get(slot_id)
+                .ok_or(crate::DriverError::InvalidArgument)?;
             match dir {
                 UsbDirection::In => {
-                    let _ = slot.bulk_in_ring.as_ref().ok_or("no bulk in ring")?;
+                    let _ = slot
+                        .bulk_in_ring
+                        .as_ref()
+                        .ok_or(crate::DriverError::NotReady)?;
                 }
                 UsbDirection::Out => {
-                    let _ = slot.bulk_out_ring.as_ref().ok_or("no bulk out ring")?;
+                    let _ = slot
+                        .bulk_out_ring
+                        .as_ref()
+                        .ok_or(crate::DriverError::NotReady)?;
                 }
             }
         }
@@ -158,7 +172,7 @@ impl XhciContext {
         let staging_phys = self
             .driver_ctx
             .allocate_contiguous_frames(staging_pages)
-            .map_err(|_| "no staging memory")?;
+            .map_err(|_| crate::DriverError::OutOfMemory)?;
         let staging_virt = self.driver_ctx.phys_to_virt(staging_phys) as *mut u8;
 
         if dir == UsbDirection::Out {
@@ -176,7 +190,7 @@ impl XhciContext {
             if ep_is_in != dir_is_in {
                 self.driver_ctx
                     .free_contiguous_frames(staging_phys, staging_pages);
-                return Err("endpoint direction mismatch");
+                return Err(crate::DriverError::InvalidArgument);
             }
 
             let ring = match dir {
@@ -203,7 +217,7 @@ impl XhciContext {
             Ok(ev) => {
                 if !matches!(ev.completion_code(), COMP_SUCCESS | COMP_SHORT_PACKET) {
                     self.deferred_free_list.push((staging_phys, staging_pages));
-                    return Err("bulk completion code not success");
+                    return Err(crate::DriverError::Protocol);
                 }
                 let remainder = ev.remaining() as usize;
                 let xfer_len = len.saturating_sub(remainder.min(len));
@@ -218,7 +232,7 @@ impl XhciContext {
             }
             Err(_) => {
                 self.deferred_free_list.push((staging_phys, staging_pages));
-                Err("bulk transfer failed")
+                Err(crate::DriverError::Protocol)
             }
         }
     }
@@ -227,7 +241,7 @@ impl XhciContext {
     pub fn get_device_descriptor(
         &mut self,
         slot_id: u32,
-    ) -> Result<crate::usb::UsbDeviceDescriptor, &'static str> {
+    ) -> Result<crate::usb::UsbDeviceDescriptor, crate::DriverError> {
         let mut buf = [0u8; 18];
         let setup = UsbSetupPacket {
             bm_request_type: 0x80,
@@ -243,7 +257,7 @@ impl XhciContext {
     }
 
     /// Set device address.
-    pub fn set_address(&mut self, slot_id: u32, addr: u8) -> Result<(), &'static str> {
+    pub fn set_address(&mut self, slot_id: u32, addr: u8) -> Result<(), crate::DriverError> {
         let setup = UsbSetupPacket {
             bm_request_type: 0x00,
             b_request: crate::usb::REQ_SET_ADDRESS,
@@ -260,7 +274,7 @@ impl XhciContext {
         &mut self,
         slot_id: u32,
         config_value: u8,
-    ) -> Result<(), &'static str> {
+    ) -> Result<(), crate::DriverError> {
         let setup = UsbSetupPacket {
             bm_request_type: 0x00,
             b_request: crate::usb::REQ_SET_CONFIGURATION,

--- a/nitrogen/src/wifi.rs
+++ b/nitrogen/src/wifi.rs
@@ -74,19 +74,19 @@ pub trait WifiDriver: Send {
 
     /// Load firmware blob into the device.
     /// Returns `Ok(())` on success.
-    fn load_firmware(&mut self, fw_data: &[u8]) -> Result<(), &'static str>;
+    fn load_firmware(&mut self, fw_data: &[u8]) -> Result<(), crate::DriverError>;
 
     /// Start firmware upload and CPU boot without waiting for alive.
     /// Used by the step-based init to avoid blocking the render loop.
-    fn start_firmware(&mut self, fw_data: &[u8]) -> Result<(), &'static str>;
+    fn start_firmware(&mut self, fw_data: &[u8]) -> Result<(), crate::DriverError>;
 
     /// Non-blocking check if firmware has signaled alive.
     /// Returns Ok(true) if alive, Ok(false) if still waiting, Err on error/timeout.
-    fn check_alive_nonblocking(&mut self, start_tsc: u64) -> Result<bool, &'static str>;
+    fn check_alive_nonblocking(&mut self, start_tsc: u64) -> Result<bool, crate::DriverError>;
 
     /// Send post-boot init commands (TX antenna config, RXON, queue setup).
     /// Called by the step-based init after firmware alive is confirmed.
-    fn send_init_commands(&mut self) -> Result<(), &'static str>;
+    fn send_init_commands(&mut self) -> Result<(), crate::DriverError>;
 }
 
 // ── Hardware info (from PCI config space, always safe) ───────────────

--- a/petroleum/src/common/macros/system.rs
+++ b/petroleum/src/common/macros/system.rs
@@ -170,7 +170,7 @@ macro_rules! init_boot_step {
 #[macro_export]
 macro_rules! init_step {
     ($name:expr, $func:expr) => {
-        ($name, $func as fn() -> Result<(), &'static str>)
+        ($name, $func as fn() -> Result<(), $crate::SystemError>)
     };
 }
 

--- a/petroleum/src/early/mapper.rs
+++ b/petroleum/src/early/mapper.rs
@@ -95,7 +95,7 @@ impl EarlyMapper {
         phys: PhysAddr,
         flags: PageTableFlags,
         frame_allocator: &mut EarlyFrameAllocator,
-    ) -> Result<(), &'static str> {
+    ) -> Result<(), crate::MemoryError> {
         unsafe {
             let mut mapper = self.offset_mapper();
             let page = Page::<Size4KiB>::containing_address(virt);
@@ -103,7 +103,7 @@ impl EarlyMapper {
             // SAFETY: The caller ensures safety.
             mapper
                 .map_to(page, frame, flags, frame_allocator)
-                .map_err(|_| "map_4k failed")?
+                .map_err(|_| crate::MemoryError::MappingFailed)?
                 .flush();
             Ok(())
         }
@@ -120,7 +120,7 @@ impl EarlyMapper {
         page_count: u64,
         flags: PageTableFlags,
         frame_allocator: &mut EarlyFrameAllocator,
-    ) -> Result<(), &'static str> {
+    ) -> Result<(), crate::MemoryError> {
         unsafe {
             for i in 0..page_count {
                 let virt = VirtAddr::new(virt_start.as_u64() + i * 4096);
@@ -144,7 +144,7 @@ impl EarlyMapper {
         page_count: u64,
         flags: PageTableFlags,
         frame_allocator: &mut EarlyFrameAllocator,
-    ) -> Result<(), &'static str> {
+    ) -> Result<(), crate::MemoryError> {
         unsafe {
             let flags_2mb = flags | PageTableFlags::HUGE_PAGE;
             for i in 0..page_count {
@@ -158,7 +158,7 @@ impl EarlyMapper {
                 // SAFETY: Caller ensures safety.
                 mapper
                     .map_to(page, frame, flags_2mb, frame_allocator)
-                    .map_err(|_| "map_2mb failed")?
+                    .map_err(|_| crate::MemoryError::MappingFailed)?
                     .flush();
             }
             Ok(())

--- a/petroleum/src/error.rs
+++ b/petroleum/src/error.rs
@@ -27,6 +27,8 @@ pub enum MemoryError {
     NotMapped,
     /// The requested access violates mapping permissions.
     PermissionDenied,
+    /// The memory subsystem required for the operation has not been initialized.
+    NotInitialized,
 }
 
 impl fmt::Display for MemoryError {
@@ -43,6 +45,7 @@ impl fmt::Display for MemoryError {
             Self::AlreadyMapped => "memory range already mapped",
             Self::NotMapped => "memory range is not mapped",
             Self::PermissionDenied => "memory access denied",
+            Self::NotInitialized => "memory subsystem not initialized",
         })
     }
 }
@@ -55,6 +58,7 @@ impl From<MemoryError> for SystemError {
             MemoryError::MappingFailed | MemoryError::AlreadyMapped => Self::MappingFailed,
             MemoryError::UnmappingFailed | MemoryError::NotMapped => Self::UnmappingFailed,
             MemoryError::PermissionDenied => Self::PermissionDenied,
+            MemoryError::NotInitialized => Self::InternalError,
             MemoryError::InvalidAddress
             | MemoryError::InvalidAlignment
             | MemoryError::InvalidSize

--- a/petroleum/src/initializer.rs
+++ b/petroleum/src/initializer.rs
@@ -219,11 +219,11 @@ pub trait ProcessMemoryManager {
 }
 
 pub struct InitSequence<'a> {
-    steps: &'a [(&'static str, fn() -> Result<(), &'static str>)],
+    steps: &'a [(&'static str, fn() -> Result<(), crate::SystemError>)],
 }
 
 impl<'a> InitSequence<'a> {
-    pub fn new(steps: &'a [(&'static str, fn() -> Result<(), &'static str>)]) -> Self {
+    pub fn new(steps: &'a [(&'static str, fn() -> Result<(), crate::SystemError>)]) -> Self {
         Self { steps }
     }
 
@@ -234,7 +234,7 @@ impl<'a> InitSequence<'a> {
 
             if let Err(e) = init_fn() {
                 crate::write_serial_bytes(0x3F8, 0x3FD, b"DEBUG: [InitSequence] Step failed\n");
-                panic!("{}", e);
+                panic!("{:?}", e);
             }
             crate::write_serial_bytes(0x3F8, 0x3FD, b"DEBUG: [InitSequence] Step done\n");
         }

--- a/petroleum/src/page_table/kernel/direct_map.rs
+++ b/petroleum/src/page_table/kernel/direct_map.rs
@@ -14,10 +14,10 @@ use x86_64::{
 pub fn init_direct_physical_mapping(
     memory_map: &[MemoryMapDescriptor],
     allocator: &mut impl FrameAllocator<Size4KiB>,
-) -> Result<OffsetPageTable<'static>, &'static str> {
+) -> Result<OffsetPageTable<'static>, crate::MemoryError> {
     let pml4_frame = allocator
         .allocate_frame()
-        .ok_or("Failed to allocate PML4 frame")?;
+        .ok_or(crate::MemoryError::FrameAllocationFailed)?;
 
     let pml4_virt = HIGHER_HALF_OFFSET + pml4_frame.start_address().as_u64();
     unsafe {
@@ -59,7 +59,7 @@ pub fn init_direct_physical_mapping(
                                     | PageTableFlags::HUGE_PAGE,
                                 allocator,
                             )
-                            .map_err(|_| "Failed to map huge page")?
+                            .map_err(|_| crate::MemoryError::MappingFailed)?
                             .flush();
                     }
                     current_phys += 2 * 1024 * 1024;
@@ -76,7 +76,7 @@ pub fn init_direct_physical_mapping(
                                 PageTableFlags::PRESENT | PageTableFlags::WRITABLE,
                                 allocator,
                             )
-                            .map_err(|_| "Failed to map 4KiB page")?
+                            .map_err(|_| crate::MemoryError::MappingFailed)?
                             .flush();
                     }
                     current_phys += 4096;

--- a/petroleum/src/page_table/kernel/init.rs
+++ b/petroleum/src/page_table/kernel/init.rs
@@ -84,8 +84,8 @@ impl<'a> KernelMemoryOperations<'a> {
     unsafe fn allocate_zeroed_table_from(
         frame_allocator: *mut BitmapFrameAllocator,
         page_table_access_offset: VirtAddr,
-        error: &'static str,
-    ) -> Result<PhysAddr, &'static str> {
+        error: crate::MemoryError,
+    ) -> Result<PhysAddr, crate::MemoryError> {
         let frame = unsafe { &mut *frame_allocator }
             .allocate_frame()
             .ok_or(error)?;
@@ -107,7 +107,7 @@ impl<'a> KernelMemoryOperations<'a> {
         virt: VirtAddr,
         phys: PhysAddr,
         flags: PageTableFlags,
-    ) -> Result<(), &'static str> {
+    ) -> Result<(), crate::MemoryError> {
         unsafe {
             let indices = PageTableIndices::new(virt);
             let offset = self.page_table_access_offset.as_u64();
@@ -119,7 +119,7 @@ impl<'a> KernelMemoryOperations<'a> {
                 let addr = Self::allocate_zeroed_table_from(
                     frame_allocator,
                     page_table_access_offset,
-                    "4k: alloc L3 failed",
+                    crate::MemoryError::FrameAllocationFailed,
                 )?;
                 l4[indices.l4].set_addr(addr, flags | PageTableFlags::PRESENT);
                 &mut *((l4[indices.l4].addr().as_u64() + offset) as *mut PageTable)
@@ -133,7 +133,7 @@ impl<'a> KernelMemoryOperations<'a> {
                 let l2_phys = Self::allocate_zeroed_table_from(
                     frame_allocator,
                     page_table_access_offset,
-                    "4k: alloc L2 for 1GB split failed",
+                    crate::MemoryError::FrameAllocationFailed,
                 )?;
                 let l2_ref = &mut *self.table_ptr(l2_phys);
                 for j in 0..ENTRIES_PER_TABLE {
@@ -151,7 +151,7 @@ impl<'a> KernelMemoryOperations<'a> {
                 let addr = Self::allocate_zeroed_table_from(
                     frame_allocator,
                     page_table_access_offset,
-                    "4k: alloc L2 failed",
+                    crate::MemoryError::FrameAllocationFailed,
                 )?;
                 l3[indices.l3].set_addr(addr, flags | PageTableFlags::PRESENT);
                 &mut *((l3[indices.l3].addr().as_u64() + offset) as *mut PageTable)
@@ -163,7 +163,7 @@ impl<'a> KernelMemoryOperations<'a> {
                 let l1_phys = Self::allocate_zeroed_table_from(
                     frame_allocator,
                     page_table_access_offset,
-                    "4k: alloc L1 failed",
+                    crate::MemoryError::FrameAllocationFailed,
                 )?;
                 l2[indices.l2].set_addr(l1_phys, flags | PageTableFlags::PRESENT);
             } else if l2[indices.l2].flags().contains(PageTableFlags::HUGE_PAGE) {
@@ -173,7 +173,7 @@ impl<'a> KernelMemoryOperations<'a> {
                 let l1_phys = Self::allocate_zeroed_table_from(
                     frame_allocator,
                     page_table_access_offset,
-                    "4k: split L1 failed",
+                    crate::MemoryError::FrameAllocationFailed,
                 )?;
                 let l1_ref = &mut *self.table_ptr(l1_phys);
                 for j in 0..ENTRIES_PER_TABLE {
@@ -198,7 +198,7 @@ impl<'a> KernelMemoryOperations<'a> {
         phys_start: PhysAddr,
         page_count: u64,
         flags: PageTableFlags,
-    ) -> Result<(), &'static str> {
+    ) -> Result<(), crate::MemoryError> {
         for i in 0..page_count {
             let virt = VirtAddr::new(virt_start.as_u64() + i * PAGE_SIZE_4K);
             let phys = PhysAddr::new(phys_start.as_u64() + i * PAGE_SIZE_4K);
@@ -214,7 +214,7 @@ impl<'a> KernelMemoryOperations<'a> {
         phys_start: PhysAddr,
         page_count: u64,
         flags: PageTableFlags,
-    ) -> Result<(), &'static str> {
+    ) -> Result<(), crate::MemoryError> {
         unsafe {
             let flags_2mb = flags | PageTableFlags::HUGE_PAGE;
             for i in 0..page_count {
@@ -230,7 +230,7 @@ impl<'a> KernelMemoryOperations<'a> {
                     let addr = Self::allocate_zeroed_table_from(
                         frame_allocator,
                         page_table_access_offset,
-                        "huge: alloc L3 failed",
+                        crate::MemoryError::FrameAllocationFailed,
                     )?;
                     l4[indices.l4].set_addr(addr, flags | PageTableFlags::PRESENT);
                 }
@@ -241,7 +241,7 @@ impl<'a> KernelMemoryOperations<'a> {
                     let addr = Self::allocate_zeroed_table_from(
                         frame_allocator,
                         page_table_access_offset,
-                        "huge: alloc L2 failed",
+                        crate::MemoryError::FrameAllocationFailed,
                     )?;
                     l3[indices.l3].set_addr(addr, flags | PageTableFlags::PRESENT);
                 }
@@ -257,7 +257,7 @@ impl<'a> KernelMemoryOperations<'a> {
     pub unsafe fn map_bootstrap_windows(
         &mut self,
         physical_memory_offset: VirtAddr,
-    ) -> Result<(), &'static str> {
+    ) -> Result<(), crate::MemoryError> {
         unsafe {
             self.map_range_2mb_huge(
                 VirtAddr::new(0),
@@ -287,7 +287,7 @@ pub unsafe fn map_page_4k_l1(
     flags: PageTableFlags,
     frame_allocator: &mut crate::page_table::allocator::bitmap::BitmapFrameAllocator,
     phys_offset: VirtAddr,
-) -> Result<(), &'static str> {
+) -> Result<(), crate::MemoryError> {
     unsafe {
         KernelMemoryOperations::new(l4, frame_allocator, phys_offset, flags)
             .map_page_4k(virt, phys, flags)

--- a/petroleum/src/page_table/process/table.rs
+++ b/petroleum/src/page_table/process/table.rs
@@ -500,7 +500,7 @@ unsafe fn split_huge_page_2mb(
     virtual_addr: VirtAddr,
     default_flags: PageTableFlags,
     frame_allocator: &mut impl FrameAllocator<Size4KiB>,
-) -> Result<(), &'static str> {
+) -> Result<(), crate::MemoryError> {
     let phys_offset = mapper.phys_offset();
 
     // Compute the 2MB-aligned virtual address covering this page
@@ -517,7 +517,7 @@ unsafe fn split_huge_page_2mb(
 
     // L3 table
     if !l4[p4].flags().contains(PageTableFlags::PRESENT) {
-        return Err("L4 entry not present during huge page split");
+        return Err(crate::MemoryError::NotMapped);
     }
     let l3_phys = l4[p4].addr();
     let l3_virt = phys_offset + l3_phys.as_u64();
@@ -525,14 +525,14 @@ unsafe fn split_huge_page_2mb(
 
     // L2 entry
     if !l3[p3].flags().contains(PageTableFlags::PRESENT) {
-        return Err("L3 entry not present during huge page split");
+        return Err(crate::MemoryError::NotMapped);
     }
     let l2_phys = l3[p3].addr();
     let l2_virt = phys_offset + l2_phys.as_u64();
     let l2 = unsafe { &mut *(l2_virt.as_mut_ptr::<PageTable>()) };
 
     if !l2[p2].flags().contains(PageTableFlags::HUGE_PAGE) {
-        return Err("L2 entry is not a huge page during split");
+        return Err(crate::MemoryError::InvalidSize);
     }
 
     // Get the physical base address and flags of the existing huge page
@@ -548,7 +548,7 @@ unsafe fn split_huge_page_2mb(
     // Allocate and zero a new L1 page table
     let l1_frame = frame_allocator
         .allocate_frame()
-        .ok_or("split: alloc L1 failed")?;
+        .ok_or(crate::MemoryError::FrameAllocationFailed)?;
     let l1_phys = l1_frame.start_address();
     let l1_virt = phys_offset + l1_phys.as_u64();
     unsafe {

--- a/petroleum/src/page_table/virtual_memory.rs
+++ b/petroleum/src/page_table/virtual_memory.rs
@@ -113,7 +113,7 @@ impl VirtualMemoryContext {
         phys: u64,
         size_bytes: u64,
         preferred_virt: Option<u64>,
-    ) -> Result<u64, &'static str> {
+    ) -> Result<u64, crate::MemoryError> {
         let va = preferred_virt.unwrap_or(phys + self.physical_offset);
 
         // Record the mapping.
@@ -144,7 +144,7 @@ impl VirtualMemoryContext {
         size_bytes: u64,
         flags: PageTableFlags,
         name: &'static str,
-    ) -> Result<u64, &'static str> {
+    ) -> Result<u64, crate::MemoryError> {
         let va = phys_start + self.physical_offset;
         let l4 = unsafe { self.l4_table_mut() };
         // Build mapper from the raw L4 pointer (avoids borrowing self twice).
@@ -160,7 +160,7 @@ impl VirtualMemoryContext {
             unsafe {
                 mapper
                     .map_to(page, frame, flags, &mut self.frame_allocator)
-                    .map_err(|_| "map_identity_huge: map_to failed")?
+                    .map_err(|_| crate::MemoryError::MappingFailed)?
                     .flush();
             }
         }
@@ -185,7 +185,7 @@ impl VirtualMemoryContext {
         size_bytes: u64,
         flags: PageTableFlags,
         name: &'static str,
-    ) -> Result<(), &'static str> {
+    ) -> Result<(), crate::MemoryError> {
         let page_count = (size_bytes + 0xFFF) / 0x1000;
         let l4 = unsafe { self.l4_table_mut() };
 
@@ -202,7 +202,7 @@ impl VirtualMemoryContext {
                     &mut self.frame_allocator,
                     VirtAddr::new(self.physical_offset),
                 )
-                .map_err(|_| "map_range_4k: map_page_4k_l1 failed")?;
+                .map_err(|_| crate::MemoryError::MappingFailed)?;
             }
         }
 
@@ -219,7 +219,7 @@ impl VirtualMemoryContext {
     }
 
     /// Map a heap region (owned, writable, no-execute).
-    pub fn map_heap(&mut self, phys: u64, size_bytes: u64) -> Result<u64, &'static str> {
+    pub fn map_heap(&mut self, phys: u64, size_bytes: u64) -> Result<u64, crate::MemoryError> {
         let va = phys + self.physical_offset;
         self.map_range_4k(
             phys,
@@ -237,7 +237,7 @@ impl VirtualMemoryContext {
     pub fn direct_map_physical(
         &mut self,
         memory_map: &[crate::page_table::memory_map::MemoryMapDescriptor],
-    ) -> Result<(), &'static str> {
+    ) -> Result<(), crate::MemoryError> {
         for desc in memory_map {
             let phys = desc.physical_start();
             let size = desc.number_of_pages() as u64 * 0x1000;
@@ -260,11 +260,11 @@ impl VirtualMemoryContext {
     /// This copies the PML4 structure but preserves all existing mappings
     /// (including `.data` and `.bss` sections) unlike the previous
     /// `clone_page_table` which zeroed temporary VA ranges.
-    pub fn clone_for_process(&mut self) -> Result<VirtualMemoryContext, &'static str> {
+    pub fn clone_for_process(&mut self) -> Result<VirtualMemoryContext, crate::MemoryError> {
         let new_frame = self
             .frame_allocator
             .allocate_frame()
-            .ok_or("clone_for_process: allocate_frame failed")?;
+            .ok_or(crate::MemoryError::FrameAllocationFailed)?;
         let new_pml4_phys = new_frame.start_address().as_u64();
 
         // Copy the current L4 entries to the new table.

--- a/petroleum/src/transition.rs
+++ b/petroleum/src/transition.rs
@@ -385,16 +385,22 @@ impl WorldSwitchBuilder {
         self
     }
 
-    pub fn build(self) -> Result<WorldSwitch, &'static str> {
+    pub fn build(self) -> Result<WorldSwitch, crate::SystemError> {
         Ok(WorldSwitch {
-            load_gdt: self.load_gdt.ok_or("Missing GDT")?,
-            load_idt: self.load_idt.ok_or("Missing IDT")?,
-            page_table: self.page_table.ok_or("Missing Page Table")?,
-            phys_offset: self.phys_offset.ok_or("Missing Phys Offset")?,
-            stack_top: self.stack_top.ok_or("Missing Stack Top")?,
-            entry_point: self.entry_point.ok_or("Missing Entry Point")?,
-            kernel_args: self.kernel_args.ok_or("Missing Kernel Args")?,
-            allocator: self.allocator.ok_or("Missing Allocator")?,
+            load_gdt: self.load_gdt.ok_or(crate::SystemError::InvalidArgument)?,
+            load_idt: self.load_idt.ok_or(crate::SystemError::InvalidArgument)?,
+            page_table: self.page_table.ok_or(crate::SystemError::InvalidArgument)?,
+            phys_offset: self
+                .phys_offset
+                .ok_or(crate::SystemError::InvalidArgument)?,
+            stack_top: self.stack_top.ok_or(crate::SystemError::InvalidArgument)?,
+            entry_point: self
+                .entry_point
+                .ok_or(crate::SystemError::InvalidArgument)?,
+            kernel_args: self
+                .kernel_args
+                .ok_or(crate::SystemError::InvalidArgument)?,
+            allocator: self.allocator.ok_or(crate::SystemError::InvalidArgument)?,
         })
     }
 }

--- a/solvent/Cargo.toml
+++ b/solvent/Cargo.toml
@@ -23,6 +23,7 @@ nozzle = { path = "../nozzle" }
 lattice = { path = "../lattice" }
 resonance = { path = "../resonance" }
 chronoline = { path = "../chronoline" }
+genome = { path = "../genome" }
 log = { workspace = true }
 
 # Media format parsers

--- a/solvent/src/explorer.rs
+++ b/solvent/src/explorer.rs
@@ -356,7 +356,7 @@ impl ExplorerContext {
     pub(crate) fn finish_navigation(
         &mut self,
         path: String,
-        result: Result<Vec<VfsEntry>, &'static str>,
+        result: Result<Vec<VfsEntry>, genome::FsError>,
     ) {
         let entries = match result {
             Ok(entries) => entries,
@@ -752,27 +752,27 @@ fn unique_destination(directory: &str, name: &str) -> String {
         .unwrap_or_else(|| join_path(directory, &format!("{} - Copy{}", stem, extension)))
 }
 
-fn copy_entry(source: &str, destination: &str, is_dir: bool) -> Result<(), &'static str> {
+fn copy_entry(source: &str, destination: &str, is_dir: bool) -> Result<(), genome::FsError> {
     let copy = SOLVENT_CALLBACKS
         .lock()
         .vfs_copy
-        .ok_or("copy unavailable")?;
+        .ok_or(genome::FsError::NotSupported)?;
     copy(source, destination, is_dir)
 }
 
-fn move_entry(source: &str, destination: &str, is_dir: bool) -> Result<(), &'static str> {
+fn move_entry(source: &str, destination: &str, is_dir: bool) -> Result<(), genome::FsError> {
     let move_path = SOLVENT_CALLBACKS
         .lock()
         .vfs_move
-        .ok_or("move unavailable")?;
+        .ok_or(genome::FsError::NotSupported)?;
     move_path(source, destination, is_dir)
 }
 
-fn delete_entry(path: &str, is_dir: bool) -> Result<(), &'static str> {
+fn delete_entry(path: &str, is_dir: bool) -> Result<(), genome::FsError> {
     let remove = SOLVENT_CALLBACKS
         .lock()
         .vfs_remove
-        .ok_or("delete unavailable")?;
+        .ok_or(genome::FsError::NotSupported)?;
     remove(path, is_dir)
 }
 

--- a/solvent/src/lib.rs
+++ b/solvent/src/lib.rs
@@ -54,12 +54,12 @@ pub struct SolventCallbacks {
     pub launch_shell: Option<fn()>,
     pub heap_extend: Option<fn(usize) -> Result<(), ()>>,
     pub wall_clock: Option<fn() -> Option<(u16, u8, u8, u8, u8, u8)>>,
-    pub vfs_readdir: Option<fn(&str) -> Result<Vec<VfsEntry>, &'static str>>,
-    pub vfs_read: Option<fn(&str) -> Result<Vec<u8>, &'static str>>,
-    pub vfs_write: Option<fn(&str, &[u8]) -> Result<(), &'static str>>,
-    pub vfs_copy: Option<fn(&str, &str, bool) -> Result<(), &'static str>>,
-    pub vfs_move: Option<fn(&str, &str, bool) -> Result<(), &'static str>>,
-    pub vfs_remove: Option<fn(&str, bool) -> Result<(), &'static str>>,
+    pub vfs_readdir: Option<fn(&str) -> Result<Vec<VfsEntry>, genome::FsError>>,
+    pub vfs_read: Option<fn(&str) -> Result<Vec<u8>, genome::FsError>>,
+    pub vfs_write: Option<fn(&str, &[u8]) -> Result<(), genome::FsError>>,
+    pub vfs_copy: Option<fn(&str, &str, bool) -> Result<(), genome::FsError>>,
+    pub vfs_move: Option<fn(&str, &str, bool) -> Result<(), genome::FsError>>,
+    pub vfs_remove: Option<fn(&str, bool) -> Result<(), genome::FsError>>,
     pub process_list: Option<fn() -> Vec<ProcessEntry>>,
     pub device_list: Option<fn() -> Vec<DeviceEntry>>,
     pub mounted_drive_list: Option<fn() -> Vec<(alloc::string::String, alloc::string::String)>>,
@@ -647,7 +647,7 @@ fn service_explorer_navigation() {
     // here previously deadlocked the desktop when a directory was opened.
     let callback = SOLVENT_CALLBACKS.lock().vfs_readdir;
     let result = callback
-        .ok_or("filesystem unavailable")
+        .ok_or(genome::FsError::NotSupported)
         .and_then(|read| read(&path));
     match &result {
         Ok(entries) => nitrogen::debug_status!("Explorer", "ready: {} entries", entries.len()),

--- a/solvent/src/viewers.rs
+++ b/solvent/src/viewers.rs
@@ -12,8 +12,11 @@ const MAX_IMG_W: u32 = 1920;
 const MAX_IMG_H: u32 = 1080;
 const GLYPH_SIZE: u32 = 8;
 
-fn read_file(path: &str) -> Result<Vec<u8>, &'static str> {
-    let read_fn = SOLVENT_CALLBACKS.lock().vfs_read.ok_or("no VFS read")?;
+fn read_file(path: &str) -> Result<Vec<u8>, genome::FsError> {
+    let read_fn = SOLVENT_CALLBACKS
+        .lock()
+        .vfs_read
+        .ok_or(genome::FsError::NotSupported)?;
     read_fn(path)
 }
 

--- a/wasi_runtime/Cargo.toml
+++ b/wasi_runtime/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 wasmi = { version = "0.33", default-features = false }
 carrier = { path = "../carrier" }
+genome = { path = "../genome" }
 
 [lib]
 name = "wasi_runtime"

--- a/wasi_runtime/src/runtime.rs
+++ b/wasi_runtime/src/runtime.rs
@@ -17,8 +17,8 @@ pub fn run(
     write_stderr: fn(&[u8]),
     read_stdin: fn() -> Option<u8>,
     yield_now: fn(),
-    read_entire_file: fn(&str) -> Result<Vec<u8>, &'static str>,
-    read_directory: fn(&str) -> Result<Vec<(String, u8)>, &'static str>,
+    read_entire_file: fn(&str) -> Result<Vec<u8>, genome::FsError>,
+    read_directory: fn(&str) -> Result<Vec<(String, u8)>, genome::FsError>,
     get_monotonic_ns: fn() -> u64,
 ) -> i32 {
     let engine = Engine::default();

--- a/wasi_runtime/src/wasi.rs
+++ b/wasi_runtime/src/wasi.rs
@@ -52,8 +52,8 @@ pub struct WasiCtx {
     pub write_stderr: fn(&[u8]),
     pub read_stdin: fn() -> Option<u8>,
     pub yield_now: fn(),
-    pub read_entire_file: fn(&str) -> Result<Vec<u8>, &'static str>,
-    pub read_directory: fn(&str) -> Result<Vec<(String, u8)>, &'static str>,
+    pub read_entire_file: fn(&str) -> Result<Vec<u8>, genome::FsError>,
+    pub read_directory: fn(&str) -> Result<Vec<(String, u8)>, genome::FsError>,
     pub get_monotonic_ns: fn() -> u64,
 }
 
@@ -64,8 +64,8 @@ impl WasiCtx {
         write_stderr: fn(&[u8]),
         read_stdin: fn() -> Option<u8>,
         yield_now: fn(),
-        read_entire_file: fn(&str) -> Result<Vec<u8>, &'static str>,
-        read_directory: fn(&str) -> Result<Vec<(String, u8)>, &'static str>,
+        read_entire_file: fn(&str) -> Result<Vec<u8>, genome::FsError>,
+        read_directory: fn(&str) -> Result<Vec<(String, u8)>, genome::FsError>,
         get_monotonic_ns: fn() -> u64,
     ) -> Self {
         let args_vec: Vec<Vec<u8>> = args


### PR DESCRIPTION
# Pull Request

## Overview

Replace every `Result<..., &'static str>` boundary in the Rust workspace with typed domain errors.

- Migrates nitrogen driver, USB, Wi-Fi, IOMMU, and RTSX paths to `DriverError`.
- Migrates petroleum memory/page-table paths to `MemoryError` and initialization paths to `SystemError`.
- Makes `BlockDevice`, VFS, Solvent, and WASI callbacks use `BlockError` / `FsError`.
- Adds typed `NetError` protocol/authentication variants and a PSF2 `FontError`.
- Removes generic static-string conversion fallbacks and preserves errno/syscall mappings.
- Checks the P1-1 TODO in `docs/fullerene_todo.md`.

Closes #277

## Type of Changes

- [ ] **New feature**
- [x] **Refactoring**
- [ ] **Bug fix**
- [x] **CI/Build settings**
- [x] **Documentation**
- [ ] **Code style**
- [x] **Tests**

## Testing Instructions

### Build verification

```sh
cargo check --workspace
cargo test -p genome
cargo test -p bonder --lib
cargo test -p lattice --lib
cargo test -p nitrogen --lib
cargo test -p solvent --lib
cargo test -p wasi_runtime --lib
cargo test -p fullerene-kernel
cargo build -Z build-std=core,alloc --package fullerene-kernel --target x86_64-unknown-uefi
```

All commands above pass. `cargo test -p petroleum --features std --lib` passes 32/33 tests; the pre-existing `graphics::framebuffer_guard_tests::exposes_validated_metadata_and_mutable_pixels` expectation remains unrelated (actual stride length 12 vs expected 8).

The multiline residual search `rg -U "Result<[^;{=]*&'static str>" --glob '*.rs'` returns no matches.

## Checklist

- [x] **Code Quality**: Code follows project style guidelines and best practices
- [x] **Tests**: Relevant tests pass; typed error mapping tests were extended
- [x] **Documentation**: TODO and public error documentation updated
- [x] **Breaking Changes**: Public error return types are intentionally migrated
- [x] **Dependencies**: Solvent and WASI reuse the existing leaf `genome` error types
- [x] **Security**: No generic string fallback remains
- [x] **Performance**: Error paths remain allocation-free

## Breaking Changes

- [ ] No
- [x] Yes — fallible driver, block, VFS callback, WASI callback, and memory APIs now return typed error enums.
