### PR TITLE
perf(fs): cache directory listings for exFAT and FAT32

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -20,12 +20,22 @@ via a CPIO initramfs archive.
 | VSCodium | `toluene/vscodium` | Linux ELF | Manual overlay (needs Microsoft/vscode) |
 
 The kernel's `build.rs` runs each port's build step during compilation.
-Built binaries are cached at `toluene/<name>/app.bin` and reused on
-subsequent builds.  To force a rebuild, delete the cached binary:
+Built binaries are cached at `target/ports/<name>/app.bin` and reused on
+subsequent builds.
+
+**Source builds are opt-in.**  By default, `cargo build` only uses cached
+binaries.  To build ports from their submodule sources, set:
 
 ```bash
-rm toluene/<name>/app.bin
-cargo build -p fullerene-kernel --target x86_64-unknown-uefi
+FULLERENE_BUILD_PORTS=1 cargo build -p fullerene-kernel --target x86_64-unknown-uefi
+```
+
+To force a rebuild from source, delete a cached binary and rebuild with
+the env var:
+
+```bash
+rm target/ports/<name>/app.bin
+FULLERENE_BUILD_PORTS=1 cargo build -p fullerene-kernel --target x86_64-unknown-uefi
 ```
 
 Prerequisites per port:
@@ -37,7 +47,7 @@ Prerequisites per port:
 
 A port whose build prerequisites are missing emits Cargo warnings directing
 users to the build output for details. You can place a manually‑compiled ELF
-at `toluene/<name>/app.bin` as well.
+at `target/ports/<name>/app.bin` as well.
 
 When the kernel boots, ports are unpacked from the initramfs into
 `/packages/` and launched with `app run <name>`.

--- a/fullerene-kernel/build.rs
+++ b/fullerene-kernel/build.rs
@@ -10,6 +10,7 @@ fn main() {
 
     // ── Declare expected cfg flags ────────────────────────────────
     println!("cargo::rustc-check-cfg=cfg(have_ports_cpio)");
+    println!("cargo:rerun-if-env-changed=FULLERENE_BUILD_PORTS");
 
     // ── Propagate .driverignore cfg flags from Nitrogen ──────────
     let nitrogen_dir = manifest_dir.parent().unwrap().join("nitrogen");
@@ -142,15 +143,20 @@ fn main() {
 ///
 /// For each known port, this function:
 /// 1. Locates its submodule under `toluene/<name>/`
-/// 2. If the submodule has source, attempts to build it (or download a
-///    pre‑built release) to produce a Linux ELF binary
-/// 3. Caches the binary at `target/ports/<name>/app.bin` so subsequent builds
-///    skip the expensive source build
-/// 4. Packages every successfully‑built port into a single CPIO archive
+/// 2. If a cached ELF exists at `target/ports/<name>/app.bin`, uses it
+/// 3. Otherwise, if `FULLERENE_BUILD_PORTS=1` is set, builds from source
+///    (or downloads a pre‑built release) to produce a Linux ELF binary
+/// 4. Caches any freshly-built binary at `target/ports/<name>/app.bin`
+/// 5. Packages every successfully‑built port into a single CPIO archive
 ///
 /// Returns the number of ports successfully packaged.
 fn build_ports_cpio(toluene_dir: &Path, ports_dir: &Path, out_dir: &Path) -> usize {
     let mut prepared: Vec<(&str, PortType, Vec<u8>)> = Vec::new();
+
+    // Source builds are opt-in.  Set FULLERENE_BUILD_PORTS=1 to build from
+    // source when no cached binary exists.  Without it, only pre-cached
+    // binaries (or manually-placed app.bin files) are used.
+    let allow_source_build = env::var_os("FULLERENE_BUILD_PORTS").is_some_and(|v| v != "0");
 
     for (name, builder) in KNOWN_PORTS.iter() {
         let submodule = toluene_dir.join(name);
@@ -167,6 +173,16 @@ fn build_ports_cpio(toluene_dir: &Path, ports_dir: &Path, out_dir: &Path) -> usi
                     continue;
                 }
             }
+        }
+
+        if !allow_source_build {
+            println!(
+                "cargo:warning=ports: {name} has no cached binary – \
+                 skipping (set FULLERENE_BUILD_PORTS=1 to build from source, \
+                 or place a pre-built ELF at {})",
+                cache.display()
+            );
+            continue;
         }
 
         // Try: build from source

--- a/genome/src/fat/exfat.rs
+++ b/genome/src/fat/exfat.rs
@@ -590,7 +590,10 @@ impl FileSystem for ExFatFileSystem {
         let index = self.handle_index(fd)?;
         let mut handle = self.handles.remove(index);
         match handle.writer.take() {
-            Some(writer) => writer.finish().map_err(Self::map_error),
+            Some(writer) => {
+                self.invalidate_dir_cache();
+                writer.finish().map_err(Self::map_error)
+            }
             None => Ok(()),
         }
     }
@@ -655,6 +658,10 @@ impl FileSystem for ExFatFileSystem {
             })
             .collect();
         let entries = entries?;
