### PR TITLE
Complete the shared syscall ABI contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1046,6 +1046,7 @@ dependencies = [
  "conquer-util",
  "embassy-futures",
  "embedded-graphics",
+ "fullerene-abi",
  "futures-util",
  "gimli",
  "goblin",
@@ -1638,6 +1639,7 @@ name = "toluene"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "fullerene-abi",
  "lattice",
  "petroleum",
 ]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -63,14 +63,18 @@ Carrier (I/O abstraction) ──── Lattice / Nozzle
 Shared across kernel and userspace:
 
 ```text
-petroleum (no_std library)
+fullerene-abi (no_std leaf crate, no dependencies)
+    └── syscall numbers, error codes, repr(C) DTOs, ABI capabilities
+
+petroleum (no_std support library)
     ├── page_table, memory, graphics
-    ├── syscall numbers + raw syscall instruction
+    ├── raw syscall instruction (numbers come from fullerene-abi)
     ├── VDSO layout (read-only metadata page)
     └── serial, early boot helpers
 ```
 
 New in this revision:
+- **Fullerene ABI** is the dependency-free contract shared directly by the kernel and Toluene SDK. Petroleum re-exports its typed syscall numbers for compatibility but does not own them.
 - **Genome** provides the filesystem framework (`FileSystem` trait, `Vfs` dispatcher, `MemFileSystem`) as a standalone leaf crate. The kernel re-exports Genome types and adds the singleton `VfsContext`.
 - **Carrier** provides the I/O abstraction (`Terminal` trait, pipeline, streaming `dispatch()`) as another leaf crate. Nozzle and Solvent depend on Carrier for terminal I/O and command dispatch.
 

--- a/docs/WORKSPACE.md
+++ b/docs/WORKSPACE.md
@@ -6,6 +6,8 @@ The project is structured as a Cargo workspace with the following crates:
 
 - **`fullerene-kernel`**: The core kernel. Handles hardware-policy integration, process scheduling via `SchedulerContext` (`SCHEDULER` singleton), VDSO read-only metadata pages, GUI integration, and enters the main shell loop. Its device registry leases block devices to Genome while retaining stable `/dev` identities.
 
+- **`fullerene-abi`**: A dependency-free no_std leaf crate defining typed native syscall numbers, error codes, stable `#[repr(C)]` DTOs, ABI versioning, and capability bits. Both the kernel and Toluene SDK depend on this contract directly.
+
 - **`flasks`**: The build and task runner. Builds the kernel and bootloader, creates a bootable ISO, and launches QEMU for emulation.
 
 - **`lattice`**: A no_std GUI framework providing compositing window system, desktop, window manager, scene graph, and terminal surface rendering.
@@ -20,7 +22,7 @@ The project is structured as a Cargo workspace with the following crates:
 
 - **`genome`**: A no_std file system / VFS framework providing the `FileSystem` trait, `MemFileSystem`, `Vfs` dispatcher with mount-table routing, path normalization, and typed `FsError`. The kernel crate re-exports Genome types and adds the singleton `VfsContext`.
 
-- **`petroleum`**: A no_std library providing common EFI types, page table management, graphics primitives, serial/early boot utilities, VirtIO driver helpers, syscall ABI numbers, and VDSO layout definition — used by both the kernel and user-space crates.
+- **`petroleum`**: A no_std library providing common EFI types, page table management, graphics primitives, serial/early boot utilities, VirtIO driver helpers, the raw syscall instruction, and VDSO layout definition. It re-exports syscall numbers from `fullerene-abi` for compatibility.
 
 - **`bonder`**: A no_std network protocol stack implementing Ethernet frame handling, IPv4 packet processing, and UDP socket abstraction with iwlwifi integration.
 
@@ -28,6 +30,6 @@ The project is structured as a Cargo workspace with the following crates:
 
 - **`solvent`**: An application framework providing file explorer, viewers (image/audio), menu actions, and handler infrastructure for building user-facing applications on top of Lattice and Nozzle.
 
-- **`toluene`**: Placeholder for userland components (e.g., user-space binaries). Currently minimal.
+- **`toluene`**: The user-space SDK and example binary. Its typed syscall wrappers consume the shared `fullerene-abi` contract directly.
 
 - **`rle_player`** (toluene/rle_player): An RLE-encoded video player that decodes and renders animation frames, used for the Bad Apple demo.

--- a/docs/api/fullerene-abi.md
+++ b/docs/api/fullerene-abi.md
@@ -15,9 +15,11 @@ this crate.
 - `MemoryInfo`, `TimeSpec`, `DeviceInfo`, and `WindowEvent`: fixed-layout
   `#[repr(C)]` records for pointer-based syscall arguments.
 
-Every pointer-facing type has a public `BYTE_SIZE`, native-endian serializer,
-and a compile-time size/alignment assertion. Reserved fields must be written as
-zero and retained when extending a structure.
+Every extensible pointer-facing type has a fixed `MIN_BYTE_SIZE`, a current
+`BYTE_SIZE`, a native-endian serializer, and compile-time size/alignment
+assertions. Kernels accept buffers at least as large as `MIN_BYTE_SIZE` and
+copy only the prefix that fits in the caller's buffer. Reserved fields must be
+written as zero and retained when extending a structure.
 
 ## ABI query
 

--- a/docs/api/fullerene-abi.md
+++ b/docs/api/fullerene-abi.md
@@ -1,0 +1,42 @@
+# Fullerene ABI
+
+`fullerene-abi` is the dependency-free, no_std contract between the kernel and
+user-space SDK. Kernel-only policy and raw x86 instructions do not belong in
+this crate.
+
+## Stable definitions
+
+- `SyscallNumber`: typed native syscall numbers, plus the raw compatibility
+  constants in `syscall_numbers`.
+- `SyscallErrorCode`: positive error numbers; the syscall return convention
+  negates them.
+- `AbiVersion`, `Capability`, `CapabilitySet`, and `AbiInfo`: version and
+  feature discovery.
+- `MemoryInfo`, `TimeSpec`, `DeviceInfo`, and `WindowEvent`: fixed-layout
+  `#[repr(C)]` records for pointer-based syscall arguments.
+
+Every pointer-facing type has a public `BYTE_SIZE`, native-endian serializer,
+and a compile-time size/alignment assertion. Reserved fields must be written as
+zero and retained when extending a structure.
+
+## ABI query
+
+Native syscall 0 supports two forms:
+
+```text
+syscall(AbiQuery, 0, 0, ...)                    -> packed AbiVersion
+syscall(AbiQuery, info_ptr, AbiInfo::BYTE_SIZE) -> bytes written
+```
+
+The first form preserves compatibility with the original version-only query.
+The second fills `AbiInfo`, including a capability bitset that lets newer SDKs
+detect optional kernel facilities at runtime.
+
+## Compatibility rules
+
+- Existing syscall numbers and error codes are never renumbered.
+- A DTO may grow only by consuming reserved space or appending fields.
+- Callers pass their buffer size; kernels reject buffers smaller than the
+  versioned structure they write.
+- Toluene depends on `fullerene-abi` directly. Petroleum only re-exports the
+  syscall-number type for older callers.

--- a/docs/api/fullerene-kernel.md
+++ b/docs/api/fullerene-kernel.md
@@ -8,41 +8,43 @@
 
 ## 1. Syscall ABI
 
-`petroleum::common::syscall::*`
+The stable contract is defined by `fullerene-abi`; Toluene exposes the
+user-space wrappers in `toluene::sys`.
 
 | Calling Convention |
 |---|
 | `syscall` instruction (x86-64) |
 | rax = syscall number, rdi/rsi/rdx/r10/r8/r9 = args |
-| Return value: rax, errors encoded in rax |
+| Return value: rax; failures are negative `SyscallErrorCode` values |
 
 ### Syscall numbers
 
-`petroleum/src/common/syscall.rs`:
+`fullerene_abi::SyscallNumber` is the authoritative typed list. Compatibility
+constants remain available from `fullerene_abi::syscall_numbers`.
 
-| # | Name | Description |
-|---|------|-------------|
-| 0 | `Uptime` | µs since system boot |
-| 1 | `GetPid` | Current process PID |
-| 2 | `ClockGetTime` | Wall clock time |
-| 3 | `Exit` | Terminate process |
-| 4 | `Write` | Write to fd |
-| 5 | `Read` | Read from fd |
-| 6 | `Open` | Open a file |
-| 7 | `Close` | Close an fd |
-| 8 | `Spawn` | Create a new process |
-| 9 | `WaitPid` | Wait for child process completion |
-| 10 | `Mmap` | Memory mapping |
-| 11 | `Munmap` | Unmap memory |
-| 12 | `SchedYield` | Explicit CPU yield |
-| 13 | `CreateThread` | Create a thread |
-| 14 | `ExitThread` | Terminate a thread |
-| 15 | `SendEvent` | Send an event |
-| 16 | `RecvEvent` | Receive an event |
+| Range | Area |
+|---|---|
+| 0 | ABI version and capability query |
+| 1–22 | process and basic I/O |
+| 30–39 | memory |
+| 40–49 | events |
+| 50–59 | threads |
+| 60–69 | windows |
+| 70–79 | devices |
+| 80–89 | IPC |
+| 90–99 | handles/capabilities |
+| 100–109 | clocks and timers |
+
+Syscall 0 is backwards compatible: with no arguments it returns
+`AbiVersion::CURRENT.pack()`. With a writable `AbiInfo` buffer and its size in
+the first two arguments it writes the ABI version, DTO size, native syscall
+count, and capability bitset, then returns the number of bytes written.
 
 ### Error Handling
 
-Negative return value = error (EINVAL, ENOENT, EACCES, ENOMEM, EAGAIN, ...).
+Negative return value = error. The positive codes are fixed by
+`fullerene_abi::SyscallErrorCode` and align with Linux errno values where
+possible.
 
 ---
 

