### PR TITLE
refactor(solvent): own runtime state in context

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -268,7 +268,9 @@ and explicitly registers the Wi-Fi service via `solvent::register_wifi_service()
 Solvent's crate root is an API facade rather than an orchestration
 implementation. Runtime responsibilities are divided under `solvent/src/`:
 
-- `runtime_context` defines runtime state, configuration, and initialization.
+- `runtime_context` owns callback, runtime-state, event-queue, and dispatcher
+  synchronization domains together with runtime configuration and
+  initialization.
 - `input_loop` translates PS/2 mouse and keyboard state into desktop actions or
   Resonance events.
 - `event_loop` owns timer processing, service ticks, event dispatch, and frame
@@ -278,9 +280,12 @@ implementation. Runtime responsibilities are divided under `solvent/src/`:
 - `callbacks` defines the kernel-provided service contract and transfer types.
 - `services` owns runtime-managed services and their shared UI snapshots.
 
-This is a structural boundary only. The current singleton ownership remains
-unchanged until the separate context-ownership work moves callbacks, runtime
-state, the event queue, and the dispatcher into an explicit `RuntimeContext`.
+`RUNTIME_CONTEXT` is the single owner of callbacks, mutable desktop runtime
+state, the Resonance event queue, and the dispatcher. Each remains behind a
+separate lock because dispatch handlers may re-enter runtime operations.
+Callers acquire these domains through `RuntimeContext` guard methods; the
+former standalone `SOLVENT_CALLBACKS`, `RUNTIME`, `EVENT_QUEUE`, and
+`DISPATCHER` globals no longer exist.
 
 ---
 

--- a/docs/fullerene_todo.md
+++ b/docs/fullerene_todo.md
@@ -74,7 +74,7 @@ You may close them using the "Development" section of the PR, or create new issu
 - [x] Split `iwlwifi.rs` → device, firmware, registers, tx, rx, connection_state ([#290](https://github.com/p14c31355/fullerene/issues/290))
 
 ### P1-4. Context ownership for callbacks & hooks
-- [ ] Move `solvent::SOLVENT_CALLBACKS`, `RUNTIME`, `EVENT_QUEUE`, `DISPATCHER` into `RuntimeContext`
+- [x] Move `solvent::SOLVENT_CALLBACKS`, `RUNTIME`, `EVENT_QUEUE`, `DISPATCHER` into `RuntimeContext` ([#292](https://github.com/p14c31355/fullerene/issues/292))
 - [ ] Move `nozzle::FS_HOOKS`, `SYS_HOOKS` into constructor-injected services
 - [ ] Move `carrier::SHARED_HISTORY` into terminal session
 - [x] Device registry: persistent `/dev` identity with exclusive take lease

--- a/fullerene-kernel/src/scheduler.rs
+++ b/fullerene-kernel/src/scheduler.rs
@@ -26,7 +26,7 @@ use crate::scheduler_context::SCHEDULER;
 /// Returns `None` if RTC is unavailable or invalid.
 fn read_rtc_us() -> Option<u64> {
     // Obtain wall-clock callback from Solvent
-    let cb = solvent::RUNTIME_CONTEXT.callbacks().wall_clock?;
+    let cb = solvent::RUNTIME_CONTEXT.callback_snapshot().wall_clock?;
     let (year, month, day, hour, minute, second) = cb()?;
 
     // Validate ranges

--- a/fullerene-kernel/src/scheduler.rs
+++ b/fullerene-kernel/src/scheduler.rs
@@ -26,7 +26,7 @@ use crate::scheduler_context::SCHEDULER;
 /// Returns `None` if RTC is unavailable or invalid.
 fn read_rtc_us() -> Option<u64> {
     // Obtain wall-clock callback from Solvent
-    let cb = solvent::SOLVENT_CALLBACKS.lock().wall_clock?;
+    let cb = solvent::RUNTIME_CONTEXT.callbacks().wall_clock?;
     let (year, month, day, hour, minute, second) = cb()?;
 
     // Validate ranges

--- a/fullerene-kernel/src/shell.rs
+++ b/fullerene-kernel/src/shell.rs
@@ -609,7 +609,7 @@ fn register_nozzle_hooks() {
             }
         }
         "date" => {
-            let cb = solvent::SOLVENT_CALLBACKS.lock().wall_clock;
+            let cb = solvent::RUNTIME_CONTEXT.callbacks().wall_clock;
             match cb.and_then(|f| f()) {
                 Some((y, mo, d, h, mi, s)) => tline!(ctx.terminal, "{:04}-{:02}-{:02} {:02}:{:02}:{:02}", y, mo, d, h, mi, s),
                 None => tstr!(ctx.terminal, "date: RTC not available"),

--- a/fullerene-kernel/src/shell.rs
+++ b/fullerene-kernel/src/shell.rs
@@ -609,7 +609,7 @@ fn register_nozzle_hooks() {
             }
         }
         "date" => {
-            let cb = solvent::RUNTIME_CONTEXT.callbacks().wall_clock;
+            let cb = solvent::RUNTIME_CONTEXT.callback_snapshot().wall_clock;
             match cb.and_then(|f| f()) {
                 Some((y, mo, d, h, mi, s)) => tline!(ctx.terminal, "{:04}-{:02}-{:02} {:02}:{:02}:{:02}", y, mo, d, h, mi, s),
                 None => tstr!(ctx.terminal, "date: RTC not available"),

--- a/solvent/src/callbacks.rs
+++ b/solvent/src/callbacks.rs
@@ -11,6 +11,7 @@ pub type VfsRemoveCallback = fn(&str, bool) -> Result<(), genome::FsError>;
 pub type MountedDriveListCallback = fn() -> Vec<(String, String)>;
 
 /// Kernel services installed into the Solvent orchestration layer.
+#[derive(Clone, Copy)]
 pub struct SolventCallbacks {
     pub shell_cmd: Option<fn(&str) -> String>,
     pub launch_shell: Option<fn()>,
@@ -56,9 +57,8 @@ impl SolventCallbacks {
 }
 
 pub fn exec_shell_command(input: &str) -> String {
-    let callbacks = crate::RUNTIME_CONTEXT.callbacks();
+    let callbacks = crate::RUNTIME_CONTEXT.callback_snapshot();
     if let Some(shell_cmd) = callbacks.shell_cmd {
-        drop(callbacks);
         shell_cmd(input)
     } else {
         String::from("(no shell)\n")
@@ -66,15 +66,16 @@ pub fn exec_shell_command(input: &str) -> String {
 }
 
 pub fn launch_shell() {
-    let callbacks = crate::RUNTIME_CONTEXT.callbacks();
+    let callbacks = crate::RUNTIME_CONTEXT.callback_snapshot();
     if let Some(launch_shell) = callbacks.launch_shell {
-        drop(callbacks);
         launch_shell();
     }
 }
 
 pub fn get_mounted_drives() -> Vec<(String, String)> {
-    let list_drives = crate::RUNTIME_CONTEXT.callbacks().mounted_drive_list;
+    let list_drives = crate::RUNTIME_CONTEXT
+        .callback_snapshot()
+        .mounted_drive_list;
     list_drives
         .map(|list_drives| list_drives())
         .unwrap_or_default()

--- a/solvent/src/callbacks.rs
+++ b/solvent/src/callbacks.rs
@@ -2,8 +2,6 @@
 
 use alloc::string::String;
 use alloc::vec::Vec;
-use spin::Mutex;
-
 pub type WallClockCallback = fn() -> Option<(u16, u8, u8, u8, u8, u8)>;
 pub type VfsReadDirCallback = fn(&str) -> Result<Vec<VfsEntry>, genome::FsError>;
 pub type VfsReadCallback = fn(&str) -> Result<Vec<u8>, genome::FsError>;
@@ -53,14 +51,12 @@ impl SolventCallbacks {
     }
 
     pub fn install(self) {
-        *SOLVENT_CALLBACKS.lock() = self;
+        crate::RUNTIME_CONTEXT.install_callbacks(self);
     }
 }
 
-pub static SOLVENT_CALLBACKS: Mutex<SolventCallbacks> = Mutex::new(SolventCallbacks::none());
-
 pub fn exec_shell_command(input: &str) -> String {
-    let callbacks = SOLVENT_CALLBACKS.lock();
+    let callbacks = crate::RUNTIME_CONTEXT.callbacks();
     if let Some(shell_cmd) = callbacks.shell_cmd {
         drop(callbacks);
         shell_cmd(input)
@@ -70,7 +66,7 @@ pub fn exec_shell_command(input: &str) -> String {
 }
 
 pub fn launch_shell() {
-    let callbacks = SOLVENT_CALLBACKS.lock();
+    let callbacks = crate::RUNTIME_CONTEXT.callbacks();
     if let Some(launch_shell) = callbacks.launch_shell {
         drop(callbacks);
         launch_shell();
@@ -78,7 +74,7 @@ pub fn launch_shell() {
 }
 
 pub fn get_mounted_drives() -> Vec<(String, String)> {
-    let list_drives = SOLVENT_CALLBACKS.lock().mounted_drive_list;
+    let list_drives = crate::RUNTIME_CONTEXT.callbacks().mounted_drive_list;
     list_drives
         .map(|list_drives| list_drives())
         .unwrap_or_default()

--- a/solvent/src/clock.rs
+++ b/solvent/src/clock.rs
@@ -37,7 +37,7 @@ fn days_in_month(month: i16, year: i16) -> i16 {
 /// dirty rect for the taskbar / top panel).
 pub fn update_clock() -> bool {
     let offset = TIMEZONE_OFFSET_HOURS.load(core::sync::atomic::Ordering::Relaxed);
-    let time_str = if let Some(get_time) = RUNTIME_CONTEXT.callbacks().wall_clock {
+    let time_str = if let Some(get_time) = RUNTIME_CONTEXT.callback_snapshot().wall_clock {
         if let Some((year, month, day, hour, minute, _second)) = get_time() {
             let mut local_hour = hour as i16 + offset as i16;
             let mut local_day = day as i16;

--- a/solvent/src/clock.rs
+++ b/solvent/src/clock.rs
@@ -2,7 +2,7 @@
 //!
 //! Extracted from `lib.rs` to reduce the size of the god-module.
 
-use crate::SOLVENT_CALLBACKS;
+use crate::RUNTIME_CONTEXT;
 use alloc::string::String;
 use spin::Mutex;
 
@@ -37,7 +37,7 @@ fn days_in_month(month: i16, year: i16) -> i16 {
 /// dirty rect for the taskbar / top panel).
 pub fn update_clock() -> bool {
     let offset = TIMEZONE_OFFSET_HOURS.load(core::sync::atomic::Ordering::Relaxed);
-    let time_str = if let Some(get_time) = SOLVENT_CALLBACKS.lock().wall_clock {
+    let time_str = if let Some(get_time) = RUNTIME_CONTEXT.callbacks().wall_clock {
         if let Some((year, month, day, hour, minute, _second)) = get_time() {
             let mut local_hour = hour as i16 + offset as i16;
             let mut local_day = day as i16;
@@ -81,7 +81,7 @@ pub fn update_clock() -> bool {
         String::from("---- ---- ----")
     };
 
-    let mut rt = crate::RUNTIME.lock();
+    let mut rt = crate::RUNTIME_CONTEXT.runtime();
     let mut changed = false;
     if let Some(ref mut r) = *rt {
         if r.desktop.clock_text != time_str {

--- a/solvent/src/editor_bridge.rs
+++ b/solvent/src/editor_bridge.rs
@@ -2,9 +2,7 @@
 //!
 //! Extracted from lib.rs to keep the main module focused on orchestration.
 
-use crate::{
-    DEFAULT_COLS, DEFAULT_ROWS, GLYPH_H, GLYPH_W, HEAP_EXTEND_RESERVE, RUNTIME, SOLVENT_CALLBACKS,
-};
+use crate::{DEFAULT_COLS, DEFAULT_ROWS, GLYPH_H, GLYPH_W, HEAP_EXTEND_RESERVE, RUNTIME_CONTEXT};
 use alloc::vec;
 use lattice::terminal_surface::{self, Cell as LatticeCell};
 use resonance::KeyCode;
@@ -43,7 +41,7 @@ pub(crate) fn render_editor(rt: &mut crate::RuntimeState) {
             let additional = needed
                 .saturating_sub(HEAP_EXTEND_RESERVE.load(core::sync::atomic::Ordering::Relaxed))
                 .next_multiple_of(4096);
-            let extend_fn = SOLVENT_CALLBACKS.lock().heap_extend;
+            let extend_fn = RUNTIME_CONTEXT.callbacks().heap_extend;
             if extend_fn.is_none() || extend_fn.unwrap()(additional).is_err() {
                 return;
             }
@@ -138,7 +136,7 @@ pub(crate) fn editor_save_current(rt: &mut crate::RuntimeState) {
         None => return,
     };
     let content = rt.editor_buf.full_text();
-    let write_fn = match SOLVENT_CALLBACKS.lock().vfs_write {
+    let write_fn = match RUNTIME_CONTEXT.callbacks().vfs_write {
         Some(f) => f,
         None => return,
     };
@@ -152,7 +150,7 @@ pub(crate) fn editor_save_current(rt: &mut crate::RuntimeState) {
 /// Handle a key event for the editor.
 pub fn editor_handle_key(scancode: u8, pressed: bool) {
     let key = crate::scancode_to_resonance_keycode(scancode);
-    let mut rt = RUNTIME.lock();
+    let mut rt = RUNTIME_CONTEXT.runtime();
     let rt = match rt.as_mut() {
         Some(r) => r,
         None => return,

--- a/solvent/src/editor_bridge.rs
+++ b/solvent/src/editor_bridge.rs
@@ -41,7 +41,7 @@ pub(crate) fn render_editor(rt: &mut crate::RuntimeState) {
             let additional = needed
                 .saturating_sub(HEAP_EXTEND_RESERVE.load(core::sync::atomic::Ordering::Relaxed))
                 .next_multiple_of(4096);
-            let extend_fn = RUNTIME_CONTEXT.callbacks().heap_extend;
+            let extend_fn = RUNTIME_CONTEXT.callback_snapshot().heap_extend;
             if extend_fn.is_none() || extend_fn.unwrap()(additional).is_err() {
                 return;
             }
@@ -136,7 +136,7 @@ pub(crate) fn editor_save_current(rt: &mut crate::RuntimeState) {
         None => return,
     };
     let content = rt.editor_buf.full_text();
-    let write_fn = match RUNTIME_CONTEXT.callbacks().vfs_write {
+    let write_fn = match RUNTIME_CONTEXT.callback_snapshot().vfs_write {
         Some(f) => f,
         None => return,
     };

--- a/solvent/src/event_loop.rs
+++ b/solvent/src/event_loop.rs
@@ -74,7 +74,7 @@ fn service_explorer_navigation() {
     // Filesystem and hardware I/O must run without the runtime lock. Rendering
     // takes locks in the opposite direction and synchronous removable-media I/O
     // here previously deadlocked the desktop when a directory was opened.
-    let callback = RUNTIME_CONTEXT.callbacks().vfs_readdir;
+    let callback = RUNTIME_CONTEXT.callback_snapshot().vfs_readdir;
     let result = callback
         .ok_or(genome::FsError::NotSupported)
         .and_then(|read| read(&path));
@@ -197,7 +197,7 @@ pub fn runtime_tick(now: u64, framebuffer: &mut petroleum::graphics::Framebuffer
     let tick = GLOBAL_TICK.load(core::sync::atomic::Ordering::Relaxed);
     if tick.wrapping_sub(LAST_USB_POLL.load(core::sync::atomic::Ordering::Relaxed)) >= 100 {
         LAST_USB_POLL.store(tick, core::sync::atomic::Ordering::Relaxed);
-        let poll_usb = RUNTIME_CONTEXT.callbacks().usb_poll;
+        let poll_usb = RUNTIME_CONTEXT.callback_snapshot().usb_poll;
         if let Some(poll_usb) = poll_usb
             && poll_usb()
             && let Some(runtime) = RUNTIME_CONTEXT.runtime().as_mut()

--- a/solvent/src/event_loop.rs
+++ b/solvent/src/event_loop.rs
@@ -5,8 +5,8 @@ use resonance::Event;
 use spin::Mutex;
 
 use crate::{
-    CURSOR_TIMER_ID, DISPATCHER, EVENT_QUEUE, FRAME_INTERVAL_MS, FRAME_TIMER_ID, NETWORK_SNAPSHOT,
-    RENDERING_SUSPENDED, RUNTIME, SERVICES, SOLVENT_CALLBACKS, TSC_PER_MS,
+    CURSOR_TIMER_ID, FRAME_INTERVAL_MS, FRAME_TIMER_ID, NETWORK_SNAPSHOT, RENDERING_SUSPENDED,
+    RUNTIME_CONTEXT, SERVICES, TSC_PER_MS,
 };
 
 pub static GLOBAL_TICK: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
@@ -17,7 +17,7 @@ static RENDER_FN: Mutex<Option<fn()>> = Mutex::new(None);
 static LAST_USB_POLL: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
 
 pub fn chrono_tick(now: u64) {
-    let mut runtime = RUNTIME.lock();
+    let mut runtime = RUNTIME_CONTEXT.runtime();
     let runtime = match runtime.as_mut() {
         Some(runtime) => runtime,
         None => return,
@@ -38,14 +38,14 @@ pub fn chrono_tick(now: u64) {
 }
 
 pub fn push_key_event(event: Event) {
-    if let Some(queue) = EVENT_QUEUE.lock().as_mut() {
+    if let Some(queue) = RUNTIME_CONTEXT.event_queue().as_mut() {
         queue.push(event);
     }
 }
 
 pub fn process_events() {
-    let mut dispatcher = DISPATCHER.lock();
-    let mut queue = EVENT_QUEUE.lock();
+    let mut dispatcher = RUNTIME_CONTEXT.dispatcher();
+    let mut queue = RUNTIME_CONTEXT.event_queue();
     if let (Some(dispatcher), Some(queue)) = (dispatcher.as_mut(), queue.as_mut()) {
         dispatcher.dispatch_queue(queue);
     }
@@ -56,8 +56,8 @@ pub fn set_render_fn(render_fn: fn()) {
 }
 
 fn service_explorer_navigation() {
-    let step = RUNTIME
-        .lock()
+    let step = RUNTIME_CONTEXT
+        .runtime()
         .as_mut()
         .and_then(|runtime| runtime.explorer.as_mut()?.take_navigation_step());
     let Some(step) = step else { return };
@@ -74,7 +74,7 @@ fn service_explorer_navigation() {
     // Filesystem and hardware I/O must run without the runtime lock. Rendering
     // takes locks in the opposite direction and synchronous removable-media I/O
     // here previously deadlocked the desktop when a directory was opened.
-    let callback = SOLVENT_CALLBACKS.lock().vfs_readdir;
+    let callback = RUNTIME_CONTEXT.callbacks().vfs_readdir;
     let result = callback
         .ok_or(genome::FsError::NotSupported)
         .and_then(|read| read(&path));
@@ -83,7 +83,7 @@ fn service_explorer_navigation() {
         Err(error) => nitrogen::debug_status!("Explorer", "readdir failed: {}", error),
     }
 
-    if let Some(runtime) = RUNTIME.lock().as_mut()
+    if let Some(runtime) = RUNTIME_CONTEXT.runtime().as_mut()
         && let Some(explorer) = runtime.explorer.as_mut()
     {
         explorer.finish_navigation(path, result);
@@ -114,7 +114,7 @@ pub fn tick_core(now: u64) {
         let access_points = snapshot.aps.clone();
         let status = snapshot.status.clone();
         drop(snapshot);
-        if let Some(runtime) = RUNTIME.lock().as_mut()
+        if let Some(runtime) = RUNTIME_CONTEXT.runtime().as_mut()
             && runtime.desktop.update_ap_list(access_points, status)
         {
             runtime.frame_due = true;
@@ -123,7 +123,7 @@ pub fn tick_core(now: u64) {
 
     process_events();
     service_explorer_navigation();
-    if RUNTIME.lock().as_mut().is_some_and(|runtime| {
+    if RUNTIME_CONTEXT.runtime().as_mut().is_some_and(|runtime| {
         let pending = runtime.shell_launch_pending;
         runtime.shell_launch_pending = false;
         pending
@@ -131,7 +131,7 @@ pub fn tick_core(now: u64) {
         crate::ensure_terminal_window();
         crate::launch_shell();
     }
-    if RUNTIME.lock().as_mut().is_some_and(|runtime| {
+    if RUNTIME_CONTEXT.runtime().as_mut().is_some_and(|runtime| {
         let pending = runtime.editor_launch_pending;
         runtime.editor_launch_pending = false;
         pending
@@ -146,7 +146,7 @@ pub fn runtime_tick_no_fb() {
     }
     let now = YIELD_TICK.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     tick_core(now);
-    let do_render = RUNTIME.lock().as_mut().is_some_and(|runtime| {
+    let do_render = RUNTIME_CONTEXT.runtime().as_mut().is_some_and(|runtime| {
         let due = runtime.frame_due;
         if due {
             let frame_tsc = TSC_PER_MS
@@ -173,7 +173,7 @@ pub fn runtime_tick_no_fb() {
 }
 
 pub fn consume_frame_due() -> bool {
-    RUNTIME.lock().as_mut().is_some_and(|runtime| {
+    RUNTIME_CONTEXT.runtime().as_mut().is_some_and(|runtime| {
         let due = runtime.frame_due;
         runtime.frame_due = false;
         due
@@ -182,8 +182,8 @@ pub fn consume_frame_due() -> bool {
 
 /// Return whether a cursor-only update is waiting for a framebuffer guard.
 pub fn cursor_update_due() -> bool {
-    RUNTIME
-        .lock()
+    RUNTIME_CONTEXT
+        .runtime()
         .as_ref()
         .is_some_and(|runtime| runtime.cursor_redraw_from.is_some())
 }
@@ -197,10 +197,10 @@ pub fn runtime_tick(now: u64, framebuffer: &mut petroleum::graphics::Framebuffer
     let tick = GLOBAL_TICK.load(core::sync::atomic::Ordering::Relaxed);
     if tick.wrapping_sub(LAST_USB_POLL.load(core::sync::atomic::Ordering::Relaxed)) >= 100 {
         LAST_USB_POLL.store(tick, core::sync::atomic::Ordering::Relaxed);
-        let poll_usb = SOLVENT_CALLBACKS.lock().usb_poll;
+        let poll_usb = RUNTIME_CONTEXT.callbacks().usb_poll;
         if let Some(poll_usb) = poll_usb
             && poll_usb()
-            && let Some(runtime) = RUNTIME.lock().as_mut()
+            && let Some(runtime) = RUNTIME_CONTEXT.runtime().as_mut()
             && let Some(explorer) = runtime.explorer.as_mut()
         {
             explorer.refresh_sidebar();
@@ -209,7 +209,7 @@ pub fn runtime_tick(now: u64, framebuffer: &mut petroleum::graphics::Framebuffer
         }
     }
 
-    let do_render = RUNTIME.lock().as_mut().is_some_and(|runtime| {
+    let do_render = RUNTIME_CONTEXT.runtime().as_mut().is_some_and(|runtime| {
         let due = runtime.frame_due;
         runtime.frame_due = false;
         due

--- a/solvent/src/explorer.rs
+++ b/solvent/src/explorer.rs
@@ -722,7 +722,7 @@ fn basename(path: &str) -> &str {
 fn path_exists(path: &str) -> bool {
     let parent = parent_path(path);
     let name = basename(path);
-    let Some(readdir) = RUNTIME_CONTEXT.callbacks().vfs_readdir else {
+    let Some(readdir) = RUNTIME_CONTEXT.callback_snapshot().vfs_readdir else {
         return false;
     };
     readdir(&parent).ok().is_some_and(|entries| {
@@ -754,7 +754,7 @@ fn unique_destination(directory: &str, name: &str) -> String {
 
 fn copy_entry(source: &str, destination: &str, is_dir: bool) -> Result<(), genome::FsError> {
     let copy = RUNTIME_CONTEXT
-        .callbacks()
+        .callback_snapshot()
         .vfs_copy
         .ok_or(genome::FsError::NotSupported)?;
     copy(source, destination, is_dir)
@@ -762,7 +762,7 @@ fn copy_entry(source: &str, destination: &str, is_dir: bool) -> Result<(), genom
 
 fn move_entry(source: &str, destination: &str, is_dir: bool) -> Result<(), genome::FsError> {
     let move_path = RUNTIME_CONTEXT
-        .callbacks()
+        .callback_snapshot()
         .vfs_move
         .ok_or(genome::FsError::NotSupported)?;
     move_path(source, destination, is_dir)
@@ -770,7 +770,7 @@ fn move_entry(source: &str, destination: &str, is_dir: bool) -> Result<(), genom
 
 fn delete_entry(path: &str, is_dir: bool) -> Result<(), genome::FsError> {
     let remove = RUNTIME_CONTEXT
-        .callbacks()
+        .callback_snapshot()
         .vfs_remove
         .ok_or(genome::FsError::NotSupported)?;
     remove(path, is_dir)

--- a/solvent/src/explorer.rs
+++ b/solvent/src/explorer.rs
@@ -22,7 +22,7 @@
 //! +-----------------------------------------------------------+
 //! ```
 