+        const MAX_DIR_CACHE_ENTRIES: usize = 256;
+        if self.dir_cache.len() >= MAX_DIR_CACHE_ENTRIES {
+            self.dir_cache.clear();
+        }
         self.dir_cache
             .insert(String::from(trimmed), entries.clone());
         Ok(entries)

--- a/genome/src/fat/exfat.rs
+++ b/genome/src/fat/exfat.rs
@@ -632,12 +632,13 @@ impl FileSystem for ExFatFileSystem {
     fn readdir(&mut self, path: &str) -> Result<Vec<VNode>, FsError> {
         const MAX_ENTRIES: usize = 4096;
         let trimmed = path.trim_matches('/');
+        let cache_key = trimmed.to_lowercase();
         if trimmed.is_empty() {
             if let Some(cached) = self.root_cache.as_ref() {
-                return Ok(cached.iter().take(MAX_ENTRIES).cloned().collect());
+                return Ok(cached.clone());
             }
-        } else if let Some(cached) = self.dir_cache.get(trimmed) {
-            return Ok(cached.iter().take(MAX_ENTRIES).cloned().collect());
+        } else if let Some(cached) = self.dir_cache.get(&cache_key) {
+            return Ok(cached.clone());
         }
         if trimmed.is_empty() {
             let entries: Vec<_> = self.root_entries()?.into_iter().take(MAX_ENTRIES).collect();
@@ -649,12 +650,13 @@ impl FileSystem for ExFatFileSystem {
             .entries()
             .take(MAX_ENTRIES)
             .map(|entry| {
-                entry.map(|entry| VNode {
-                    size: entry.size(),
-                    is_dir: entry.is_directory(),
-                    name: entry.name,
-                })
-                .map_err(Self::map_error)
+                entry
+                    .map(|entry| VNode {
+                        size: entry.size(),
+                        is_dir: entry.is_directory(),
+                        name: entry.name,
+                    })
+                    .map_err(Self::map_error)
             })
             .collect();
         let entries = entries?;
@@ -662,8 +664,7 @@ impl FileSystem for ExFatFileSystem {
         if self.dir_cache.len() >= MAX_DIR_CACHE_ENTRIES {
             self.dir_cache.clear();
         }
-        self.dir_cache
-            .insert(String::from(trimmed), entries.clone());
+        self.dir_cache.insert(cache_key, entries.clone());
         Ok(entries)
     }
 

--- a/genome/src/fat/exfat.rs
+++ b/genome/src/fat/exfat.rs
@@ -237,6 +237,7 @@ pub struct ExFatFileSystem {
     device_size: u64,
     next_fd: u32,
     root_cache: Option<Vec<VNode>>,
+    dir_cache: BTreeMap<String, Vec<VNode>>,
 }
 
 impl ExFatFileSystem {
@@ -294,6 +295,7 @@ impl ExFatFileSystem {
             device_size: size,
             next_fd: 1,
             root_cache: None,
+            dir_cache: BTreeMap::new(),
         })
     }
 
@@ -428,6 +430,11 @@ impl ExFatFileSystem {
         Ok(unsafe { mem::transmute::<ExFatFileWriter<'_, ExFatDevice>, Writer>(writer) })
     }
 
+    fn invalidate_dir_cache(&mut self) {
+        self.root_cache = None;
+        self.dir_cache.clear();
+    }
+
     fn root_entries(&self) -> Result<Vec<VNode>, FsError> {
         let info = self.fs().info();
         let mut device = ExFatDevice {
@@ -554,7 +561,7 @@ impl FileSystem for ExFatFileSystem {
     }
 
     fn write(&mut self, fd: u32, data: &[u8]) -> Result<usize, FsError> {
-        self.root_cache = None;
+        self.invalidate_dir_cache();
         let index = self.handle_index(fd)?;
         if data.is_empty() {
             return Ok(0);
@@ -599,7 +606,7 @@ impl FileSystem for ExFatFileSystem {
     }
 
     fn create(&mut self, path: &str, kind: InodeType) -> Option<u64> {
-        self.root_cache = None;
+        self.invalidate_dir_cache();
         match kind {
             InodeType::Directory => self.create_directory(path).ok()?,
             InodeType::File => self.create_file(path).ok()?,
@@ -609,39 +616,48 @@ impl FileSystem for ExFatFileSystem {
     }
 
     fn mkdir(&mut self, path: &str) -> Result<(), FsError> {
-        self.root_cache = None;
+        self.invalidate_dir_cache();
         self.create_directory(path)
     }
 
     fn unlink(&mut self, path: &str) -> Result<(), FsError> {
-        self.root_cache = None;
+        self.invalidate_dir_cache();
         let entry = self.fs().open_path(path).map_err(Self::map_error)?;
         self.fs().delete(&entry).map_err(Self::map_error)
     }
 
     fn readdir(&mut self, path: &str) -> Result<Vec<VNode>, FsError> {
         const MAX_ENTRIES: usize = 4096;
-        if path.trim_matches('/').is_empty() {
-            if let Some(ref cached) = self.root_cache {
+        let trimmed = path.trim_matches('/');
+        if trimmed.is_empty() {
+            if let Some(cached) = self.root_cache.as_ref() {
                 return Ok(cached.iter().take(MAX_ENTRIES).cloned().collect());
             }
+        } else if let Some(cached) = self.dir_cache.get(trimmed) {
+            return Ok(cached.iter().take(MAX_ENTRIES).cloned().collect());
+        }
+        if trimmed.is_empty() {
             let entries: Vec<_> = self.root_entries()?.into_iter().take(MAX_ENTRIES).collect();
             self.root_cache = Some(entries.clone());
             return Ok(entries);
         }
-        self.directory(path)?
+        let entries: Result<Vec<_>, _> = self
+            .directory(path)?
             .entries()
             .take(MAX_ENTRIES)
             .map(|entry| {
-                entry
-                    .map(|entry| VNode {
-                        size: entry.size(),
-                        is_dir: entry.is_directory(),
-                        name: entry.name,
-                    })
-                    .map_err(Self::map_error)
+                entry.map(|entry| VNode {
+                    size: entry.size(),
+                    is_dir: entry.is_directory(),
+                    name: entry.name,
+                })
+                .map_err(Self::map_error)
             })
-            .collect()
+            .collect();
+        let entries = entries?;
+        self.dir_cache
+            .insert(String::from(trimmed), entries.clone());
+        Ok(entries)
     }
 
     fn exists(&mut self, path: &str) -> bool {

--- a/genome/src/fat/fat32.rs
+++ b/genome/src/fat/fat32.rs
@@ -230,6 +230,10 @@ impl FileSystem for FatFileSystem {
         if trimmed.is_empty() {
             self.root_cache = Some(result.clone());
         } else {
+            const MAX_DIR_CACHE_ENTRIES: usize = 256;
+            if self.dir_cache.len() >= MAX_DIR_CACHE_ENTRIES {
+                self.dir_cache.clear();
+            }
             self.dir_cache
                 .insert(String::from(trimmed), result.clone());
         }

--- a/genome/src/fat/fat32.rs
+++ b/genome/src/fat/fat32.rs
@@ -1,4 +1,5 @@
 use alloc::boxed::Box;
+use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -20,6 +21,7 @@ pub struct FatFileSystem {
     next_fd: u32,
     handles: Vec<(u32, String, u64)>,
     root_cache: Option<Vec<VNode>>,
+    dir_cache: BTreeMap<String, Vec<VNode>>,
 }
 
 impl FatFileSystem {
@@ -35,7 +37,13 @@ impl FatFileSystem {
             next_fd: 1,
             handles: Vec::new(),
             root_cache: None,
+            dir_cache: BTreeMap::new(),
         })
+    }
+
+    fn invalidate_dir_cache(&mut self) {
+        self.root_cache = None;
+        self.dir_cache.clear();
     }
 
     fn map_err<T>(result: Result<T, FatError>) -> Result<T, FsError> {
@@ -113,7 +121,7 @@ impl FileSystem for FatFileSystem {
     }
 
     fn write(&mut self, fd: u32, data: &[u8]) -> Result<usize, FsError> {
-        self.root_cache = None;
+        self.invalidate_dir_cache();
         let (path, offset) = {
             let handle = self
                 .handles
@@ -154,13 +162,13 @@ impl FileSystem for FatFileSystem {
     }
 
     fn create(&mut self, path: &str, _kind: InodeType) -> Option<u64> {
-        self.root_cache = None;
+        self.invalidate_dir_cache();
         let _file = self.create_file(path).ok()?;
         Some(0)
     }
 
     fn mkdir(&mut self, path: &str) -> Result<(), FsError> {
-        self.root_cache = None;
+        self.invalidate_dir_cache();
         let path = path.trim_matches('/');
         if path.is_empty() {
             return Err(FsError::InvalidInput);
@@ -180,7 +188,7 @@ impl FileSystem for FatFileSystem {
     }
 
     fn unlink(&mut self, path: &str) -> Result<(), FsError> {
-        self.root_cache = None;
+        self.invalidate_dir_cache();
         let path = path.trim_matches('/');
         if path.is_empty() {
             return Err(FsError::InvalidInput);
@@ -197,40 +205,33 @@ impl FileSystem for FatFileSystem {
         const MAX_ENTRIES: usize = 4096;
         let trimmed = path.trim_matches('/');
         if trimmed.is_empty() {
-            if let Some(ref cached) = self.root_cache {
+            if let Some(cached) = self.root_cache.as_ref() {
                 return Ok(cached.clone());
             }
-            let result = {
-                let directory = self.open_dir(path)?;
-                let mut entries = Vec::new();
-                for entry in directory.iter() {
-                    let entry = Self::map_err(entry)?;
-                    entries.push(VNode {
-                        name: entry.file_name(),
-                        size: entry.len(),
-                        is_dir: entry.is_dir(),
-                    });
-                    if entries.len() >= MAX_ENTRIES {
-                        break;
-                    }
-                }
-                entries
-            };
-            self.root_cache = Some(result.clone());
-            return Ok(result);
+        } else if let Some(cached) = self.dir_cache.get(trimmed) {
+            return Ok(cached.clone());
         }
-        let directory = self.open_dir(path)?;
-        let mut result = Vec::new();
-        for entry in directory.iter() {
-            let entry = Self::map_err(entry)?;
-            result.push(VNode {
-                name: entry.file_name(),
-                size: entry.len(),
-                is_dir: entry.is_dir(),
-            });
-            if result.len() >= MAX_ENTRIES {
-                break;
+        let result = {
+            let directory = self.open_dir(path)?;
+            let mut entries = Vec::new();
+            for entry in directory.iter() {
+                let entry = Self::map_err(entry)?;
+                entries.push(VNode {
+                    name: entry.file_name(),
+                    size: entry.len(),
+                    is_dir: entry.is_dir(),
+                });
+                if entries.len() >= MAX_ENTRIES {
+                    break;
+                }
             }
+            entries
+        };
+        if trimmed.is_empty() {
+            self.root_cache = Some(result.clone());
+        } else {
+            self.dir_cache
+                .insert(String::from(trimmed), result.clone());
         }
         Ok(result)
     }

--- a/genome/src/fat/fat32.rs
+++ b/genome/src/fat/fat32.rs
@@ -204,11 +204,12 @@ impl FileSystem for FatFileSystem {
     fn readdir(&mut self, path: &str) -> Result<Vec<VNode>, FsError> {
         const MAX_ENTRIES: usize = 4096;
         let trimmed = path.trim_matches('/');
+        let cache_key = trimmed.to_lowercase();
         if trimmed.is_empty() {
             if let Some(cached) = self.root_cache.as_ref() {
                 return Ok(cached.clone());
             }
-        } else if let Some(cached) = self.dir_cache.get(trimmed) {
+        } else if let Some(cached) = self.dir_cache.get(&cache_key) {
             return Ok(cached.clone());
         }
         let result = {
@@ -234,8 +235,7 @@ impl FileSystem for FatFileSystem {
             if self.dir_cache.len() >= MAX_DIR_CACHE_ENTRIES {
                 self.dir_cache.clear();
             }
-            self.dir_cache
-                .insert(String::from(trimmed), result.clone());
+            self.dir_cache.insert(cache_key, result.clone());
         }
         Ok(result)
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved directory listing performance by caching results for subdirectories on FAT32 and exFAT filesystems.

- **Bug Fixes**
  - Directory listings now refresh correctly after files or folders are created, modified, or removed.

- **Documentation**
  - Updated application port build instructions with the current cache location.
  - Clarified that source builds are opt-in and documented how to enable or rebuild them.

- **Build Improvements**
  - Missing cached application binaries are skipped unless source builds are explicitly enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->