### PR TITLE
feat(fat): add root directory cache and limit readdir entries

### DIFF
--- a/fullerene-kernel/src/drivers/fat/exfat.rs
+++ b/fullerene-kernel/src/drivers/fat/exfat.rs
@@ -632,9 +632,9 @@ impl FileSystem for ExFatFileSystem {
         const MAX_ENTRIES: usize = 4096;
         if path.trim_matches('/').is_empty() {
             if let Some(ref cached) = self.root_cache {
-                return Ok(cached.clone());
+                return Ok(cached.iter().take(MAX_ENTRIES).cloned().collect());
             }
-            let entries = self.root_entries()?;
+            let entries: Vec<_> = self.root_entries()?.into_iter().take(MAX_ENTRIES).collect();
             self.root_cache = Some(entries.clone());
             return Ok(entries);
         }

--- a/fullerene-kernel/src/drivers/fat/exfat.rs
+++ b/fullerene-kernel/src/drivers/fat/exfat.rs
@@ -242,6 +242,7 @@ pub struct ExFatFileSystem {
     cache: Arc<Mutex<MetadataCache>>,
     device_size: u64,
     next_fd: u32,
+    root_cache: Option<Vec<VNode>>,
 }
 
 impl ExFatFileSystem {
@@ -298,6 +299,7 @@ impl ExFatFileSystem {
             cache,
             device_size: size,
             next_fd: 1,
+            root_cache: None,
         })
     }
 
@@ -561,6 +563,7 @@ impl FileSystem for ExFatFileSystem {
     }
 
     fn write(&mut self, fd: u32, data: &[u8]) -> Result<usize, FsError> {
+        self.root_cache = None;
         let index = self.handle_index(fd)?;
         if data.is_empty() {
             return Ok(0);
@@ -605,6 +608,7 @@ impl FileSystem for ExFatFileSystem {
     }
 
     fn create(&mut self, path: &str, kind: InodeType) -> Option<u64> {
+        self.root_cache = None;
         match kind {
             InodeType::Directory => self.create_directory(path).ok()?,
             InodeType::File => self.create_file(path).ok()?,
@@ -614,20 +618,29 @@ impl FileSystem for ExFatFileSystem {
     }
 
     fn mkdir(&mut self, path: &str) -> Result<(), FsError> {
+        self.root_cache = None;
         self.create_directory(path)
     }
 
     fn unlink(&mut self, path: &str) -> Result<(), FsError> {
+        self.root_cache = None;
         let entry = self.fs().open_path(path).map_err(Self::map_error)?;
         self.fs().delete(&entry).map_err(Self::map_error)
     }
 
     fn readdir(&mut self, path: &str) -> Result<Vec<VNode>, FsError> {
+        const MAX_ENTRIES: usize = 4096;
         if path.trim_matches('/').is_empty() {
-            return self.root_entries();
+            if let Some(ref cached) = self.root_cache {
+                return Ok(cached.clone());
+            }
+            let entries = self.root_entries()?;
+            self.root_cache = Some(entries.clone());
+            return Ok(entries);
         }
         self.directory(path)?
             .entries()
+            .take(MAX_ENTRIES)
             .map(|entry| {
                 entry
                     .map(|entry| VNode {

--- a/fullerene-kernel/src/drivers/fat/fat32.rs
+++ b/fullerene-kernel/src/drivers/fat/fat32.rs
@@ -20,6 +20,7 @@ pub struct FatFileSystem {
     inner: FatType,
     next_fd: u32,
     handles: Vec<(u32, String, u64)>,
+    root_cache: Option<Vec<VNode>>,
 }
 
 impl FatFileSystem {
@@ -34,6 +35,7 @@ impl FatFileSystem {
             inner,
             next_fd: 1,
             handles: Vec::new(),
+            root_cache: None,
         })
     }
 
@@ -112,6 +114,7 @@ impl FileSystem for FatFileSystem {
     }
 
     fn write(&mut self, fd: u32, data: &[u8]) -> Result<usize, FsError> {
+        self.root_cache = None;
         let (path, offset) = {
             let handle = self
                 .handles
@@ -152,11 +155,13 @@ impl FileSystem for FatFileSystem {
     }
 
     fn create(&mut self, path: &str, _kind: InodeType) -> Option<u64> {
+        self.root_cache = None;
         let _file = self.create_file(path).ok()?;
         Some(0)
     }
 
     fn mkdir(&mut self, path: &str) -> Result<(), FsError> {
+        self.root_cache = None;
         let path = path.trim_matches('/');
         if path.is_empty() {
             return Err(FsError::InvalidInput);
@@ -176,6 +181,7 @@ impl FileSystem for FatFileSystem {
     }
 
     fn unlink(&mut self, path: &str) -> Result<(), FsError> {
+        self.root_cache = None;
         let path = path.trim_matches('/');
         if path.is_empty() {
             return Err(FsError::InvalidInput);
@@ -189,6 +195,31 @@ impl FileSystem for FatFileSystem {
     }
 
     fn readdir(&mut self, path: &str) -> Result<Vec<VNode>, FsError> {
+        const MAX_ENTRIES: usize = 4096;
+        let trimmed = path.trim_matches('/');
+        if trimmed.is_empty() {
+            if let Some(ref cached) = self.root_cache {
+                return Ok(cached.clone());
+            }
+            let result = {
+                let directory = self.open_dir(path)?;
+                let mut entries = Vec::new();
+                for entry in directory.iter() {
+                    let entry = Self::map_err(entry)?;
+                    entries.push(VNode {
+                        name: entry.file_name(),
+                        size: entry.len(),
+                        is_dir: entry.is_dir(),
+                    });
+                    if entries.len() >= MAX_ENTRIES {
+                        break;
+                    }
+                }
+                entries
+            };
+            self.root_cache = Some(result.clone());
+            return Ok(result);
+        }
         let directory = self.open_dir(path)?;
         let mut result = Vec::new();
         for entry in directory.iter() {
@@ -198,6 +229,9 @@ impl FileSystem for FatFileSystem {
                 size: entry.len(),
                 is_dir: entry.is_dir(),
             });
+            if result.len() >= MAX_ENTRIES {
+                break;
+            }
         }
         Ok(result)
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved responsiveness when browsing the root directory on FAT32 and exFAT filesystems by caching directory listings.
  * Directory caches are refreshed automatically after file or directory changes, keeping listings current.

* **Bug Fixes**
  * Limited directory listings to a maximum of 4,096 entries, improving reliability when accessing directories containing very large numbers of files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->