-use crate::{SOLVENT_CALLBACKS, VfsEntry};
+use crate::{RUNTIME_CONTEXT, VfsEntry};
 use alloc::format;
 use alloc::string::String;
 use alloc::vec;
@@ -722,7 +722,7 @@ fn basename(path: &str) -> &str {
 fn path_exists(path: &str) -> bool {
     let parent = parent_path(path);
     let name = basename(path);
-    let Some(readdir) = SOLVENT_CALLBACKS.lock().vfs_readdir else {
+    let Some(readdir) = RUNTIME_CONTEXT.callbacks().vfs_readdir else {
         return false;
     };
     readdir(&parent).ok().is_some_and(|entries| {
@@ -753,24 +753,24 @@ fn unique_destination(directory: &str, name: &str) -> String {
 }
 
 fn copy_entry(source: &str, destination: &str, is_dir: bool) -> Result<(), genome::FsError> {
-    let copy = SOLVENT_CALLBACKS
-        .lock()
+    let copy = RUNTIME_CONTEXT
+        .callbacks()
         .vfs_copy
         .ok_or(genome::FsError::NotSupported)?;
     copy(source, destination, is_dir)
 }
 
 fn move_entry(source: &str, destination: &str, is_dir: bool) -> Result<(), genome::FsError> {
-    let move_path = SOLVENT_CALLBACKS
-        .lock()
+    let move_path = RUNTIME_CONTEXT
+        .callbacks()
         .vfs_move
         .ok_or(genome::FsError::NotSupported)?;
     move_path(source, destination, is_dir)
 }
 
 fn delete_entry(path: &str, is_dir: bool) -> Result<(), genome::FsError> {
-    let remove = SOLVENT_CALLBACKS
-        .lock()
+    let remove = RUNTIME_CONTEXT
+        .callbacks()
         .vfs_remove
         .ok_or(genome::FsError::NotSupported)?;
     remove(path, is_dir)

--- a/solvent/src/handlers.rs
+++ b/solvent/src/handlers.rs
@@ -1,9 +1,9 @@
 //! Event handlers — extracted from lib.rs as part of god-module decomposition.
 //!
-//! These handlers are thin wrappers that delegate to `crate` globals.
+//! These handlers are thin wrappers over state owned by `RuntimeContext`.
 //! The heavy logic (menu dispatch, terminal I/O) lives in dedicated modules.
 
-use crate::{FB_DIMS, RUNTIME, SUPER_HELD};
+use crate::{FB_DIMS, RUNTIME_CONTEXT, SUPER_HELD};
 use lattice::shell_overlay::ShellState;
 use resonance::{Event, EventHandler, InputEvent, KeyCode, MouseButton};
 
@@ -13,7 +13,7 @@ pub(crate) struct WmEventHandler;
 
 impl EventHandler for WmEventHandler {
     fn handle(&mut self, event: &Event) -> bool {
-        let mut rt = RUNTIME.lock();
+        let mut rt = RUNTIME_CONTEXT.runtime();
         let rt = match rt.as_mut() {
             Some(r) => r,
             None => return false,
@@ -42,7 +42,7 @@ impl EventHandler for WmEventHandler {
                                 "Shell" => {
                                     // Defer shell launch — cannot call
                                     // ensure_terminal_window() or launch_shell()
-                                    // while holding RUNTIME lock (deadlock).
+                                    // while holding the runtime-state lock (deadlock).
                                     rt.shell_launch_pending = true;
                                     rt.frame_due = true;
                                     return true;
@@ -301,7 +301,7 @@ fn handle_appgrid_click(rt: &mut crate::RuntimeState) -> bool {
             match idx {
                 0 => {
                     // Defer shell launch — cannot call ensure_terminal_window()
-                    // or launch_shell() while holding RUNTIME lock (deadlock).
+                    // or launch_shell() while holding the runtime-state lock (deadlock).
                     rt.shell_launch_pending = true;
                     rt.shell_state = ShellState::Desktop;
                     rt.frame_due = true;
@@ -309,7 +309,7 @@ fn handle_appgrid_click(rt: &mut crate::RuntimeState) -> bool {
                 }
                 2 => {
                     // Defer editor launch — cannot call ensure_editor_window()
-                    // while holding RUNTIME lock (deadlock).
+                    // while holding the runtime-state lock (deadlock).
                     rt.editor_launch_pending = true;
                     rt.shell_state = ShellState::Desktop;
                     rt.frame_due = true;
@@ -339,7 +339,7 @@ impl EventHandler for TerminalInputHandler {
     fn handle(&mut self, event: &Event) -> bool {
         match event {
             Event::Input(InputEvent::KeyDown(KeyCode::PageUp)) => {
-                if let Some(ref mut rt) = *RUNTIME.lock() {
+                if let Some(ref mut rt) = *RUNTIME_CONTEXT.runtime() {
                     rt.term_buf.scroll_back(1);
                     rt.term_dirty = true;
                     rt.frame_due = true;
@@ -347,7 +347,7 @@ impl EventHandler for TerminalInputHandler {
                 true
             }
             Event::Input(InputEvent::KeyDown(KeyCode::PageDown)) => {
-                if let Some(ref mut rt) = *RUNTIME.lock() {
+                if let Some(ref mut rt) = *RUNTIME_CONTEXT.runtime() {
                     rt.term_buf.scroll_forward(1);
                     rt.term_dirty = true;
                     rt.frame_due = true;
@@ -355,7 +355,7 @@ impl EventHandler for TerminalInputHandler {
                 true
             }
             Event::Input(InputEvent::KeyDown(KeyCode::Home)) => {
-                if let Some(ref mut rt) = *RUNTIME.lock() {
+                if let Some(ref mut rt) = *RUNTIME_CONTEXT.runtime() {
                     rt.term_buf.reset_scroll();
                     rt.term_dirty = true;
                     rt.frame_due = true;
@@ -371,7 +371,7 @@ pub(crate) struct ShellEventHandler;
 
 impl EventHandler for ShellEventHandler {
     fn handle(&mut self, event: &Event) -> bool {
-        let mut rt = RUNTIME.lock();
+        let mut rt = RUNTIME_CONTEXT.runtime();
         let rt = match rt.as_mut() {
             Some(r) => r,
             None => return false,

--- a/solvent/src/input_loop.rs
+++ b/solvent/src/input_loop.rs
@@ -5,7 +5,7 @@ use resonance::{Event, InputEvent, MouseButton};
 use spin::Mutex;
 
 use crate::{
-    EVENT_QUEUE, MOUSE_SENSITIVITY, PREV_MOUSE_BUTTONS, RUNTIME, RuntimeState, editor_bridge,
+    MOUSE_SENSITIVITY, PREV_MOUSE_BUTTONS, RUNTIME_CONTEXT, RuntimeState, editor_bridge,
     network_manager, settings_bridge,
 };
 
@@ -52,7 +52,7 @@ pub fn poll_mouse_state() {
     let moved = old_x != mouse.x || old_y != mouse.y;
     drop(mouse);
 
-    if moved && let Some(queue) = EVENT_QUEUE.lock().as_mut() {
+    if moved && let Some(queue) = RUNTIME_CONTEXT.event_queue().as_mut() {
         queue.push(Event::Input(InputEvent::MouseMove {
             x: cursor_x,
             y: cursor_y,
@@ -62,7 +62,7 @@ pub fn poll_mouse_state() {
     let mut previous_buttons = PREV_MOUSE_BUTTONS.lock();
     let previous = *previous_buttons;
     if buttons != previous
-        && let Some(queue) = EVENT_QUEUE.lock().as_mut()
+        && let Some(queue) = RUNTIME_CONTEXT.event_queue().as_mut()
     {
         mouse_edge!(queue, buttons, previous, 0x01, Left);
         mouse_edge!(queue, buttons, previous, 0x02, Right);
@@ -77,7 +77,7 @@ pub fn poll_keyboard() {
             Some(key) => key,
             None => break,
         };
-        let mut runtime_guard = RUNTIME.lock();
+        let mut runtime_guard = RUNTIME_CONTEXT.runtime();
         if let Some(runtime) = runtime_guard.as_mut() {
             if runtime.desktop.pwd_dialog_open {
                 handle_password_dialog_key(runtime, scancode, pressed);
@@ -118,7 +118,7 @@ fn push_keyboard_event(scancode: u8, pressed: bool) {
     } else {
         Event::Input(InputEvent::KeyUp(key))
     };
-    if let Some(queue) = EVENT_QUEUE.lock().as_mut() {
+    if let Some(queue) = RUNTIME_CONTEXT.event_queue().as_mut() {
         queue.push(event);
     }
 }

--- a/solvent/src/lib.rs
+++ b/solvent/src/lib.rs
@@ -35,8 +35,8 @@ mod viewers;
 mod window_api;
 
 pub use callbacks::{
-    DeviceEntry, ProcessEntry, ProcessStateKind, SOLVENT_CALLBACKS, SolventCallbacks, VfsEntry,
-    exec_shell_command, get_mounted_drives, launch_shell,
+    DeviceEntry, ProcessEntry, ProcessStateKind, SolventCallbacks, VfsEntry, exec_shell_command,
+    get_mounted_drives, launch_shell,
 };
 pub use clock::clock_string;
 pub use editor_bridge::editor_handle_key;
@@ -47,8 +47,9 @@ pub use event_loop::{
 pub use input_loop::{MOUSE_STATE, MouseState, poll_keyboard, poll_mouse_state};
 pub use render::{render, render_cursor_fast, set_render_progress_fn};
 pub use runtime_context::{
-    DISPLAY_BRIGHTNESS_X100, HEAP_EXTEND_RESERVE, MOUSE_SENSITIVITY, RuntimeState, apply_settings,
-    get_tsc_per_ms, init, is_initialized, set_tsc_per_ms,
+    DISPLAY_BRIGHTNESS_X100, HEAP_EXTEND_RESERVE, MOUSE_SENSITIVITY, RUNTIME_CONTEXT,
+    RuntimeContext, RuntimeState, apply_settings, get_tsc_per_ms, init, is_initialized,
+    set_tsc_per_ms,
 };
 #[cfg(not(nitrogen_no_iwlwifi))]
 pub use services::register_wifi_service;
@@ -73,9 +74,8 @@ pub use lattice::wallpaper::{
 
 pub(crate) use input_loop::{scancode_to_ascii, scancode_to_resonance_keycode};
 pub(crate) use runtime_context::{
-    BACK_BUFFER, CURSOR_TIMER_ID, DEFAULT_COLS, DEFAULT_ROWS, DISPATCHER, EVENT_QUEUE, FB_DIMS,
-    FRAME_INTERVAL_MS, FRAME_TIMER_ID, GLYPH_H, GLYPH_W, PREV_MOUSE_BUTTONS, RUNTIME, TERM_WIN_H,
-    TERM_WIN_W, TSC_PER_MS,
+    BACK_BUFFER, CURSOR_TIMER_ID, DEFAULT_COLS, DEFAULT_ROWS, FB_DIMS, FRAME_INTERVAL_MS,
+    FRAME_TIMER_ID, GLYPH_H, GLYPH_W, PREV_MOUSE_BUTTONS, TERM_WIN_H, TERM_WIN_W, TSC_PER_MS,
 };
 pub(crate) use services::SERVICES;
 pub(crate) use window_api::{RENDERING_SUSPENDED, render_explorer};

--- a/solvent/src/menu_actions.rs
+++ b/solvent/src/menu_actions.rs
@@ -120,7 +120,7 @@ pub(crate) fn open_info_window(rt: &mut RuntimeState, kind: InfoWindow) {
     }
     let text = match kind {
         InfoWindow::TaskManager => {
-            let Some(get_procs) = RUNTIME_CONTEXT.callbacks().process_list else {
+            let Some(get_procs) = RUNTIME_CONTEXT.callback_snapshot().process_list else {
                 return show_text_window(
                     rt,
                     "Task Manager",
@@ -154,7 +154,7 @@ pub(crate) fn open_info_window(rt: &mut RuntimeState, kind: InfoWindow) {
             s
         }
         InfoWindow::DeviceManager => {
-            let Some(get_devs) = RUNTIME_CONTEXT.callbacks().device_list else {
+            let Some(get_devs) = RUNTIME_CONTEXT.callback_snapshot().device_list else {
                 return show_text_window(
                     rt,
                     "Device Manager",

--- a/solvent/src/menu_actions.rs
+++ b/solvent/src/menu_actions.rs
@@ -1,7 +1,7 @@
 //! Menu actions and info-window dispatch.
 //! Extracted from the monolith lib.rs to respect AGENTS.md §10.
 
-use crate::{FB_DIMS, RuntimeState, SOLVENT_CALLBACKS, network_manager, truncate_to_chars};
+use crate::{FB_DIMS, RUNTIME_CONTEXT, RuntimeState, network_manager, truncate_to_chars};
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt::Write;
@@ -52,7 +52,7 @@ pub(crate) fn dispatch_menu_action(rt: &mut RuntimeState, action: &DesktopAction
         }
         NewShell => {
             // Defer shell launch — cannot call ensure_terminal_window()
-            // or launch_shell() while holding RUNTIME lock (deadlock).
+            // or launch_shell() while holding RUNTIME_CONTEXT lock (deadlock).
             rt.shell_launch_pending = true;
             rt.desktop.force_full_redraw();
             rt.frame_due = true;
@@ -75,7 +75,7 @@ pub(crate) fn dispatch_menu_action(rt: &mut RuntimeState, action: &DesktopAction
         }
         OpenEditor => {
             // Defer editor launch — cannot call ensure_editor_window()
-            // while holding RUNTIME lock (deadlock).
+            // while holding RUNTIME_CONTEXT lock (deadlock).
             rt.editor_launch_pending = true;
             rt.desktop.force_full_redraw();
             rt.frame_due = true;
@@ -120,7 +120,7 @@ pub(crate) fn open_info_window(rt: &mut RuntimeState, kind: InfoWindow) {
     }
     let text = match kind {
         InfoWindow::TaskManager => {
-            let Some(get_procs) = SOLVENT_CALLBACKS.lock().process_list else {
+            let Some(get_procs) = RUNTIME_CONTEXT.callbacks().process_list else {
                 return show_text_window(
                     rt,
                     "Task Manager",
@@ -154,7 +154,7 @@ pub(crate) fn open_info_window(rt: &mut RuntimeState, kind: InfoWindow) {
             s
         }
         InfoWindow::DeviceManager => {
-            let Some(get_devs) = SOLVENT_CALLBACKS.lock().device_list else {
+            let Some(get_devs) = RUNTIME_CONTEXT.callbacks().device_list else {
                 return show_text_window(
                     rt,
                     "Device Manager",

--- a/solvent/src/render.rs
+++ b/solvent/src/render.rs
@@ -337,7 +337,7 @@ pub fn render(fb: &mut petroleum::graphics::FramebufferGuard) {
             let reserve = HEAP_EXTEND_RESERVE.load(core::sync::atomic::Ordering::Relaxed);
             if back_needed > reserve {
                 let additional = back_needed.saturating_sub(reserve).next_multiple_of(4096);
-                match RUNTIME_CONTEXT.callbacks().heap_extend {
+                match RUNTIME_CONTEXT.callback_snapshot().heap_extend {
                     Some(f) if f(additional).is_ok() => {
                         HEAP_EXTEND_RESERVE
                             .fetch_add(additional, core::sync::atomic::Ordering::Relaxed);

--- a/solvent/src/render.rs
+++ b/solvent/src/render.rs
@@ -2,7 +2,7 @@
 //!
 //! Extracted from `lib.rs` to reduce the size of the god-module.
 
-use crate::{DISPLAY_BRIGHTNESS_X100, HEAP_EXTEND_RESERVE, RUNTIME, SOLVENT_CALLBACKS};
+use crate::{DISPLAY_BRIGHTNESS_X100, HEAP_EXTEND_RESERVE, RUNTIME_CONTEXT};
 use lattice::compositor::{Compositor, RenderTarget};
 use lattice::cursor::Cursor;
 use lattice::scene::DirtyRect;
@@ -195,7 +195,7 @@ pub fn render_cursor_fast(framebuffer: &mut petroleum::graphics::FramebufferGuar
     }
     let _suspend = SuspendGuard;
 
-    let mut runtime = RUNTIME.lock();
+    let mut runtime = RUNTIME_CONTEXT.runtime();
     let Some(runtime) = runtime.as_mut() else {
         return;
     };
@@ -227,7 +227,7 @@ pub fn render(fb: &mut petroleum::graphics::FramebufferGuard) {
     }
     let _guard = SuspendGuard;
 
-    let mut rt_lock = RUNTIME.lock();
+    let mut rt_lock = RUNTIME_CONTEXT.runtime();
     let rt = match rt_lock.as_mut() {
         Some(r) => r,
         None => return,
@@ -337,7 +337,7 @@ pub fn render(fb: &mut petroleum::graphics::FramebufferGuard) {
             let reserve = HEAP_EXTEND_RESERVE.load(core::sync::atomic::Ordering::Relaxed);
             if back_needed > reserve {
                 let additional = back_needed.saturating_sub(reserve).next_multiple_of(4096);
-                match SOLVENT_CALLBACKS.lock().heap_extend {
+                match RUNTIME_CONTEXT.callbacks().heap_extend {
                     Some(f) if f(additional).is_ok() => {
                         HEAP_EXTEND_RESERVE
                             .fetch_add(additional, core::sync::atomic::Ordering::Relaxed);

--- a/solvent/src/runtime_context.rs
+++ b/solvent/src/runtime_context.rs
@@ -1,7 +1,4 @@
-//! Runtime state, configuration, and initialization.
-//!
-//! This module preserves the current singleton ownership model. Consolidating
-//! the singletons into an owned `RuntimeContext` is tracked separately.
+//! Runtime ownership, configuration, and initialization.
 
 use alloc::boxed::Box;
 use alloc::string::String;
@@ -14,8 +11,9 @@ use lattice::terminal_surface::Cell as LatticeCell;
 use lattice::window::WindowId;
 use nozzle::terminal_buffer::TerminalBuffer;
 use resonance::{Dispatcher, EventQueue};
-use spin::Mutex;
+use spin::{Mutex, MutexGuard};
 
+use crate::callbacks::SolventCallbacks;
 use crate::handlers;
 
 pub(crate) const DEFAULT_COLS: u32 = 80;
@@ -40,11 +38,59 @@ pub(crate) static TSC_PER_MS: core::sync::atomic::AtomicU64 =
     core::sync::atomic::AtomicU64::new(3_000_000);
 
 pub(crate) static BACK_BUFFER: Mutex<Option<Vec<u32>>> = Mutex::new(None);
-pub(crate) static RUNTIME: Mutex<Option<RuntimeState>> = Mutex::new(None);
-pub(crate) static EVENT_QUEUE: Mutex<Option<EventQueue>> = Mutex::new(None);
-pub(crate) static DISPATCHER: Mutex<Option<Dispatcher>> = Mutex::new(None);
 pub(crate) static PREV_MOUSE_BUTTONS: Mutex<u8> = Mutex::new(0);
 pub(crate) static FB_DIMS: Mutex<(u32, u32, u32)> = Mutex::new((1024, 768, 1024));
+
+/// Owns Solvent's mutable orchestration state.
+///
+/// The synchronization domains remain separate because event handlers may
+/// re-enter runtime operations while the dispatcher is active. Ownership is
+/// centralized without imposing a single lock across unrelated lifecycles.
+pub struct RuntimeContext {
+    callbacks: Mutex<SolventCallbacks>,
+    runtime: Mutex<Option<RuntimeState>>,
+    event_queue: Mutex<Option<EventQueue>>,
+    dispatcher: Mutex<Option<Dispatcher>>,
+}
+
+impl RuntimeContext {
+    pub const fn new() -> Self {
+        Self {
+            callbacks: Mutex::new(SolventCallbacks::none()),
+            runtime: Mutex::new(None),
+            event_queue: Mutex::new(None),
+            dispatcher: Mutex::new(None),
+        }
+    }
+
+    pub fn install_callbacks(&self, callbacks: SolventCallbacks) {
+        *self.callbacks.lock() = callbacks;
+    }
+
+    pub fn callbacks(&self) -> MutexGuard<'_, SolventCallbacks> {
+        self.callbacks.lock()
+    }
+
+    pub(crate) fn runtime(&self) -> MutexGuard<'_, Option<RuntimeState>> {
+        self.runtime.lock()
+    }
+
+    pub(crate) fn event_queue(&self) -> MutexGuard<'_, Option<EventQueue>> {
+        self.event_queue.lock()
+    }
+
+    pub(crate) fn dispatcher(&self) -> MutexGuard<'_, Option<Dispatcher>> {
+        self.dispatcher.lock()
+    }
+}
+
+impl Default for RuntimeContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub static RUNTIME_CONTEXT: RuntimeContext = RuntimeContext::new();
 
 /// Mutable desktop runtime state protected by the crate's runtime lock.
 pub struct RuntimeState {
@@ -101,8 +147,8 @@ pub fn init() {
     dispatcher.register(Box::new(handlers::TerminalInputHandler));
     dispatcher.register(Box::new(handlers::ShellEventHandler));
 
-    *EVENT_QUEUE.lock() = Some(EventQueue::new());
-    *DISPATCHER.lock() = Some(dispatcher);
+    *RUNTIME_CONTEXT.event_queue() = Some(EventQueue::new());
+    *RUNTIME_CONTEXT.dispatcher() = Some(dispatcher);
 
     let _ = chrono.register_with_mode(
         Deadline::new(FRAME_INTERVAL_TICKS),
@@ -112,7 +158,7 @@ pub fn init() {
         },
     );
 
-    *RUNTIME.lock() = Some(RuntimeState {
+    *RUNTIME_CONTEXT.runtime() = Some(RuntimeState {
         desktop,
         term_window: None,
         term_buf,
@@ -139,7 +185,7 @@ pub fn init() {
 }
 
 pub fn is_initialized() -> bool {
-    RUNTIME.lock().is_some()
+    RUNTIME_CONTEXT.runtime().is_some()
 }
 
 pub fn apply_settings(sensitivity: f32, brightness_x100: u32, top_panel_enabled: bool) {
@@ -158,4 +204,27 @@ pub fn set_tsc_per_ms(value: u64) {
 
 pub fn get_tsc_per_ms() -> u64 {
     TSC_PER_MS.load(core::sync::atomic::Ordering::Relaxed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RuntimeContext;
+    use crate::callbacks::SolventCallbacks;
+
+    #[test]
+    fn callbacks_can_be_installed_before_runtime_initialization() {
+        let context = RuntimeContext::new();
+        assert!(context.runtime().is_none());
+        assert!(context.event_queue().is_none());
+        assert!(context.dispatcher().is_none());
+
+        let callbacks = SolventCallbacks {
+            launch_shell: Some(|| {}),
+            ..SolventCallbacks::none()
+        };
+        context.install_callbacks(callbacks);
+
+        assert!(context.callbacks().launch_shell.is_some());
+        assert!(context.runtime().is_none());
+    }
 }

--- a/solvent/src/runtime_context.rs
+++ b/solvent/src/runtime_context.rs
@@ -67,8 +67,10 @@ impl RuntimeContext {
         *self.callbacks.lock() = callbacks;
     }
 
-    pub fn callbacks(&self) -> MutexGuard<'_, SolventCallbacks> {
-        self.callbacks.lock()
+    /// Copy the callback table so callers never execute kernel code while
+    /// holding the callbacks lock.
+    pub fn callback_snapshot(&self) -> SolventCallbacks {
+        *self.callbacks.lock()
     }
 
     pub(crate) fn runtime(&self) -> MutexGuard<'_, Option<RuntimeState>> {
@@ -224,7 +226,7 @@ mod tests {
         };
         context.install_callbacks(callbacks);
 
-        assert!(context.callbacks().launch_shell.is_some());
+        assert!(context.callback_snapshot().launch_shell.is_some());
         assert!(context.runtime().is_none());
     }
 }

--- a/solvent/src/settings_bridge.rs
+++ b/solvent/src/settings_bridge.rs
@@ -2,7 +2,7 @@
 //!
 //! Extracted from lib.rs to keep the main module focused on orchestration.
 
-use crate::{DISPLAY_BRIGHTNESS_X100, FB_DIMS, MOUSE_SENSITIVITY, RUNTIME, SOLVENT_CALLBACKS};
+use crate::{DISPLAY_BRIGHTNESS_X100, FB_DIMS, MOUSE_SENSITIVITY, RUNTIME_CONTEXT};
 use alloc::vec;
 use lattice::compositor::WINDOW_CORNER_RADIUS;
 use lattice::terminal_surface::{self, Cell as LatticeCell};
@@ -14,7 +14,7 @@ pub(crate) static SETTINGS_SELECTED: spin::Mutex<u32> = spin::Mutex::new(0);
 
 /// Handle a key event when the settings window is focused (public entry point).
 pub fn settings_handle_key(scancode: u8, pressed: bool) {
-    let mut rt = RUNTIME.lock();
+    let mut rt = RUNTIME_CONTEXT.runtime();
     if let Some(ref mut r) = *rt {
         settings_handle_key_inner(r, scancode, pressed);
     }
@@ -114,7 +114,7 @@ pub(crate) fn settings_handle_key_inner(rt: &mut crate::RuntimeState, scancode: 
 
 fn persist_settings() {
     let save_fn = {
-        let cb_guard = SOLVENT_CALLBACKS.lock();
+        let cb_guard = RUNTIME_CONTEXT.callbacks();
         cb_guard.settings_save
     };
     if let Some(f) = save_fn {

--- a/solvent/src/settings_bridge.rs
+++ b/solvent/src/settings_bridge.rs
@@ -114,7 +114,7 @@ pub(crate) fn settings_handle_key_inner(rt: &mut crate::RuntimeState, scancode: 
 
 fn persist_settings() {
     let save_fn = {
-        let cb_guard = RUNTIME_CONTEXT.callbacks();
+        let cb_guard = RUNTIME_CONTEXT.callback_snapshot();
         cb_guard.settings_save
     };
     if let Some(f) = save_fn {

--- a/solvent/src/terminal.rs
+++ b/solvent/src/terminal.rs
@@ -2,7 +2,7 @@
 //!
 //! Extracted from `lib.rs` to reduce the size of the god-module.
 
-use crate::{HEAP_EXTEND_RESERVE, SOLVENT_CALLBACKS};
+use crate::{HEAP_EXTEND_RESERVE, RUNTIME_CONTEXT};
 use alloc::string::String;
 use lattice::terminal_surface::{self, Cell as LatticeCell};
 use lattice::window::WindowId;
@@ -54,7 +54,7 @@ pub fn render_terminal(rt: &mut crate::RuntimeState, term_window: Option<WindowI
         let reserve = HEAP_EXTEND_RESERVE.load(core::sync::atomic::Ordering::Relaxed);
         if needed > reserve {
             let additional = needed.saturating_sub(reserve).next_multiple_of(4096);
-            match SOLVENT_CALLBACKS.lock().heap_extend {
+            match RUNTIME_CONTEXT.callbacks().heap_extend {
                 Some(f) if f(additional).is_ok() => {
                     HEAP_EXTEND_RESERVE
                         .fetch_add(additional, core::sync::atomic::Ordering::Relaxed);
@@ -155,7 +155,7 @@ impl carrier::terminal::Terminal for LatticeTerminal {
         if let Some(ref mut out) = *crate::PIPE_STDOUT.lock() {
             out.push_str(s);
         } else {
-            let mut rt = crate::RUNTIME.lock();
+            let mut rt = crate::RUNTIME_CONTEXT.runtime();
             if let Some(ref mut r) = *rt {
                 r.term_buf.put_str(s);
                 r.term_dirty = true;

--- a/solvent/src/terminal.rs
+++ b/solvent/src/terminal.rs
@@ -54,7 +54,7 @@ pub fn render_terminal(rt: &mut crate::RuntimeState, term_window: Option<WindowI
         let reserve = HEAP_EXTEND_RESERVE.load(core::sync::atomic::Ordering::Relaxed);
         if needed > reserve {
             let additional = needed.saturating_sub(reserve).next_multiple_of(4096);
-            match RUNTIME_CONTEXT.callbacks().heap_extend {
+            match RUNTIME_CONTEXT.callback_snapshot().heap_extend {
                 Some(f) if f(additional).is_ok() => {
                     HEAP_EXTEND_RESERVE
                         .fetch_add(additional, core::sync::atomic::Ordering::Relaxed);

--- a/solvent/src/viewers.rs
+++ b/solvent/src/viewers.rs
@@ -3,7 +3,7 @@
 //! Each viewer reads file data via `vfs_read`, parses the format, and
 //! creates a window with the content rendered into the surface.
 
-use crate::{GLYPH_H, RuntimeState, SOLVENT_CALLBACKS};
+use crate::{GLYPH_H, RUNTIME_CONTEXT, RuntimeState};
 use alloc::format;
 use alloc::vec;
 use alloc::vec::Vec;
@@ -13,8 +13,8 @@ const MAX_IMG_H: u32 = 1080;
 const GLYPH_SIZE: u32 = 8;
 
 fn read_file(path: &str) -> Result<Vec<u8>, genome::FsError> {
-    let read_fn = SOLVENT_CALLBACKS
-        .lock()
+    let read_fn = RUNTIME_CONTEXT
+        .callbacks()
         .vfs_read
         .ok_or(genome::FsError::NotSupported)?;
     read_fn(path)

--- a/solvent/src/viewers.rs
+++ b/solvent/src/viewers.rs
@@ -14,7 +14,7 @@ const GLYPH_SIZE: u32 = 8;
 
 fn read_file(path: &str) -> Result<Vec<u8>, genome::FsError> {
     let read_fn = RUNTIME_CONTEXT
-        .callbacks()
+        .callback_snapshot()
         .vfs_read
         .ok_or(genome::FsError::NotSupported)?;
     read_fn(path)

--- a/solvent/src/window_api.rs
+++ b/solvent/src/window_api.rs
@@ -181,7 +181,7 @@ pub fn launch_file(runtime: &mut RuntimeState, path: &str) {
     );
 
     if is_text {
-        let read_file = RUNTIME_CONTEXT.callbacks().vfs_read;
+        let read_file = RUNTIME_CONTEXT.callback_snapshot().vfs_read;
         let file_content = match read_file {
             Some(read) => match read(path) {
                 Ok(data) => match core::str::from_utf8(&data) {

--- a/solvent/src/window_api.rs
+++ b/solvent/src/window_api.rs
@@ -5,15 +5,15 @@ use alloc::string::{String, ToString};
 use lattice::window::WindowId;
 
 use crate::{
-    DEFAULT_COLS, DEFAULT_ROWS, FB_DIMS, GLYPH_H, GLYPH_W, RUNTIME, RuntimeState,
-    SOLVENT_CALLBACKS, TERM_WIN_H, TERM_WIN_W,
+    DEFAULT_COLS, DEFAULT_ROWS, FB_DIMS, GLYPH_H, GLYPH_W, RUNTIME_CONTEXT, RuntimeState,
+    TERM_WIN_H, TERM_WIN_W,
 };
 
 pub(crate) static RENDERING_SUSPENDED: core::sync::atomic::AtomicBool =
     core::sync::atomic::AtomicBool::new(false);
 
 pub fn write_terminal(text: &str) {
-    if let Some(runtime) = RUNTIME.lock().as_mut() {
+    if let Some(runtime) = RUNTIME_CONTEXT.runtime().as_mut() {
         runtime.term_buf.put_str(text);
         runtime.term_dirty = true;
     }
@@ -31,7 +31,7 @@ pub fn force_desktop_redraw() {
     if RENDERING_SUSPENDED.swap(true, core::sync::atomic::Ordering::SeqCst) {
         return;
     }
-    if let Some(runtime) = RUNTIME.lock().as_mut() {
+    if let Some(runtime) = RUNTIME_CONTEXT.runtime().as_mut() {
         runtime.desktop.force_full_redraw();
         runtime.frame_due = true;
     }
@@ -45,7 +45,7 @@ pub fn create_window(
     width: u32,
     height: u32,
 ) -> Option<WindowId> {
-    RUNTIME.lock().as_mut().map(|runtime| {
+    RUNTIME_CONTEXT.runtime().as_mut().map(|runtime| {
         runtime
             .desktop
             .wm
@@ -57,7 +57,7 @@ pub fn with_window_surface<F, R>(id: WindowId, callback: F) -> Option<R>
 where
     F: FnOnce(&mut [u32], u32, u32) -> R,
 {
-    RUNTIME.lock().as_mut().and_then(|runtime| {
+    RUNTIME_CONTEXT.runtime().as_mut().and_then(|runtime| {
         let window = runtime
             .desktop
             .wm
@@ -73,7 +73,7 @@ where
 }
 
 pub fn invalidate_window(id: WindowId) {
-    if let Some(runtime) = RUNTIME.lock().as_mut() {
+    if let Some(runtime) = RUNTIME_CONTEXT.runtime().as_mut() {
         runtime.desktop.invalidate_window(id);
         runtime.frame_due = true;
         runtime.term_dirty = true;
@@ -81,8 +81,8 @@ pub fn invalidate_window(id: WindowId) {
 }
 
 pub fn close_window(id: WindowId) -> bool {
-    RUNTIME
-        .lock()
+    RUNTIME_CONTEXT
+        .runtime()
         .as_mut()
         .is_some_and(|runtime| runtime.desktop.wm.close_window(id))
 }
@@ -93,7 +93,7 @@ pub fn framebuffer_dims() -> (u32, u32) {
 }
 
 pub fn ensure_terminal_window() -> Option<WindowId> {
-    let mut runtime = RUNTIME.lock();
+    let mut runtime = RUNTIME_CONTEXT.runtime();
     let runtime = runtime.as_mut()?;
     if let Some(id) = runtime.term_window
         && runtime
@@ -117,8 +117,8 @@ pub fn ensure_terminal_window() -> Option<WindowId> {
 }
 
 pub fn ensure_editor_window() -> Option<WindowId> {
-    RUNTIME
-        .lock()
+    RUNTIME_CONTEXT
+        .runtime()
         .as_mut()
         .and_then(crate::editor_bridge::ensure_editor_window)
 }
@@ -181,7 +181,7 @@ pub fn launch_file(runtime: &mut RuntimeState, path: &str) {
     );
 
     if is_text {
-        let read_file = SOLVENT_CALLBACKS.lock().vfs_read;
+        let read_file = RUNTIME_CONTEXT.callbacks().vfs_read;
         let file_content = match read_file {
             Some(read) => match read(path) {
                 Ok(data) => match core::str::from_utf8(&data) {


### PR DESCRIPTION
## Summary

- add `RuntimeContext` as the single owner of Solvent callbacks, runtime state, event queue, and dispatcher
- keep separate synchronization domains to preserve safe event-handler re-entry and existing lock ordering
- migrate Solvent and kernel callers to context guard methods
- document the ownership boundary and mark the P1-4 TODO complete

## Why

Solvent previously exposed four independent mutable globals. That obscured lifecycle ownership and made initialization dependencies implicit. The new context centralizes ownership while retaining the separate locks required by event dispatch and runtime callbacks.

## Validation

- `cargo fmt --package solvent -- --check`
- `cargo test -p solvent --locked` (8 passed)
- `cargo check --workspace --exclude bellows --exclude fullerene-kernel --locked`
- `cargo check -p fullerene-kernel --locked`
- `cargo build -Z build-std=core,alloc -p fullerene-kernel --target x86_64-unknown-uefi --locked`
- `git diff --check`

`cargo clippy -p solvent --no-deps --tests --locked -- -D warnings` remains blocked by 32 pre-existing Solvent warnings outside this ownership change.

Closes #292