--- a/docs/fullerene_todo.md
+++ b/docs/fullerene_todo.md
@@ -62,9 +62,9 @@ You may close them using the "Development" section of the PR, or create new issu
 - [x] Remove `Result<..., &'static str>` usage (~200+ sites across kernel/nitrogen/genome) ([#277](https://github.com/p14c31355/fullerene/issues/277))
 
 ### P1-2. Syscall ABI crate (`fullerene-abi`)
-- [ ] Extract syscall numbers, error codes, `#[repr(C)]` DTOs into leaf crate
-- [ ] Both kernel and SDK depend on the shared crate
-- [ ] `AbiVersion` / capability query syscall
+- [x] Extract syscall numbers, error codes, `#[repr(C)]` DTOs into leaf crate ([#279](https://github.com/p14c31355/fullerene/issues/279))
+- [x] Both kernel and SDK depend on the shared crate ([#279](https://github.com/p14c31355/fullerene/issues/279))
+- [x] `AbiVersion` / capability query syscall ([#279](https://github.com/p14c31355/fullerene/issues/279))
 
 ### P1-3. Module splitting by context boundary
 - [ ] Split `drivers/fat.rs` → `block_device`, `partition`, `cache`, `fat32`, `exfat`

--- a/fullerene-abi/src/lib.rs
+++ b/fullerene-abi/src/lib.rs
@@ -1,98 +1,315 @@
 #![no_std]
 
-/// Syscall numbers for the Fullerene native ABI.
-pub mod syscall_numbers {
-    // ABI version query
-    pub const ABI_VERSION: u64 = 0;
+//! Stable data types shared by the Fullerene kernel and user-space SDK.
+//!
+//! This crate intentionally has no dependencies. Everything that crosses the
+//! syscall boundary lives here so the kernel and SDK cannot silently drift.
 
-    // Basic (1-22)
-    pub const EXIT: u64 = 1;
-    pub const FORK: u64 = 2;
-    pub const READ: u64 = 3;
-    pub const WRITE: u64 = 4;
-    pub const OPEN: u64 = 5;
-    pub const CLOSE: u64 = 6;
-    pub const WAIT: u64 = 7;
-    pub const GETPID: u64 = 20;
-    pub const GET_PROCESS_NAME: u64 = 21;
-    pub const YIELD: u64 = 22;
+use core::convert::TryFrom;
 
-    // Memory (30-39)
-    pub const MAP_MEMORY: u64 = 30;
-    pub const UNMAP_MEMORY: u64 = 31;
-    pub const PROTECT_MEMORY: u64 = 32;
-    pub const QUERY_MEMORY: u64 = 33;
-
-    // Event (40-49)
-    pub const CREATE_EVENT: u64 = 40;
-    pub const WAIT_EVENT: u64 = 41;
-    pub const SIGNAL_EVENT: u64 = 42;
-    pub const SUBSCRIBE_EVENT: u64 = 43;
-
-    // Thread (50-59)
-    pub const CREATE_THREAD: u64 = 50;
-    pub const JOIN_THREAD: u64 = 51;
-    pub const DETACH_THREAD: u64 = 52;
-    pub const EXIT_THREAD: u64 = 53;
-
-    // Window (60-69)
-    pub const CREATE_WINDOW: u64 = 60;
-    pub const DESTROY_WINDOW: u64 = 61;
-    pub const RESIZE_WINDOW: u64 = 62;
-    pub const PRESENT_WINDOW: u64 = 63;
-    pub const GET_WINDOW_EVENT: u64 = 64;
-
-    // Device (70-79)
-    pub const ENUMERATE_DEVICES: u64 = 70;
-    pub const OPEN_DEVICE: u64 = 71;
-    pub const DEVICE_IOCTL: u64 = 72;
-
-    // IPC (80-89)
-    pub const CHANNEL_CREATE: u64 = 80;
-    pub const CHANNEL_SEND: u64 = 81;
-    pub const CHANNEL_RECV: u64 = 82;
-    pub const PIPE_CREATE: u64 = 83;
-
-    // Handle/Cap (90-99)
-    pub const HANDLE_TRANSFER: u64 = 90;
-    pub const HANDLE_DUPLICATE: u64 = 91;
-    pub const HANDLE_REVOKE: u64 = 92;
-
-    // Time (100-109)
-    pub const CLOCK_GETTIME: u64 = 100;
-    pub const TIMER_CREATE: u64 = 101;
-    pub const SLEEP: u64 = 102;
-    pub const UPTIME: u64 = 103;
-}
-
-/// Syscall error codes (aligned with Linux errno values for compatibility).
-pub mod syscall_errors {
-    pub const INVALID_SYSCALL: i64 = 1;
-    pub const FILE_NOT_FOUND: i64 = 2;
-    pub const NO_SUCH_PROCESS: i64 = 3;
-    pub const IO_ERROR: i64 = 5;
-    pub const BAD_FILE_DESCRIPTOR: i64 = 9;
-    pub const AGAIN: i64 = 11;
-    pub const OUT_OF_MEMORY: i64 = 12;
-    pub const PERMISSION_DENIED: i64 = 13;
-    pub const ADDRESS_FAULT: i64 = 14;
-    pub const BUSY: i64 = 16;
-    pub const ALREADY_EXISTS: i64 = 17;
-    pub const NO_SUCH_DEVICE: i64 = 19;
-    pub const NOT_A_DIRECTORY: i64 = 20;
-    pub const IS_A_DIRECTORY: i64 = 21;
-    pub const INVALID_ARGUMENT: i64 = 22;
-    pub const NO_SPACE: i64 = 28;
-    pub const DIRECTORY_NOT_EMPTY: i64 = 39;
-    pub const OVERFLOW: i64 = 75;
-    pub const NOT_SUPPORTED: i64 = 95;
-    pub const BAD_HANDLE: i64 = 104;
-    pub const TIMED_OUT: i64 = 110;
-    pub const WOULD_BLOCK: i64 = 140;
-}
-
-/// ABI version information.
+/// A Fullerene native syscall number.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u64)]
+pub enum SyscallNumber {
+    AbiQuery = 0,
+    Exit = 1,
+    Fork = 2,
+    Read = 3,
+    Write = 4,
+    Open = 5,
+    Close = 6,
+    Wait = 7,
+    GetPid = 20,
+    GetProcessName = 21,
+    Yield = 22,
+    MapMemory = 30,
+    UnmapMemory = 31,
+    ProtectMemory = 32,
+    QueryMemory = 33,
+    CreateEvent = 40,
+    WaitEvent = 41,
+    SignalEvent = 42,
+    SubscribeEvent = 43,
+    CreateThread = 50,
+    JoinThread = 51,
+    DetachThread = 52,
+    ExitThread = 53,
+    CreateWindow = 60,
+    DestroyWindow = 61,
+    ResizeWindow = 62,
+    PresentWindow = 63,
+    GetWindowEvent = 64,
+    EnumerateDevices = 70,
+    OpenDevice = 71,
+    DeviceIoctl = 72,
+    ChannelCreate = 80,
+    ChannelSend = 81,
+    ChannelRecv = 82,
+    PipeCreate = 83,
+    HandleTransfer = 90,
+    HandleDuplicate = 91,
+    HandleRevoke = 92,
+    ClockGetTime = 100,
+    TimerCreate = 101,
+    Sleep = 102,
+    Uptime = 103,
+}
+
+impl SyscallNumber {
+    pub const ALL: &'static [Self] = &[
+        Self::AbiQuery,
+        Self::Exit,
+        Self::Fork,
+        Self::Read,
+        Self::Write,
+        Self::Open,
+        Self::Close,
+        Self::Wait,
+        Self::GetPid,
+        Self::GetProcessName,
+        Self::Yield,
+        Self::MapMemory,
+        Self::UnmapMemory,
+        Self::ProtectMemory,
+        Self::QueryMemory,
+        Self::CreateEvent,
+        Self::WaitEvent,
+        Self::SignalEvent,
+        Self::SubscribeEvent,
+        Self::CreateThread,
+        Self::JoinThread,
+        Self::DetachThread,
+        Self::ExitThread,
+        Self::CreateWindow,
+        Self::DestroyWindow,
+        Self::ResizeWindow,
+        Self::PresentWindow,
+        Self::GetWindowEvent,
+        Self::EnumerateDevices,
+        Self::OpenDevice,
+        Self::DeviceIoctl,
+        Self::ChannelCreate,
+        Self::ChannelSend,
+        Self::ChannelRecv,
+        Self::PipeCreate,
+        Self::HandleTransfer,
+        Self::HandleDuplicate,
+        Self::HandleRevoke,
+        Self::ClockGetTime,
+        Self::TimerCreate,
+        Self::Sleep,
+        Self::Uptime,
+    ];
+
+    #[inline]
+    pub const fn as_u64(self) -> u64 {
+        self as u64
+    }
+}
+
+impl TryFrom<u64> for SyscallNumber {
+    type Error = ();
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        match value {
+            syscall_numbers::ABI_QUERY => Ok(Self::AbiQuery),
+            syscall_numbers::EXIT => Ok(Self::Exit),
+            syscall_numbers::FORK => Ok(Self::Fork),
+            syscall_numbers::READ => Ok(Self::Read),
+            syscall_numbers::WRITE => Ok(Self::Write),
+            syscall_numbers::OPEN => Ok(Self::Open),
+            syscall_numbers::CLOSE => Ok(Self::Close),
+            syscall_numbers::WAIT => Ok(Self::Wait),
+            syscall_numbers::GETPID => Ok(Self::GetPid),
+            syscall_numbers::GET_PROCESS_NAME => Ok(Self::GetProcessName),
+            syscall_numbers::YIELD => Ok(Self::Yield),
+            syscall_numbers::MAP_MEMORY => Ok(Self::MapMemory),
+            syscall_numbers::UNMAP_MEMORY => Ok(Self::UnmapMemory),
+            syscall_numbers::PROTECT_MEMORY => Ok(Self::ProtectMemory),
+            syscall_numbers::QUERY_MEMORY => Ok(Self::QueryMemory),
+            syscall_numbers::CREATE_EVENT => Ok(Self::CreateEvent),
+            syscall_numbers::WAIT_EVENT => Ok(Self::WaitEvent),
+            syscall_numbers::SIGNAL_EVENT => Ok(Self::SignalEvent),
+            syscall_numbers::SUBSCRIBE_EVENT => Ok(Self::SubscribeEvent),
+            syscall_numbers::CREATE_THREAD => Ok(Self::CreateThread),
+            syscall_numbers::JOIN_THREAD => Ok(Self::JoinThread),
+            syscall_numbers::DETACH_THREAD => Ok(Self::DetachThread),
+            syscall_numbers::EXIT_THREAD => Ok(Self::ExitThread),
+            syscall_numbers::CREATE_WINDOW => Ok(Self::CreateWindow),
+            syscall_numbers::DESTROY_WINDOW => Ok(Self::DestroyWindow),
+            syscall_numbers::RESIZE_WINDOW => Ok(Self::ResizeWindow),
+            syscall_numbers::PRESENT_WINDOW => Ok(Self::PresentWindow),
+            syscall_numbers::GET_WINDOW_EVENT => Ok(Self::GetWindowEvent),
+            syscall_numbers::ENUMERATE_DEVICES => Ok(Self::EnumerateDevices),
+            syscall_numbers::OPEN_DEVICE => Ok(Self::OpenDevice),
+            syscall_numbers::DEVICE_IOCTL => Ok(Self::DeviceIoctl),
+            syscall_numbers::CHANNEL_CREATE => Ok(Self::ChannelCreate),
+            syscall_numbers::CHANNEL_SEND => Ok(Self::ChannelSend),
+            syscall_numbers::CHANNEL_RECV => Ok(Self::ChannelRecv),
+            syscall_numbers::PIPE_CREATE => Ok(Self::PipeCreate),
+            syscall_numbers::HANDLE_TRANSFER => Ok(Self::HandleTransfer),
+            syscall_numbers::HANDLE_DUPLICATE => Ok(Self::HandleDuplicate),
+            syscall_numbers::HANDLE_REVOKE => Ok(Self::HandleRevoke),
+            syscall_numbers::CLOCK_GETTIME => Ok(Self::ClockGetTime),
+            syscall_numbers::TIMER_CREATE => Ok(Self::TimerCreate),
+            syscall_numbers::SLEEP => Ok(Self::Sleep),
+            syscall_numbers::UPTIME => Ok(Self::Uptime),
+            _ => Err(()),
+        }
+    }
+}
+
+/// Compatibility constants for code that matches on raw syscall numbers.
+pub mod syscall_numbers {
+    use super::SyscallNumber;
+
+    pub const ABI_QUERY: u64 = SyscallNumber::AbiQuery.as_u64();
+    pub const ABI_VERSION: u64 = ABI_QUERY;
+    pub const EXIT: u64 = SyscallNumber::Exit.as_u64();
+    pub const FORK: u64 = SyscallNumber::Fork.as_u64();
+    pub const READ: u64 = SyscallNumber::Read.as_u64();
+    pub const WRITE: u64 = SyscallNumber::Write.as_u64();
+    pub const OPEN: u64 = SyscallNumber::Open.as_u64();
+    pub const CLOSE: u64 = SyscallNumber::Close.as_u64();
+    pub const WAIT: u64 = SyscallNumber::Wait.as_u64();
+    pub const GETPID: u64 = SyscallNumber::GetPid.as_u64();
+    pub const GET_PROCESS_NAME: u64 = SyscallNumber::GetProcessName.as_u64();
+    pub const YIELD: u64 = SyscallNumber::Yield.as_u64();
+    pub const MAP_MEMORY: u64 = SyscallNumber::MapMemory.as_u64();
+    pub const UNMAP_MEMORY: u64 = SyscallNumber::UnmapMemory.as_u64();
+    pub const PROTECT_MEMORY: u64 = SyscallNumber::ProtectMemory.as_u64();
+    pub const QUERY_MEMORY: u64 = SyscallNumber::QueryMemory.as_u64();
+    pub const CREATE_EVENT: u64 = SyscallNumber::CreateEvent.as_u64();
+    pub const WAIT_EVENT: u64 = SyscallNumber::WaitEvent.as_u64();
+    pub const SIGNAL_EVENT: u64 = SyscallNumber::SignalEvent.as_u64();
+    pub const SUBSCRIBE_EVENT: u64 = SyscallNumber::SubscribeEvent.as_u64();
+    pub const CREATE_THREAD: u64 = SyscallNumber::CreateThread.as_u64();
+    pub const JOIN_THREAD: u64 = SyscallNumber::JoinThread.as_u64();
+    pub const DETACH_THREAD: u64 = SyscallNumber::DetachThread.as_u64();
+    pub const EXIT_THREAD: u64 = SyscallNumber::ExitThread.as_u64();
+    pub const CREATE_WINDOW: u64 = SyscallNumber::CreateWindow.as_u64();
+    pub const DESTROY_WINDOW: u64 = SyscallNumber::DestroyWindow.as_u64();
+    pub const RESIZE_WINDOW: u64 = SyscallNumber::ResizeWindow.as_u64();
+    pub const PRESENT_WINDOW: u64 = SyscallNumber::PresentWindow.as_u64();
+    pub const GET_WINDOW_EVENT: u64 = SyscallNumber::GetWindowEvent.as_u64();
+    pub const ENUMERATE_DEVICES: u64 = SyscallNumber::EnumerateDevices.as_u64();
+    pub const OPEN_DEVICE: u64 = SyscallNumber::OpenDevice.as_u64();
+    pub const DEVICE_IOCTL: u64 = SyscallNumber::DeviceIoctl.as_u64();
+    pub const CHANNEL_CREATE: u64 = SyscallNumber::ChannelCreate.as_u64();
+    pub const CHANNEL_SEND: u64 = SyscallNumber::ChannelSend.as_u64();
+    pub const CHANNEL_RECV: u64 = SyscallNumber::ChannelRecv.as_u64();
+    pub const PIPE_CREATE: u64 = SyscallNumber::PipeCreate.as_u64();
+    pub const HANDLE_TRANSFER: u64 = SyscallNumber::HandleTransfer.as_u64();
+    pub const HANDLE_DUPLICATE: u64 = SyscallNumber::HandleDuplicate.as_u64();
+    pub const HANDLE_REVOKE: u64 = SyscallNumber::HandleRevoke.as_u64();
+    pub const CLOCK_GETTIME: u64 = SyscallNumber::ClockGetTime.as_u64();
+    pub const TIMER_CREATE: u64 = SyscallNumber::TimerCreate.as_u64();
+    pub const SLEEP: u64 = SyscallNumber::Sleep.as_u64();
+    pub const UPTIME: u64 = SyscallNumber::Uptime.as_u64();
+}
+
+/// A positive error code returned as its negated value from a syscall.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i64)]
+pub enum SyscallErrorCode {
+    InvalidSyscall = 1,
+    FileNotFound = 2,
+    NoSuchProcess = 3,
+    Io = 5,
+    BadFileDescriptor = 9,
+    Again = 11,
+    OutOfMemory = 12,
+    PermissionDenied = 13,
+    AddressFault = 14,
+    Busy = 16,
+    AlreadyExists = 17,
+    NoSuchDevice = 19,
+    NotADirectory = 20,
+    IsADirectory = 21,
+    InvalidArgument = 22,
+    NoSpace = 28,
+    DirectoryNotEmpty = 39,
+    Overflow = 75,
+    NotSupported = 95,
+    BadHandle = 104,
+    TimedOut = 110,
+    WouldBlock = 140,
+}
+
+impl SyscallErrorCode {
+    pub const ALL: &'static [Self] = &[
+        Self::InvalidSyscall,
+        Self::FileNotFound,
+        Self::NoSuchProcess,
+        Self::Io,
+        Self::BadFileDescriptor,
+        Self::Again,
+        Self::OutOfMemory,
+        Self::PermissionDenied,
+        Self::AddressFault,
+        Self::Busy,
+        Self::AlreadyExists,
+        Self::NoSuchDevice,
+        Self::NotADirectory,
+        Self::IsADirectory,
+        Self::InvalidArgument,
+        Self::NoSpace,
+        Self::DirectoryNotEmpty,
+        Self::Overflow,
+        Self::NotSupported,
+        Self::BadHandle,
+        Self::TimedOut,
+        Self::WouldBlock,
+    ];
+
+    #[inline]
+    pub const fn as_i64(self) -> i64 {
+        self as i64
+    }
+}
+
+impl TryFrom<i64> for SyscallErrorCode {
+    type Error = ();
+
+    fn try_from(value: i64) -> Result<Self, Self::Error> {
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|code| code.as_i64() == value)
+            .ok_or(())
+    }
+}
+
+/// Compatibility constants for raw error-code users.
+pub mod syscall_errors {
+    use super::SyscallErrorCode;
+
+    pub const INVALID_SYSCALL: i64 = SyscallErrorCode::InvalidSyscall.as_i64();
+    pub const FILE_NOT_FOUND: i64 = SyscallErrorCode::FileNotFound.as_i64();
+    pub const NO_SUCH_PROCESS: i64 = SyscallErrorCode::NoSuchProcess.as_i64();
+    pub const IO_ERROR: i64 = SyscallErrorCode::Io.as_i64();
+    pub const BAD_FILE_DESCRIPTOR: i64 = SyscallErrorCode::BadFileDescriptor.as_i64();
+    pub const AGAIN: i64 = SyscallErrorCode::Again.as_i64();
+    pub const OUT_OF_MEMORY: i64 = SyscallErrorCode::OutOfMemory.as_i64();
+    pub const PERMISSION_DENIED: i64 = SyscallErrorCode::PermissionDenied.as_i64();
+    pub const ADDRESS_FAULT: i64 = SyscallErrorCode::AddressFault.as_i64();
+    pub const BUSY: i64 = SyscallErrorCode::Busy.as_i64();
+    pub const ALREADY_EXISTS: i64 = SyscallErrorCode::AlreadyExists.as_i64();
+    pub const NO_SUCH_DEVICE: i64 = SyscallErrorCode::NoSuchDevice.as_i64();
+    pub const NOT_A_DIRECTORY: i64 = SyscallErrorCode::NotADirectory.as_i64();
+    pub const IS_A_DIRECTORY: i64 = SyscallErrorCode::IsADirectory.as_i64();
+    pub const INVALID_ARGUMENT: i64 = SyscallErrorCode::InvalidArgument.as_i64();
+    pub const NO_SPACE: i64 = SyscallErrorCode::NoSpace.as_i64();
+    pub const DIRECTORY_NOT_EMPTY: i64 = SyscallErrorCode::DirectoryNotEmpty.as_i64();
+    pub const OVERFLOW: i64 = SyscallErrorCode::Overflow.as_i64();
+    pub const NOT_SUPPORTED: i64 = SyscallErrorCode::NotSupported.as_i64();
+    pub const BAD_HANDLE: i64 = SyscallErrorCode::BadHandle.as_i64();
+    pub const TIMED_OUT: i64 = SyscallErrorCode::TimedOut.as_i64();
+    pub const WOULD_BLOCK: i64 = SyscallErrorCode::WouldBlock.as_i64();
+}
+
+/// Semantic version of the native syscall ABI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[repr(C)]
 pub struct AbiVersion {
     pub major: u16,
@@ -102,16 +319,34 @@ pub struct AbiVersion {
 }
 
 impl AbiVersion {
-    pub const CURRENT: AbiVersion = AbiVersion {
+    pub const CURRENT: Self = Self {
         major: 0,
-        minor: 2,
+        minor: 3,
         patch: 0,
         reserved: 0,
     };
+
+    #[inline]
+    pub const fn pack(self) -> u64 {
+        (self.major as u64) << 48
+            | (self.minor as u64) << 32
+            | (self.patch as u64) << 16
+            | self.reserved as u64
+    }
+
+    #[inline]
+    pub const fn unpack(value: u64) -> Self {
+        Self {
+            major: (value >> 48) as u16,
+            minor: (value >> 32) as u16,
+            patch: (value >> 16) as u16,
+            reserved: value as u16,
+        }
+    }
 }
 
-/// Capability bits for feature querying.
-#[derive(Debug, Clone, Copy)]
+/// One capability advertised by [`AbiInfo`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u64)]
 pub enum Capability {
     NativeSyscall = 1 << 0,
@@ -125,8 +360,270 @@ pub enum Capability {
     DeviceEnumeration = 1 << 8,
 }
 
-// Size/alignment compile-time checks
+impl Capability {
+    #[inline]
+    pub const fn bit(self) -> u64 {
+        self as u64
+    }
+}
+
+/// Capability bitset with a stable C-compatible representation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[repr(transparent)]
+pub struct CapabilitySet(pub u64);
+
+impl CapabilitySet {
+    pub const EMPTY: Self = Self(0);
+    pub const ALL_DEFINED: Self = Self(
+        Capability::NativeSyscall.bit()
+            | Capability::LinuxCompat.bit()
+            | Capability::MultiWindow.bit()
+            | Capability::EventSystem.bit()
+            | Capability::Threading.bit()
+            | Capability::IpcChannels.bit()
+            | Capability::IpcPipes.bit()
+            | Capability::TimerSystem.bit()
+            | Capability::DeviceEnumeration.bit(),
+    );
+
+    #[inline]
+    pub const fn contains(self, capability: Capability) -> bool {
+        self.0 & capability.bit() != 0
+    }
+
+    #[inline]
+    pub const fn with(self, capability: Capability) -> Self {
+        Self(self.0 | capability.bit())
+    }
+
+    #[inline]
+    pub const fn bits(self) -> u64 {
+        self.0
+    }
+}
+
+/// Result of the ABI query syscall.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+pub struct AbiInfo {
+    pub version: AbiVersion,
+    pub struct_size: u32,
+    pub syscall_count: u32,
+    pub capabilities: CapabilitySet,
+    pub reserved: [u64; 2],
+}
+
+impl AbiInfo {
+    pub const BYTE_SIZE: usize = 40;
+    pub const EMPTY: Self = Self {
+        version: AbiVersion {
+            major: 0,
+            minor: 0,
+            patch: 0,
+            reserved: 0,
+        },
+        struct_size: 0,
+        syscall_count: 0,
+        capabilities: CapabilitySet::EMPTY,
+        reserved: [0; 2],
+    };
+    pub const fn new(capabilities: CapabilitySet) -> Self {
+        Self {
+            version: AbiVersion::CURRENT,
+            struct_size: Self::BYTE_SIZE as u32,
+            syscall_count: SyscallNumber::ALL.len() as u32,
+            capabilities,
+            reserved: [0; 2],
+        }
+    }
+
+    pub fn to_ne_bytes(self) -> [u8; Self::BYTE_SIZE] {
+        let mut bytes = [0; Self::BYTE_SIZE];
+        bytes[0..2].copy_from_slice(&self.version.major.to_ne_bytes());
+        bytes[2..4].copy_from_slice(&self.version.minor.to_ne_bytes());
+        bytes[4..6].copy_from_slice(&self.version.patch.to_ne_bytes());
+        bytes[6..8].copy_from_slice(&self.version.reserved.to_ne_bytes());
+        bytes[8..12].copy_from_slice(&self.struct_size.to_ne_bytes());
+        bytes[12..16].copy_from_slice(&self.syscall_count.to_ne_bytes());
+        bytes[16..24].copy_from_slice(&self.capabilities.bits().to_ne_bytes());
+        bytes[24..32].copy_from_slice(&self.reserved[0].to_ne_bytes());
+        bytes[32..40].copy_from_slice(&self.reserved[1].to_ne_bytes());
+        bytes
+    }
+}
+
+impl Default for AbiInfo {
+    fn default() -> Self {
+        Self::EMPTY
+    }
+}
+
+/// Information returned by `query_memory`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[repr(C)]
+pub struct MemoryInfo {
+    pub base_address: u64,
+    pub length: u64,
+    pub protection: u32,
+    pub flags: u32,
+    pub page_size: u64,
+    pub committed_bytes: u64,
+    pub reserved: [u64; 3],
+}
+
+impl MemoryInfo {
+    pub const BYTE_SIZE: usize = 64;
+
+    pub fn to_ne_bytes(self) -> [u8; Self::BYTE_SIZE] {
+        let mut bytes = [0; Self::BYTE_SIZE];
+        bytes[0..8].copy_from_slice(&self.base_address.to_ne_bytes());
+        bytes[8..16].copy_from_slice(&self.length.to_ne_bytes());
+        bytes[16..20].copy_from_slice(&self.protection.to_ne_bytes());
+        bytes[20..24].copy_from_slice(&self.flags.to_ne_bytes());
+        bytes[24..32].copy_from_slice(&self.page_size.to_ne_bytes());
+        bytes[32..40].copy_from_slice(&self.committed_bytes.to_ne_bytes());
+        for (index, value) in self.reserved.iter().enumerate() {
+            let start = 40 + index * 8;
+            bytes[start..start + 8].copy_from_slice(&value.to_ne_bytes());
+        }
+        bytes
+    }
+}
+
+/// Time value returned by `clock_gettime`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[repr(C)]
+pub struct TimeSpec {
+    pub seconds: u64,
+    pub nanoseconds: u64,
+}
+
+impl TimeSpec {
+    pub const BYTE_SIZE: usize = 16;
+
+    pub fn to_ne_bytes(self) -> [u8; Self::BYTE_SIZE] {
+        let mut bytes = [0; Self::BYTE_SIZE];
+        bytes[0..8].copy_from_slice(&self.seconds.to_ne_bytes());
+        bytes[8..16].copy_from_slice(&self.nanoseconds.to_ne_bytes());
+        bytes
+    }
+}
+
+/// One device record returned by `enumerate_devices`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[repr(C)]
+pub struct DeviceInfo {
+    pub class: u32,
+    pub device_id: u32,
+    pub vendor_id: u32,
+    pub product_id: u32,
+}
+
+impl DeviceInfo {
+    pub const BYTE_SIZE: usize = 16;
+
+    pub fn to_ne_bytes(self) -> [u8; Self::BYTE_SIZE] {
+        let mut bytes = [0; Self::BYTE_SIZE];
+        bytes[0..4].copy_from_slice(&self.class.to_ne_bytes());
+        bytes[4..8].copy_from_slice(&self.device_id.to_ne_bytes());
+        bytes[8..12].copy_from_slice(&self.vendor_id.to_ne_bytes());
+        bytes[12..16].copy_from_slice(&self.product_id.to_ne_bytes());
+        bytes
+    }
+}
+
+/// Fixed-size window event record returned by `get_window_event`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[repr(C)]
+pub struct WindowEvent {
+    pub kind: u32,
+    pub flags: u32,
+    pub window_id: u64,
+    pub data: [u64; 14],
+}
+
+impl WindowEvent {
+    pub const BYTE_SIZE: usize = 128;
+
+    pub fn to_ne_bytes(self) -> [u8; Self::BYTE_SIZE] {
+        let mut bytes = [0; Self::BYTE_SIZE];
+        bytes[0..4].copy_from_slice(&self.kind.to_ne_bytes());
+        bytes[4..8].copy_from_slice(&self.flags.to_ne_bytes());
+        bytes[8..16].copy_from_slice(&self.window_id.to_ne_bytes());
+        for (index, value) in self.data.iter().enumerate() {
+            let start = 16 + index * 8;
+            bytes[start..start + 8].copy_from_slice(&value.to_ne_bytes());
+        }
+        bytes
+    }
+}
+
 const _: () = {
     assert!(core::mem::size_of::<AbiVersion>() == 8);
     assert!(core::mem::align_of::<AbiVersion>() == 2);
+    assert!(core::mem::size_of::<CapabilitySet>() == 8);
+    assert!(core::mem::align_of::<CapabilitySet>() == 8);
+    assert!(core::mem::size_of::<AbiInfo>() == AbiInfo::BYTE_SIZE);
+    assert!(core::mem::align_of::<AbiInfo>() == 8);
+    assert!(core::mem::size_of::<MemoryInfo>() == MemoryInfo::BYTE_SIZE);
+    assert!(core::mem::align_of::<MemoryInfo>() == 8);
+    assert!(core::mem::size_of::<TimeSpec>() == TimeSpec::BYTE_SIZE);
+    assert!(core::mem::align_of::<TimeSpec>() == 8);
+    assert!(core::mem::size_of::<DeviceInfo>() == DeviceInfo::BYTE_SIZE);
+    assert!(core::mem::align_of::<DeviceInfo>() == 4);
+    assert!(core::mem::size_of::<WindowEvent>() == WindowEvent::BYTE_SIZE);
+    assert!(core::mem::align_of::<WindowEvent>() == 8);
 };
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn syscall_numbers_are_unique_and_round_trip() {
+        for (index, number) in SyscallNumber::ALL.iter().copied().enumerate() {
+            assert_eq!(SyscallNumber::try_from(number.as_u64()), Ok(number));
+            assert!(
+                SyscallNumber::ALL[..index]
+                    .iter()
+                    .all(|other| other.as_u64() != number.as_u64())
+            );
+        }
+        assert!(SyscallNumber::try_from(u64::MAX).is_err());
+    }
+
+    #[test]
+    fn error_codes_are_unique_and_round_trip() {
+        for (index, code) in SyscallErrorCode::ALL.iter().copied().enumerate() {
+            assert_eq!(SyscallErrorCode::try_from(code.as_i64()), Ok(code));
+            assert!(
+                SyscallErrorCode::ALL[..index]
+                    .iter()
+                    .all(|other| other.as_i64() != code.as_i64())
+            );
+        }
+    }
+
+    #[test]
+    fn version_packing_is_backwards_compatible() {
+        assert_eq!(
+            AbiVersion::unpack(AbiVersion::CURRENT.pack()),
+            AbiVersion::CURRENT
+        );
+    }
+
+    #[test]
+    fn abi_info_serialization_matches_repr_c_layout() {
+        let info = AbiInfo::new(CapabilitySet::ALL_DEFINED);
+        let bytes = info.to_ne_bytes();
+        assert_eq!(
+            u32::from_ne_bytes(bytes[8..12].try_into().unwrap()),
+            AbiInfo::BYTE_SIZE as u32
+        );
+        assert_eq!(
+            u64::from_ne_bytes(bytes[16..24].try_into().unwrap()),
+            CapabilitySet::ALL_DEFINED.bits()
+        );
+        assert!(info.capabilities.contains(Capability::NativeSyscall));
+    }
+}

--- a/fullerene-abi/src/lib.rs
+++ b/fullerene-abi/src/lib.rs
@@ -414,6 +414,9 @@ pub struct AbiInfo {
 }
 
 impl AbiInfo {
+    /// Size accepted from clients built against ABI version 0.3.
+    /// This value remains fixed when fields are appended in later versions.
+    pub const MIN_BYTE_SIZE: usize = 40;
     pub const BYTE_SIZE: usize = 40;
     pub const EMPTY: Self = Self {
         version: AbiVersion {
@@ -472,6 +475,9 @@ pub struct MemoryInfo {
 }
 
 impl MemoryInfo {
+    /// Size accepted from clients built against ABI version 0.3.
+    /// This value remains fixed when fields are appended in later versions.
+    pub const MIN_BYTE_SIZE: usize = 64;
     pub const BYTE_SIZE: usize = 64;
 
     pub fn to_ne_bytes(self) -> [u8; Self::BYTE_SIZE] {
@@ -543,6 +549,9 @@ pub struct WindowEvent {
 }
 
 impl WindowEvent {
+    /// Size accepted from clients built against ABI version 0.3.
+    /// This value remains fixed when fields are appended in later versions.
+    pub const MIN_BYTE_SIZE: usize = 128;
     pub const BYTE_SIZE: usize = 128;
 
     pub fn to_ne_bytes(self) -> [u8; Self::BYTE_SIZE] {
@@ -564,14 +573,17 @@ const _: () = {
     assert!(core::mem::size_of::<CapabilitySet>() == 8);
     assert!(core::mem::align_of::<CapabilitySet>() == 8);
     assert!(core::mem::size_of::<AbiInfo>() == AbiInfo::BYTE_SIZE);
+    assert!(AbiInfo::MIN_BYTE_SIZE <= AbiInfo::BYTE_SIZE);
     assert!(core::mem::align_of::<AbiInfo>() == 8);
     assert!(core::mem::size_of::<MemoryInfo>() == MemoryInfo::BYTE_SIZE);
+    assert!(MemoryInfo::MIN_BYTE_SIZE <= MemoryInfo::BYTE_SIZE);
     assert!(core::mem::align_of::<MemoryInfo>() == 8);
     assert!(core::mem::size_of::<TimeSpec>() == TimeSpec::BYTE_SIZE);
     assert!(core::mem::align_of::<TimeSpec>() == 8);
     assert!(core::mem::size_of::<DeviceInfo>() == DeviceInfo::BYTE_SIZE);
     assert!(core::mem::align_of::<DeviceInfo>() == 4);
     assert!(core::mem::size_of::<WindowEvent>() == WindowEvent::BYTE_SIZE);
+    assert!(WindowEvent::MIN_BYTE_SIZE <= WindowEvent::BYTE_SIZE);
     assert!(core::mem::align_of::<WindowEvent>() == 8);
 };
 

--- a/fullerene-kernel/src/syscall/basic.rs
+++ b/fullerene-kernel/src/syscall/basic.rs
@@ -6,7 +6,7 @@ use petroleum::common::memory::UserSlice;
 use petroleum::page_table::PageTableHelper;
 use x86_64::PhysAddr;
 
-use super::interface::{SyscallError, SyscallResult, copy_user_string};
+use super::interface::{SyscallError, SyscallResult, copy_user_string, copy_versioned_dto_to_user};
 use super::process::{alloc_kernel_stack, free_kernel_stack, with_current_fd_table};
 use crate::linux::{O_APPEND, O_CREAT, O_RDONLY, O_RDWR, O_TRUNC, O_WRONLY};
 use crate::process::{self, Process, ProcessState};
@@ -31,15 +31,13 @@ pub(crate) fn syscall_abi_query(info_buf: *mut u8, buf_size: usize) -> SyscallRe
         };
     }
 
-    if buf_size < fullerene_abi::AbiInfo::BYTE_SIZE {
-        return Err(SyscallError::InvalidArgument);
-    }
-
-    let slice = UserSlice::new(info_buf, fullerene_abi::AbiInfo::BYTE_SIZE, true)
-        .map_err(|_| SyscallError::AddressFault)?;
     let bytes = fullerene_abi::AbiInfo::new(KERNEL_CAPABILITIES).to_ne_bytes();
-    unsafe { slice.copy_to_user(&bytes) }.map_err(|_| SyscallError::AddressFault)?;
-    Ok(fullerene_abi::AbiInfo::BYTE_SIZE as u64)
+    copy_versioned_dto_to_user(
+        info_buf,
+        buf_size,
+        fullerene_abi::AbiInfo::MIN_BYTE_SIZE,
+        &bytes,
+    )
 }
 
 pub(crate) fn syscall_exit(exit_code: i32) -> SyscallResult {

--- a/fullerene-kernel/src/syscall/basic.rs
+++ b/fullerene-kernel/src/syscall/basic.rs
@@ -11,13 +11,35 @@ use super::process::{alloc_kernel_stack, free_kernel_stack, with_current_fd_tabl
 use crate::linux::{O_APPEND, O_CREAT, O_RDONLY, O_RDWR, O_TRUNC, O_WRONLY};
 use crate::process::{self, Process, ProcessState};
 
-pub(crate) fn syscall_abi_version() -> SyscallResult {
-    let ver = fullerene_abi::AbiVersion::CURRENT;
-    let packed = (ver.major as u64) << 48
-        | (ver.minor as u64) << 32
-        | (ver.patch as u64) << 16
-        | ver.reserved as u64;
-    Ok(packed)
+const KERNEL_CAPABILITIES: fullerene_abi::CapabilitySet = fullerene_abi::CapabilitySet::EMPTY
+    .with(fullerene_abi::Capability::NativeSyscall)
+    .with(fullerene_abi::Capability::LinuxCompat)
+    .with(fullerene_abi::Capability::MultiWindow)
+    .with(fullerene_abi::Capability::EventSystem)
+    .with(fullerene_abi::Capability::Threading)
+    .with(fullerene_abi::Capability::IpcChannels)
+    .with(fullerene_abi::Capability::IpcPipes)
+    .with(fullerene_abi::Capability::TimerSystem)
+    .with(fullerene_abi::Capability::DeviceEnumeration);
+
+pub(crate) fn syscall_abi_query(info_buf: *mut u8, buf_size: usize) -> SyscallResult {
+    if info_buf.is_null() {
+        return if buf_size == 0 {
+            Ok(fullerene_abi::AbiVersion::CURRENT.pack())
+        } else {
+            Err(SyscallError::InvalidArgument)
+        };
+    }
+
+    if buf_size < fullerene_abi::AbiInfo::BYTE_SIZE {
+        return Err(SyscallError::InvalidArgument);
+    }
+
+    let slice = UserSlice::new(info_buf, fullerene_abi::AbiInfo::BYTE_SIZE, true)
+        .map_err(|_| SyscallError::AddressFault)?;
+    let bytes = fullerene_abi::AbiInfo::new(KERNEL_CAPABILITIES).to_ne_bytes();
+    unsafe { slice.copy_to_user(&bytes) }.map_err(|_| SyscallError::AddressFault)?;
+    Ok(fullerene_abi::AbiInfo::BYTE_SIZE as u64)
 }
 
 pub(crate) fn syscall_exit(exit_code: i32) -> SyscallResult {

--- a/fullerene-kernel/src/syscall/device.rs
+++ b/fullerene-kernel/src/syscall/device.rs
@@ -30,15 +30,24 @@ pub(crate) fn syscall_enumerate_devices(
         };
 
         let mut offset = 0;
-        for _dev in devices.iter().take(buf_size / 16) {
-            if offset + 16 > buf_size {
+        for dev in devices
+            .iter()
+            .take(buf_size / fullerene_abi::DeviceInfo::BYTE_SIZE)
+        {
+            if offset + fullerene_abi::DeviceInfo::BYTE_SIZE > buf_size {
                 break;
             }
-            kernel_buf[offset..offset + 4].copy_from_slice(&(class as u32).to_ne_bytes());
-            kernel_buf[offset + 4..offset + 8].copy_from_slice(&0_u32.to_ne_bytes());
-            kernel_buf[offset + 8..offset + 12].copy_from_slice(&0_u32.to_ne_bytes());
-            kernel_buf[offset + 12..offset + 16].copy_from_slice(&0_u32.to_ne_bytes());
-            offset += 16;
+            let bytes = fullerene_abi::DeviceInfo {
+                class: class as u32,
+                device_id: ((dev.bus as u32) << 16)
+                    | ((dev.device as u32) << 8)
+                    | dev.function as u32,
+                vendor_id: dev.vendor_id as u32,
+                product_id: dev.device_id as u32,
+            }
+            .to_ne_bytes();
+            kernel_buf[offset..offset + bytes.len()].copy_from_slice(&bytes);
+            offset += bytes.len();
         }
         devices.len()
     })

--- a/fullerene-kernel/src/syscall/dispatch.rs
+++ b/fullerene-kernel/src/syscall/dispatch.rs
@@ -1,4 +1,4 @@
-use fullerene_abi::syscall_numbers::*;
+use fullerene_abi::SyscallNumber;
 
 use super::basic;
 use super::cap;
@@ -60,69 +60,83 @@ pub unsafe extern "C" fn handle_syscall(
         return ret;
     }
 
-    let result = match syscall_num {
-        ABI_VERSION => basic::syscall_abi_version(),
+    let result = match SyscallNumber::try_from(syscall_num) {
+        Ok(SyscallNumber::AbiQuery) => basic::syscall_abi_query(arg1 as *mut u8, arg2 as usize),
 
-        EXIT => basic::syscall_exit(arg1 as i32),
-        FORK => basic::syscall_fork(),
-        READ => basic::syscall_read(arg1 as core::ffi::c_int, arg2 as *mut u8, arg3 as usize),
-        WRITE => basic::syscall_write(arg1 as core::ffi::c_int, arg2 as *const u8, arg3 as usize),
-        OPEN => basic::syscall_open(arg1 as *const u8, arg2 as core::ffi::c_int, arg3 as u32),
-        CLOSE => basic::syscall_close(arg1 as core::ffi::c_int),
-        WAIT => basic::syscall_wait(arg1 as u64),
-        GETPID => basic::syscall_getpid(),
-        GET_PROCESS_NAME => basic::syscall_get_process_name(arg1 as *mut u8, arg2 as usize),
-        YIELD => basic::syscall_yield(),
+        Ok(SyscallNumber::Exit) => basic::syscall_exit(arg1 as i32),
+        Ok(SyscallNumber::Fork) => basic::syscall_fork(),
+        Ok(SyscallNumber::Read) => {
+            basic::syscall_read(arg1 as core::ffi::c_int, arg2 as *mut u8, arg3 as usize)
+        }
+        Ok(SyscallNumber::Write) => {
+            basic::syscall_write(arg1 as core::ffi::c_int, arg2 as *const u8, arg3 as usize)
+        }
+        Ok(SyscallNumber::Open) => {
+            basic::syscall_open(arg1 as *const u8, arg2 as core::ffi::c_int, arg3 as u32)
+        }
+        Ok(SyscallNumber::Close) => basic::syscall_close(arg1 as core::ffi::c_int),
+        Ok(SyscallNumber::Wait) => basic::syscall_wait(arg1),
+        Ok(SyscallNumber::GetPid) => basic::syscall_getpid(),
+        Ok(SyscallNumber::GetProcessName) => {
+            basic::syscall_get_process_name(arg1 as *mut u8, arg2 as usize)
+        }
+        Ok(SyscallNumber::Yield) => basic::syscall_yield(),
 
-        MAP_MEMORY => memory::syscall_map_memory(arg1, arg2, arg3),
-        UNMAP_MEMORY => memory::syscall_unmap_memory(arg1, arg2),
-        PROTECT_MEMORY => memory::syscall_protect_memory(arg1, arg2, arg3),
-        QUERY_MEMORY => memory::syscall_query_memory(arg1 as *mut u8, arg2 as usize),
+        Ok(SyscallNumber::MapMemory) => memory::syscall_map_memory(arg1, arg2, arg3),
+        Ok(SyscallNumber::UnmapMemory) => memory::syscall_unmap_memory(arg1, arg2),
+        Ok(SyscallNumber::ProtectMemory) => memory::syscall_protect_memory(arg1, arg2, arg3),
+        Ok(SyscallNumber::QueryMemory) => {
+            memory::syscall_query_memory(arg1 as *mut u8, arg2 as usize)
+        }
 
-        CREATE_EVENT => event::syscall_create_event(arg1),
-        WAIT_EVENT => event::syscall_wait_event(arg1, arg2),
-        SIGNAL_EVENT => event::syscall_signal_event(arg1),
-        SUBSCRIBE_EVENT => event::syscall_subscribe_event(arg1, arg2),
+        Ok(SyscallNumber::CreateEvent) => event::syscall_create_event(arg1),
+        Ok(SyscallNumber::WaitEvent) => event::syscall_wait_event(arg1, arg2),
+        Ok(SyscallNumber::SignalEvent) => event::syscall_signal_event(arg1),
+        Ok(SyscallNumber::SubscribeEvent) => event::syscall_subscribe_event(arg1, arg2),
 
-        CREATE_THREAD => thread::syscall_create_thread(arg1, arg2, arg3),
-        JOIN_THREAD => thread::syscall_join_thread(arg1),
-        DETACH_THREAD => thread::syscall_detach_thread(arg1),
-        EXIT_THREAD => thread::syscall_exit_thread(arg1 as i32),
+        Ok(SyscallNumber::CreateThread) => thread::syscall_create_thread(arg1, arg2, arg3),
+        Ok(SyscallNumber::JoinThread) => thread::syscall_join_thread(arg1),
+        Ok(SyscallNumber::DetachThread) => thread::syscall_detach_thread(arg1),
+        Ok(SyscallNumber::ExitThread) => thread::syscall_exit_thread(arg1 as i32),
 
-        CREATE_WINDOW => {
+        Ok(SyscallNumber::CreateWindow) => {
             window::syscall_create_window(arg1 as i32, arg2 as i32, arg3 as u32, arg4 as u32, arg5)
         }
-        DESTROY_WINDOW => window::syscall_destroy_window(arg1),
-        RESIZE_WINDOW => window::syscall_resize_window(arg1, arg2 as u32, arg3 as u32),
-        PRESENT_WINDOW => window::syscall_present_window(arg1),
-        GET_WINDOW_EVENT => window::syscall_get_window_event(arg1, arg2 as *mut u8, arg3 as usize),
+        Ok(SyscallNumber::DestroyWindow) => window::syscall_destroy_window(arg1),
+        Ok(SyscallNumber::ResizeWindow) => {
+            window::syscall_resize_window(arg1, arg2 as u32, arg3 as u32)
+        }
+        Ok(SyscallNumber::PresentWindow) => window::syscall_present_window(arg1),
+        Ok(SyscallNumber::GetWindowEvent) => {
+            window::syscall_get_window_event(arg1, arg2 as *mut u8, arg3 as usize)
+        }
 
-        ENUMERATE_DEVICES => {
+        Ok(SyscallNumber::EnumerateDevices) => {
             device::syscall_enumerate_devices(arg1, arg2 as *mut u8, arg3 as usize)
         }
-        OPEN_DEVICE => device::syscall_open_device(arg1 as *const u8),
-        DEVICE_IOCTL => device::syscall_device_ioctl(arg1, arg2, arg3),
+        Ok(SyscallNumber::OpenDevice) => device::syscall_open_device(arg1 as *const u8),
+        Ok(SyscallNumber::DeviceIoctl) => device::syscall_device_ioctl(arg1, arg2, arg3),
 
-        CHANNEL_CREATE => ipc::syscall_channel_create(arg1),
-        CHANNEL_SEND => ipc::syscall_channel_send(arg1, arg2 as *const u8, arg3),
-        CHANNEL_RECV => ipc::syscall_channel_recv(arg1, arg2 as *mut u8, arg3),
-        PIPE_CREATE => ipc::syscall_pipe_create(arg1 as *mut u64),
+        Ok(SyscallNumber::ChannelCreate) => ipc::syscall_channel_create(arg1),
+        Ok(SyscallNumber::ChannelSend) => ipc::syscall_channel_send(arg1, arg2 as *const u8, arg3),
+        Ok(SyscallNumber::ChannelRecv) => ipc::syscall_channel_recv(arg1, arg2 as *mut u8, arg3),
+        Ok(SyscallNumber::PipeCreate) => ipc::syscall_pipe_create(arg1 as *mut u64),
 
-        HANDLE_TRANSFER => cap::syscall_handle_transfer(arg1 as u64, arg2),
-        HANDLE_DUPLICATE => cap::syscall_handle_duplicate(arg1),
-        HANDLE_REVOKE => cap::syscall_handle_revoke(arg1),
+        Ok(SyscallNumber::HandleTransfer) => cap::syscall_handle_transfer(arg1, arg2),
+        Ok(SyscallNumber::HandleDuplicate) => cap::syscall_handle_duplicate(arg1),
+        Ok(SyscallNumber::HandleRevoke) => cap::syscall_handle_revoke(arg1),
 
-        CLOCK_GETTIME => time::syscall_clock_gettime(arg1, arg2 as *mut u8),
-        TIMER_CREATE => time::syscall_timer_create(arg1, arg2, arg3),
-        SLEEP => time::syscall_sleep(arg1),
-        UPTIME => time::syscall_uptime(arg1 as *mut u8),
+        Ok(SyscallNumber::ClockGetTime) => time::syscall_clock_gettime(arg1, arg2 as *mut u8),
+        Ok(SyscallNumber::TimerCreate) => time::syscall_timer_create(arg1, arg2, arg3),
+        Ok(SyscallNumber::Sleep) => time::syscall_sleep(arg1),
+        Ok(SyscallNumber::Uptime) => time::syscall_uptime(arg1 as *mut u8),
 
-        _ => Err(SyscallError::InvalidSyscall),
+        Err(()) => Err(SyscallError::InvalidSyscall),
     };
 
     match result {
         Ok(value) => value,
-        Err(error) => -(error as i32) as u64,
+        Err(error) => (-(error as i64)) as u64,
     }
 }
 

--- a/fullerene-kernel/src/syscall/interface.rs
+++ b/fullerene-kernel/src/syscall/interface.rs
@@ -1,4 +1,5 @@
 use alloc::string::String;
+use fullerene_abi::SyscallErrorCode;
 use petroleum::common::logging::SystemError;
 
 use crate::user_memory::{self, UserCopyError};
@@ -11,51 +12,52 @@ pub type SyscallResult = Result<u64, SyscallError>;
 
 /// System call errors
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i64)]
 pub enum SyscallError {
     /// Invalid system call number
-    InvalidSyscall = 1,
+    InvalidSyscall = SyscallErrorCode::InvalidSyscall as i64,
     /// File not found
-    FileNotFound = 2,
+    FileNotFound = SyscallErrorCode::FileNotFound as i64,
     /// No such process
-    NoSuchProcess = 3,
+    NoSuchProcess = SyscallErrorCode::NoSuchProcess as i64,
     /// Device or block I/O error
-    Io = 5,
+    Io = SyscallErrorCode::Io as i64,
     /// Bad file descriptor
-    BadFileDescriptor = 9,
+    BadFileDescriptor = SyscallErrorCode::BadFileDescriptor as i64,
     /// Out of memory
-    OutOfMemory = 12,
+    OutOfMemory = SyscallErrorCode::OutOfMemory as i64,
     /// Permission denied
-    PermissionDenied = 13,
+    PermissionDenied = SyscallErrorCode::PermissionDenied as i64,
     /// Invalid or inaccessible address
-    AddressFault = 14,
+    AddressFault = SyscallErrorCode::AddressFault as i64,
     /// Resource or device is busy
-    Busy = 16,
+    Busy = SyscallErrorCode::Busy as i64,
     /// Invalid argument
-    InvalidArgument = 22,
+    InvalidArgument = SyscallErrorCode::InvalidArgument as i64,
     /// Resource temporarily unavailable (try again)
-    Again = 11,
+    Again = SyscallErrorCode::Again as i64,
     /// Operation timed out
-    TimedOut = 110,
+    TimedOut = SyscallErrorCode::TimedOut as i64,
     /// Operation not supported
-    NotSupported = 95,
+    NotSupported = SyscallErrorCode::NotSupported as i64,
     /// Resource already exists
-    AlreadyExists = 17,
+    AlreadyExists = SyscallErrorCode::AlreadyExists as i64,
     /// No such device
-    NoSuchDevice = 19,
+    NoSuchDevice = SyscallErrorCode::NoSuchDevice as i64,
     /// Expected a directory
-    NotADirectory = 20,
+    NotADirectory = SyscallErrorCode::NotADirectory as i64,
     /// Expected a non-directory object
-    IsADirectory = 21,
+    IsADirectory = SyscallErrorCode::IsADirectory as i64,
     /// Storage capacity exhausted
-    NoSpace = 28,
+    NoSpace = SyscallErrorCode::NoSpace as i64,
     /// Directory must be empty
-    DirectoryNotEmpty = 39,
+    DirectoryNotEmpty = SyscallErrorCode::DirectoryNotEmpty as i64,
     /// Numeric or address overflow
-    Overflow = 75,
+    Overflow = SyscallErrorCode::Overflow as i64,
     /// Bad handle
-    BadHandle = 104,
+    BadHandle = SyscallErrorCode::BadHandle as i64,
     /// Operation would block
-    WouldBlock = 140,
+    WouldBlock = SyscallErrorCode::WouldBlock as i64,
 }
 
 petroleum::error_chain!(SyscallError, petroleum::common::logging::SystemError,

--- a/fullerene-kernel/src/syscall/interface.rs
+++ b/fullerene-kernel/src/syscall/interface.rs
@@ -1,6 +1,7 @@
 use alloc::string::String;
 use fullerene_abi::SyscallErrorCode;
 use petroleum::common::logging::SystemError;
+use petroleum::common::memory::UserSlice;
 
 use crate::user_memory::{self, UserCopyError};
 
@@ -191,6 +192,38 @@ impl From<petroleum::MemoryError> for SyscallError {
     }
 }
 
+fn versioned_copy_len(
+    caller_size: usize,
+    minimum_size: usize,
+    current_size: usize,
+) -> Result<usize, SyscallError> {
+    if minimum_size == 0 || current_size < minimum_size || caller_size < minimum_size {
+        return Err(SyscallError::InvalidArgument);
+    }
+    Ok(caller_size.min(current_size))
+}
+
+/// Copy the compatible prefix of a versioned DTO to a validated user buffer.
+pub(crate) fn copy_versioned_dto_to_user(
+    destination: *mut u8,
+    caller_size: usize,
+    minimum_size: usize,
+    bytes: &[u8],
+) -> SyscallResult {
+    if destination.is_null() {
+        return Err(SyscallError::InvalidArgument);
+    }
+
+    let copy_len = versioned_copy_len(caller_size, minimum_size, bytes.len())?;
+    petroleum::validate_user_buffer(destination as usize, copy_len, false)
+        .map_err(|_| SyscallError::AddressFault)?;
+    let destination =
+        UserSlice::new(destination, copy_len, true).map_err(|_| SyscallError::AddressFault)?;
+    unsafe { destination.copy_to_user(&bytes[..copy_len]) }
+        .map_err(|_| SyscallError::AddressFault)?;
+    Ok(copy_len as u64)
+}
+
 /// Helper function to safely copy a null-terminated string from user space.
 ///
 /// Uses the shared user-memory implementation for page-wise validation and
@@ -283,6 +316,17 @@ mod tests {
         assert_eq!(SyscallError::BadHandle as i64, syscall_errors::BAD_HANDLE);
         assert_eq!(SyscallError::TimedOut as i64, syscall_errors::TIMED_OUT);
         assert_eq!(SyscallError::WouldBlock as i64, syscall_errors::WOULD_BLOCK);
+    }
+
+    #[test]
+    fn versioned_dto_copy_length_accepts_older_buffers() {
+        assert_eq!(versioned_copy_len(40, 40, 48), Ok(40));
+        assert_eq!(versioned_copy_len(48, 40, 48), Ok(48));
+        assert_eq!(versioned_copy_len(64, 40, 48), Ok(48));
+        assert_eq!(
+            versioned_copy_len(39, 40, 48),
+            Err(SyscallError::InvalidArgument)
+        );
     }
 
     #[test]

--- a/fullerene-kernel/src/syscall/memory.rs
+++ b/fullerene-kernel/src/syscall/memory.rs
@@ -1,4 +1,3 @@
-use alloc::vec;
 use alloc::vec::Vec;
 
 use core::sync::atomic::{AtomicU64, Ordering};
@@ -201,14 +200,22 @@ pub(crate) fn syscall_protect_memory(addr: u64, length: u64, prot: u64) -> Sysca
 }
 
 pub(crate) fn syscall_query_memory(info_buf: *mut u8, buf_size: usize) -> SyscallResult {
-    if info_buf.is_null() || buf_size < 64 || buf_size > (1 << 20) {
+    if info_buf.is_null() || buf_size < fullerene_abi::MemoryInfo::BYTE_SIZE {
         return Err(SyscallError::InvalidArgument);
     }
-    petroleum::validate_user_buffer(info_buf as usize, buf_size, false)?;
+    petroleum::validate_user_buffer(
+        info_buf as usize,
+        fullerene_abi::MemoryInfo::BYTE_SIZE,
+        false,
+    )?;
 
+    let info = fullerene_abi::MemoryInfo {
+        page_size: 4096,
+        ..fullerene_abi::MemoryInfo::default()
+    };
+    let bytes = info.to_ne_bytes();
     let slice =
-        UserSlice::new(info_buf, buf_size, true).map_err(|_| SyscallError::InvalidArgument)?;
-    let kernel_buf = vec![0u8; buf_size];
-    unsafe { slice.copy_to_user(&kernel_buf) }.map_err(|_| SyscallError::InvalidArgument)?;
-    Ok(0)
+        UserSlice::new(info_buf, bytes.len(), true).map_err(|_| SyscallError::AddressFault)?;
+    unsafe { slice.copy_to_user(&bytes) }.map_err(|_| SyscallError::AddressFault)?;
+    Ok(bytes.len() as u64)
 }

--- a/fullerene-kernel/src/syscall/memory.rs
+++ b/fullerene-kernel/src/syscall/memory.rs
@@ -1,11 +1,10 @@
 use alloc::vec::Vec;
 
 use core::sync::atomic::{AtomicU64, Ordering};
-use petroleum::common::memory::UserSlice;
 use petroleum::page_table::types::PageTableHelper;
 use x86_64::VirtAddr;
 
-use super::interface::{SyscallError, SyscallResult};
+use super::interface::{SyscallError, SyscallResult, copy_versioned_dto_to_user};
 use super::process::with_kernel_mut_result;
 
 const PROT_READ: u64 = 1;
@@ -200,22 +199,15 @@ pub(crate) fn syscall_protect_memory(addr: u64, length: u64, prot: u64) -> Sysca
 }
 
 pub(crate) fn syscall_query_memory(info_buf: *mut u8, buf_size: usize) -> SyscallResult {
-    if info_buf.is_null() || buf_size < fullerene_abi::MemoryInfo::BYTE_SIZE {
-        return Err(SyscallError::InvalidArgument);
-    }
-    petroleum::validate_user_buffer(
-        info_buf as usize,
-        fullerene_abi::MemoryInfo::BYTE_SIZE,
-        false,
-    )?;
-
     let info = fullerene_abi::MemoryInfo {
         page_size: 4096,
         ..fullerene_abi::MemoryInfo::default()
     };
     let bytes = info.to_ne_bytes();
-    let slice =
-        UserSlice::new(info_buf, bytes.len(), true).map_err(|_| SyscallError::AddressFault)?;
-    unsafe { slice.copy_to_user(&bytes) }.map_err(|_| SyscallError::AddressFault)?;
-    Ok(bytes.len() as u64)
+    copy_versioned_dto_to_user(
+        info_buf,
+        buf_size,
+        fullerene_abi::MemoryInfo::MIN_BYTE_SIZE,
+        &bytes,
+    )
 }

--- a/fullerene-kernel/src/syscall/mod.rs
+++ b/fullerene-kernel/src/syscall/mod.rs
@@ -23,9 +23,17 @@ pub use types::*;
 mod tests {
     #[test]
     fn test_syscall_numbers() {
-        assert_eq!(petroleum::SyscallNumber::Exit as u64, 1);
-        assert_eq!(petroleum::SyscallNumber::Write as u64, 4);
-        assert_eq!(petroleum::SyscallNumber::Read as u64, 3);
+        assert_eq!(fullerene_abi::SyscallNumber::Exit.as_u64(), 1);
+        assert_eq!(fullerene_abi::SyscallNumber::Write.as_u64(), 4);
+        assert_eq!(fullerene_abi::SyscallNumber::Read.as_u64(), 3);
+    }
+
+    #[test]
+    fn abi_query_preserves_the_version_only_call() {
+        assert_eq!(
+            super::basic::syscall_abi_query(core::ptr::null_mut(), 0),
+            Ok(fullerene_abi::AbiVersion::CURRENT.pack())
+        );
     }
 }
 
@@ -50,7 +58,7 @@ mod support_matrix {
     const SYSCALLS: &[SyscallInfo] = &[
         SyscallInfo {
             number: 0,
-            name: "abi_version",
+            name: "abi_query",
             support: Support::Full,
             notes: "",
         },

--- a/fullerene-kernel/src/syscall/time.rs
+++ b/fullerene-kernel/src/syscall/time.rs
@@ -64,7 +64,11 @@ pub(crate) fn syscall_clock_gettime(clock_id: u64, timespec_buf: *mut u8) -> Sys
     if timespec_buf.is_null() {
         return Err(SyscallError::InvalidArgument);
     }
-    petroleum::validate_user_buffer(timespec_buf as usize, 16, false)?;
+    petroleum::validate_user_buffer(
+        timespec_buf as usize,
+        fullerene_abi::TimeSpec::BYTE_SIZE,
+        false,
+    )?;
 
     let (sec, nsec) = match clock_id {
         0 => {
@@ -75,12 +79,14 @@ pub(crate) fn syscall_clock_gettime(clock_id: u64, timespec_buf: *mut u8) -> Sys
         _ => return Err(SyscallError::InvalidArgument),
     };
 
+    let bytes = fullerene_abi::TimeSpec {
+        seconds: sec,
+        nanoseconds: nsec,
+    }
+    .to_ne_bytes();
     let slice =
-        UserSlice::new(timespec_buf, 16, true).map_err(|_| SyscallError::InvalidArgument)?;
-    let mut kernel_buf = [0u8; 16];
-    kernel_buf[0..8].copy_from_slice(&sec.to_ne_bytes());
-    kernel_buf[8..16].copy_from_slice(&nsec.to_ne_bytes());
-    unsafe { slice.copy_to_user(&kernel_buf) }.map_err(|_| SyscallError::InvalidArgument)?;
+        UserSlice::new(timespec_buf, bytes.len(), true).map_err(|_| SyscallError::AddressFault)?;
+    unsafe { slice.copy_to_user(&bytes) }.map_err(|_| SyscallError::AddressFault)?;
 
     Ok(0)
 }

--- a/fullerene-kernel/src/syscall/user.rs
+++ b/fullerene-kernel/src/syscall/user.rs
@@ -1,7 +1,7 @@
 /// Syscall helper macros for user space (would be in user-space library)
 #[cfg(feature = "user_space")]
 pub mod user {
-    use super::SyscallNumber;
+    use fullerene_abi::SyscallNumber;
 
     /// Make a system call (user space wrapper)
     #[inline(always)]
@@ -14,9 +14,17 @@ pub mod user {
         arg5: u64,
         arg6: u64,
     ) -> u64 {
-        let mut result: u64;
-        result = petroleum::syscall_call!(syscall_num as u64, arg1, arg2, arg3, arg4, arg5, arg6);
-        result
+        unsafe {
+            petroleum::common::syscall::syscall(
+                syscall_num.as_u64(),
+                arg1,
+                arg2,
+                arg3,
+                arg4,
+                arg5,
+                arg6,
+            )
+        }
     }
 
     /// Exit wrapper

--- a/fullerene-kernel/src/syscall/window.rs
+++ b/fullerene-kernel/src/syscall/window.rs
@@ -89,7 +89,7 @@ pub(crate) fn syscall_get_window_event(
     buf: *mut u8,
     buf_size: usize,
 ) -> SyscallResult {
-    if buf.is_null() || buf_size < 128 {
+    if buf.is_null() || buf_size < fullerene_abi::WindowEvent::BYTE_SIZE {
         return Err(SyscallError::InvalidArgument);
     }
     petroleum::validate_user_buffer(buf as usize, buf_size, false)?;
@@ -100,11 +100,11 @@ pub(crate) fn syscall_get_window_event(
 
         let has_event = kernel::with_kernel(|k| k.event.has_pending()).unwrap_or(false);
         if has_event {
-            let slice = UserSlice::new(buf, 8, true).map_err(|_| SyscallError::InvalidArgument)?;
-            let kernel_buf = [0u8; 8];
-            unsafe { slice.copy_to_user(&kernel_buf) }
-                .map_err(|_| SyscallError::InvalidArgument)?;
-            Ok(8)
+            let bytes = fullerene_abi::WindowEvent::default().to_ne_bytes();
+            let slice =
+                UserSlice::new(buf, bytes.len(), true).map_err(|_| SyscallError::AddressFault)?;
+            unsafe { slice.copy_to_user(&bytes) }.map_err(|_| SyscallError::AddressFault)?;
+            Ok(bytes.len() as u64)
         } else {
             Err(SyscallError::Again)
         }

--- a/fullerene-kernel/src/syscall/window.rs
+++ b/fullerene-kernel/src/syscall/window.rs
@@ -1,10 +1,8 @@
-use crate::map_handle;
-use petroleum::common::memory::UserSlice;
-
-use super::interface::{SyscallError, SyscallResult};
+use super::interface::{SyscallError, SyscallResult, copy_versioned_dto_to_user};
 use super::process::{alloc_handle, check_handle_permission, with_handle_mut};
 use super::types::*;
 use crate::contexts::kernel;
+use crate::map_handle;
 use crate::process;
 
 pub(crate) fn syscall_create_window(
@@ -89,10 +87,9 @@ pub(crate) fn syscall_get_window_event(
     buf: *mut u8,
     buf_size: usize,
 ) -> SyscallResult {
-    if buf.is_null() || buf_size < fullerene_abi::WindowEvent::BYTE_SIZE {
+    if buf.is_null() || buf_size < fullerene_abi::WindowEvent::MIN_BYTE_SIZE {
         return Err(SyscallError::InvalidArgument);
     }
-    petroleum::validate_user_buffer(buf as usize, buf_size, false)?;
 
     let h = Handle::from_raw(handle);
     with_handle_mut(h, |obj| {
@@ -101,10 +98,12 @@ pub(crate) fn syscall_get_window_event(
         let has_event = kernel::with_kernel(|k| k.event.has_pending()).unwrap_or(false);
         if has_event {
             let bytes = fullerene_abi::WindowEvent::default().to_ne_bytes();
-            let slice =
-                UserSlice::new(buf, bytes.len(), true).map_err(|_| SyscallError::AddressFault)?;
-            unsafe { slice.copy_to_user(&bytes) }.map_err(|_| SyscallError::AddressFault)?;
-            Ok(bytes.len() as u64)
+            copy_versioned_dto_to_user(
+                buf,
+                buf_size,
+                fullerene_abi::WindowEvent::MIN_BYTE_SIZE,
+                &bytes,
+            )
         } else {
             Err(SyscallError::Again)
         }

--- a/petroleum/Cargo.toml
+++ b/petroleum/Cargo.toml
@@ -10,6 +10,7 @@ vga_panic = []
 debug_pf = []
 
 [dependencies]
+fullerene-abi = { path = "../fullerene-abi" }
 # Using spin 0.10 instead of workspace 0.12 — 0.12 changed MutexGuard API (added R generic)
 spin = { version = "0.10.0", default-features = false, features = [
   "once",

--- a/petroleum/src/common/syscall.rs
+++ b/petroleum/src/common/syscall.rs
@@ -1,114 +1,14 @@
-/// System call numbers
-#[repr(u64)]
-#[derive(Debug, Clone, Copy)]
-pub enum SyscallNumber {
-    /// Exit the current process (exit_code in RDI)
-    Exit = 1,
-    /// Create a new process (entry_point in RDI)
-    Fork = 2,
-    /// Read from file descriptor (fd in RDI, buffer in RSI, count in RDX)
-    Read = 3,
-    /// Write to file descriptor (fd in RDI, buffer in RSI, count in RDX)
-    Write = 4,
-    /// Open file (filename in RDI, flags in RSI, mode in RDX)
-    Open = 5,
-    /// Close file descriptor (fd in RDI)
-    Close = 6,
-    /// Wait for process to finish (pid in RDI)
-    Wait = 7,
-    /// Get current process ID
-    GetPid = 20,
-    /// Get process name (buffer in RDI, size in RSI)
-    GetProcessName = 21,
-    /// Yield to scheduler
-    Yield = 22,
+//! Low-level syscall instruction and compatibility wrappers.
+//!
+//! Syscall numbers are owned by the dependency-free `fullerene-abi` crate.
 
-    // ── Memory API (30–39) ──────────────────────────────────────
-    /// Map virtual memory (addr, length, flags)
-    MapMemory = 30,
-    /// Unmap virtual memory (addr, length)
-    UnmapMemory = 31,
-    /// Change page protection (addr, length, prot)
-    ProtectMemory = 32,
-    /// Query memory region info (addr, info_buf)
-    QueryMemory = 33,
+pub use fullerene_abi::SyscallNumber;
 
-    // ── Event API (40–49) ───────────────────────────────────────
-    /// Create an event object (flags → event_handle)
-    CreateEvent = 40,
-    /// Wait on an event (handle, timeout_us)
-    WaitEvent = 41,
-    /// Signal an event (handle)
-    SignalEvent = 42,
-    /// Subscribe to an event type (event_type, callback_info)
-    SubscribeEvent = 43,
-
-    // ── Thread API (50–59) ──────────────────────────────────────
-    /// Create a thread sharing the parent address space (entry, stack, flags → tid)
-    CreateThread = 50,
-    /// Wait for a thread to finish (tid → exit_code)
-    JoinThread = 51,
-    /// Detach a thread so it is cleaned up automatically (tid)
-    DetachThread = 52,
-    /// Exit the calling thread (exit_code)
-    ExitThread = 53,
-
-    // ── Window API (60–69) ──────────────────────────────────────
-    /// Create a window (x, y, w, h, flags → window_handle)
-    CreateWindow = 60,
-    /// Destroy a window (handle)
-    DestroyWindow = 61,
-    /// Resize a window (handle, w, h)
-    ResizeWindow = 62,
-    /// Present / flush window contents (handle)
-    PresentWindow = 63,
-    /// Poll for the next window event (handle, event_buf)
-    GetWindowEvent = 64,
-
-    // ── Device API (70–79) ──────────────────────────────────────
-    /// Enumerate devices of a given class (class, buf, bufsize → count)
-    EnumerateDevices = 70,
-    /// Open a device by ID (device_id → handle)
-    OpenDevice = 71,
-    /// Perform device-specific I/O control (handle, cmd, arg)
-    DeviceIoctl = 72,
-
-    // ── IPC API (80–89) ─────────────────────────────────────────
-    /// Create a message channel (flags → channel_handle)
-    ChannelCreate = 80,
-    /// Send a message on a channel (handle, data, size)
-    ChannelSend = 81,
-    /// Receive a message from a channel (handle, buf, bufsize)
-    ChannelRecv = 82,
-    /// Create a unidirectional pipe (flags → [read_handle, write_handle])
-    PipeCreate = 83,
-
-    // ── Capability / Handle API (90–99) ─────────────────────────
-    /// Transfer a handle to another process (target_pid, handle)
-    HandleTransfer = 90,
-    /// Duplicate a handle (handle → new_handle)
-    HandleDuplicate = 91,
-    /// Revoke a handle (handle)
-    HandleRevoke = 92,
-
-    // ── Time API (100–109) ──────────────────────────────────────
-    /// Get current time from a clock (clock_id, timespec_buf)
-    ClockGetTime = 100,
-    /// Create a timer that signals an event (clock_id, deadline_ns, event_handle)
-    TimerCreate = 101,
-    /// Sleep for the given number of microseconds (us)
-    Sleep = 102,
-    /// Get system uptime in microseconds (uptime_buf)
-    Uptime = 103,
-}
-
-/// Check if VDSO is available (user-space pointer initialized).
 #[inline]
 fn vdso_available() -> bool {
     crate::vdso::user::vdso_ptr_initialized()
 }
 
-/// Execute a raw `syscall` instruction (always traps to kernel).
 #[inline]
 unsafe fn syscall_insn(
     syscall_num: u64,
@@ -138,7 +38,13 @@ unsafe fn syscall_insn(
     result
 }
 
-/// Raw syscall: uses VDSO for non-blocking queries, `syscall` instruction otherwise.
+/// Raw syscall: uses the VDSO for non-blocking queries and traps otherwise.
+///
+/// # Safety
+///
+/// The caller must follow the ABI contract for `syscall_num`, ensure every
+/// pointer argument is valid for the operation, and uphold any aliasing and
+/// lifetime requirements of buffers that the kernel may read or write.
 #[inline]
 pub unsafe fn syscall(
     syscall_num: u64,
@@ -150,30 +56,24 @@ pub unsafe fn syscall(
     arg6: u64,
 ) -> u64 {
     if vdso_available() {
-        // Truly zero-overhead: read directly from VDSO page, no ring submission.
-        if syscall_num == SyscallNumber::Uptime as u64 {
-            if arg1 != 0 {
-                unsafe {
-                    core::ptr::write_unaligned(
-                        arg1 as *mut u64,
-                        crate::vdso::user::vdso_uptime_us(),
-                    );
-                }
-                return 0;
+        if syscall_num == SyscallNumber::Uptime.as_u64() && arg1 != 0 {
+            unsafe {
+                core::ptr::write_unaligned(arg1 as *mut u64, crate::vdso::user::vdso_uptime_us());
             }
-        } else if syscall_num == SyscallNumber::GetPid as u64 {
+            return 0;
+        }
+        if syscall_num == SyscallNumber::GetPid.as_u64() {
             return crate::vdso::user::vdso_pid();
         }
     }
-    // Fallback: traditional syscall instruction (traps to kernel)
     unsafe { syscall_insn(syscall_num, arg1, arg2, arg3, arg4, arg5, arg6) }
 }
 
-/// Simple write syscall wrapper
+/// Compatibility wrapper. New user-space code should use `toluene::sys`.
 pub fn write(fd: i32, buf: &[u8]) -> i64 {
     unsafe {
         syscall(
-            SyscallNumber::Write as u64,
+            SyscallNumber::Write.as_u64(),
             fd as u64,
             buf.as_ptr() as u64,
             buf.len() as u64,
@@ -184,24 +84,24 @@ pub fn write(fd: i32, buf: &[u8]) -> i64 {
     }
 }
 
-/// Simple exit syscall wrapper
+/// Compatibility wrapper. New user-space code should use `toluene::sys`.
 pub fn exit(code: i32) -> ! {
     unsafe {
-        syscall(SyscallNumber::Exit as u64, code as u64, 0, 0, 0, 0, 0);
+        syscall(SyscallNumber::Exit.as_u64(), code as u64, 0, 0, 0, 0, 0);
     }
     loop {
         core::hint::spin_loop();
     }
 }
 
-/// Get PID syscall wrapper
+/// Compatibility wrapper. New user-space code should use `toluene::sys`.
 pub fn getpid() -> u64 {
-    unsafe { syscall(SyscallNumber::GetPid as u64, 0, 0, 0, 0, 0, 0) }
+    unsafe { syscall(SyscallNumber::GetPid.as_u64(), 0, 0, 0, 0, 0, 0) }
 }
 
-/// Yield syscall wrapper
+/// Compatibility wrapper. New user-space code should use `toluene::sys`.
 pub fn sleep() {
     unsafe {
-        syscall(SyscallNumber::Yield as u64, 0, 0, 0, 0, 0, 0);
+        syscall(SyscallNumber::Yield.as_u64(), 0, 0, 0, 0, 0, 0);
     }
 }

--- a/toluene/Cargo.toml
+++ b/toluene/Cargo.toml
@@ -23,6 +23,7 @@ kernel-syscall = []
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+fullerene-abi = { path = "../fullerene-abi" }
 lattice = { path = "../lattice" }
 petroleum = { path = "../petroleum" }
 

--- a/toluene/src/lib.rs
+++ b/toluene/src/lib.rs
@@ -24,6 +24,8 @@
 
 extern crate alloc;
 
+pub use fullerene_abi as abi;
+
 pub mod app;
 pub mod calc;
 pub mod clock;

--- a/toluene/src/main.rs
+++ b/toluene/src/main.rs
@@ -3,7 +3,7 @@
 
 //! User space system call wrappers for toluene
 
-use petroleum::common::syscall::{exit, getpid, sleep, write};
+use toluene::sys::{current_pid, exit_process, write, yield_now};
 
 petroleum::define_panic_handler!();
 
@@ -20,7 +20,7 @@ pub extern "C" fn main() -> ! {
     safe_print!(1, b"Hello from toluene user program!\n");
 
     // Get our PID and display it
-    let pid = getpid() as usize;
+    let pid = current_pid();
     let mut pid_buffer = [0u8; 20];
     let len = petroleum::serial::format_dec_to_buffer(pid, &mut pid_buffer);
     let pid_msg = &pid_buffer[..len];
@@ -30,10 +30,10 @@ pub extern "C" fn main() -> ! {
 
     // Sleep a bit to simulate work
     for _ in 0..10 {
-        sleep();
+        yield_now();
     }
 
     // Write final message and exit
     safe_print!(1, b"Toluene program finished executing.\n");
-    exit(0);
+    exit_process(0);
 }

--- a/toluene/src/sys.rs
+++ b/toluene/src/sys.rs
@@ -1,33 +1,96 @@
-//! System call wrappers for Toluene SDK.
-//!
-//! Thin wrappers around the petroleum syscall interface that provide
-//! ergonomic Rust APIs for user-space programs.
+//! Typed system-call wrappers for the Toluene SDK.
 
-use petroleum::common::syscall::{exit, getpid, sleep, write};
+use fullerene_abi::{AbiInfo, AbiVersion, SyscallErrorCode, SyscallNumber};
+
+#[inline]
+unsafe fn raw_syscall(
+    number: SyscallNumber,
+    arg1: u64,
+    arg2: u64,
+    arg3: u64,
+    arg4: u64,
+    arg5: u64,
+    arg6: u64,
+) -> u64 {
+    unsafe {
+        petroleum::common::syscall::syscall(number.as_u64(), arg1, arg2, arg3, arg4, arg5, arg6)
+    }
+}
+
+#[inline]
+fn syscall_result(value: u64) -> Result<u64, i64> {
+    let signed = value as i64;
+    if signed < 0 { Err(signed) } else { Ok(value) }
+}
+
+/// Query the packed ABI version. This works with kernels predating `AbiInfo`.
+pub fn abi_version() -> AbiVersion {
+    let packed = unsafe { raw_syscall(SyscallNumber::AbiQuery, 0, 0, 0, 0, 0, 0) };
+    AbiVersion::unpack(packed)
+}
+
+/// Query the ABI version and capabilities advertised by the kernel.
+pub fn abi_info() -> Result<AbiInfo, i64> {
+    let mut info = AbiInfo::EMPTY;
+    let value = unsafe {
+        raw_syscall(
+            SyscallNumber::AbiQuery,
+            (&mut info as *mut AbiInfo) as u64,
+            AbiInfo::BYTE_SIZE as u64,
+            0,
+            0,
+            0,
+            0,
+        )
+    };
+    let written = syscall_result(value)? as usize;
+    if written < AbiInfo::BYTE_SIZE || info.struct_size < AbiInfo::BYTE_SIZE as u32 {
+        return Err(-SyscallErrorCode::NotSupported.as_i64());
+    }
+    Ok(info)
+}
 
 /// Get the current process ID.
 pub fn current_pid() -> usize {
-    getpid() as usize
+    unsafe { raw_syscall(SyscallNumber::GetPid, 0, 0, 0, 0, 0, 0) as usize }
 }
 
 /// Yield the CPU to the scheduler.
 pub fn yield_now() {
-    sleep();
+    unsafe {
+        raw_syscall(SyscallNumber::Yield, 0, 0, 0, 0, 0, 0);
+    }
 }
 
 /// Terminate the process with an exit code.
 pub fn exit_process(code: i32) -> ! {
-    exit(code);
+    unsafe {
+        raw_syscall(SyscallNumber::Exit, code as u64, 0, 0, 0, 0, 0);
+    }
+    loop {
+        core::hint::spin_loop();
+    }
+}
+
+/// Write raw bytes to a file descriptor.
+pub fn write(fd: i32, data: &[u8]) -> Result<usize, i64> {
+    let value = unsafe {
+        raw_syscall(
+            SyscallNumber::Write,
+            fd as u64,
+            data.as_ptr() as u64,
+            data.len() as u64,
+            0,
+            0,
+            0,
+        )
+    };
+    syscall_result(value).map(|written| written as usize)
 }
 
 /// Write raw bytes to stdout (fd 1).
 pub fn stdout_write(data: &[u8]) -> Result<usize, i64> {
-    let result = write(1, data);
-    if result < 0 {
-        Err(result)
-    } else {
-        Ok(result as usize)
-    }
+    write(1, data)
 }
 
 /// Print a string to stdout.
@@ -41,16 +104,36 @@ pub fn print(s: &str) {
     let _ = stdout_write(s.as_bytes());
 }
 
-/// Get the number of active processes.
-/// Returns None if the syscall is not available.
+/// Get the number of active processes, if supported by the kernel.
 pub fn process_count() -> Option<usize> {
-    // No syscall available yet
     None
 }
 
-/// Get the system uptime in scheduler ticks.
-/// Returns None if the syscall is not available.
+/// Get system uptime in microseconds.
 pub fn uptime_ticks() -> Option<u64> {
-    // No syscall available yet
-    None
+    let mut uptime = 0u64;
+    let value = unsafe {
+        raw_syscall(
+            SyscallNumber::Uptime,
+            (&mut uptime as *mut u64) as u64,
+            0,
+            0,
+            0,
+            0,
+            0,
+        )
+    };
+    syscall_result(value).ok().map(|_| uptime)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn negative_returns_are_errors() {
+        let raw = (-SyscallErrorCode::InvalidArgument.as_i64()) as u64;
+        assert_eq!(syscall_result(raw), Err(-22));
+        assert_eq!(syscall_result(7), Ok(7));
+    }
 }


### PR DESCRIPTION
# Pull Request

## Overview

- Make `fullerene-abi` the dependency-free authority for typed native syscall numbers, error codes, ABI versioning, capability bits, and stable `#[repr(C)]` DTOs.
- Dispatch typed syscall numbers in the kernel and extend syscall 0 with a backwards-compatible `AbiInfo` version/capability query.
- Make Toluene depend on the shared ABI directly and expose typed SDK wrappers while Petroleum keeps compatibility re-exports.
- Use the shared DTOs for memory, time, device, and window syscall buffers.
- Update architecture/API/workspace documentation and complete all P1-2 TODO checkboxes.

Closes #279

## Type of Changes

- [x] **New feature**
- [x] **Refactoring**
- [x] **Documentation**
- [x] **Tests**

## Testing

- `cargo test -p fullerene-abi` (4 passed)
- `cargo test -p toluene --lib` (6 passed)
- `cargo test -p fullerene-kernel` (33 passed)
- `cargo check -p fullerene-kernel --features user_space`
- Host workspace check excluding UEFI-only packages and the standalone Toluene binary
- UEFI kernel build and Bellows check with `x86_64-unknown-uefi`

## Compatibility

The ABI minor version advances to 0.3.0. Calling syscall 0 without a buffer still returns the packed version, so existing clients retain their previous query path.

## Checklist

- [x] Code follows project style guidelines
- [x] Tests added and passing
- [x] Documentation updated
- [x] ABI layout sizes and alignments checked at compile time
- [x] No unnecessary runtime dependencies added
