### PR TITLE
Wifi WIP

### DIFF
--- a/nitrogen/src/iwlwifi/connection_state.rs
+++ b/nitrogen/src/iwlwifi/connection_state.rs
@@ -4,7 +4,7 @@ use alloc::boxed::Box;
 use alloc::collections::VecDeque;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
-use core::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, AtomicUsize, Ordering};
 use spin::Mutex;
 
 use crate::DriverContext;
@@ -35,6 +35,10 @@ static WIFI_INIT_PHASE: core::sync::atomic::AtomicU8 =
     core::sync::atomic::AtomicU8::new(WifiInitPhase::Idle as u8);
 static WIFI_INIT_LAST_ACTIVE_PHASE: core::sync::atomic::AtomicU8 =
     core::sync::atomic::AtomicU8::new(WifiInitPhase::Idle as u8);
+// Hints are drawn from the scheduler context only. set_init_phase() is also
+// used by the NMI watchdog failure path, where taking the debug callback lock
+// could deadlock.
+static WIFI_LAST_HINT_PHASE: AtomicU8 = AtomicU8::new(u8::MAX);
 static WIFI_INIT_CTX: Mutex<WifiInitContext> = Mutex::new(WifiInitContext {
     mmio_device: None,
     fw_candidate_idx: 0,
@@ -303,6 +307,15 @@ fn set_init_phase(phase: WifiInitPhase) {
 fn get_init_phase() -> WifiInitPhase {
     let raw = WIFI_INIT_PHASE.load(core::sync::atomic::Ordering::Acquire);
     WifiInitPhase::from(raw)
+}
+
+fn draw_init_hint_if_changed() {
+    let phase = get_init_phase();
+    let current = phase as u8;
+    let previous = WIFI_LAST_HINT_PHASE.swap(current, Ordering::AcqRel);
+    if previous != current {
+        debug::hint(phase.screen_label());
+    }
 }
 
 // ── Incremental init state machine ─
@@ -1207,6 +1220,10 @@ pub fn process_wifi_submission_queue(budget: usize) {
 
 /// Move Wi-Fi SQ entries through the executor until either budget is reached.
 pub fn process_wifi_submission_queue_until(budget: usize, deadline_tsc: u64) {
+    // Keep boot-screen phase changes in the normal scheduler path. In
+    // particular, never call debug::hint() from force_init_failed(), which
+    // may be reached by the NMI watchdog while another context owns a lock.
+    draw_init_hint_if_changed();
     let mut processed_any = false;
     for _ in 0..budget {
         // A short scheduler budget must not turn the SQ into a starvation
@@ -1265,6 +1282,7 @@ pub fn process_wifi_submission_queue_until(budget: usize, deadline_tsc: u64) {
                 accepted: perform_send_data_frame(&frame),
             },
         };
+        draw_init_hint_if_changed();
         if completion_reserved {
             WIFI_CQ
                 .lock()

--- a/nitrogen/src/iwlwifi/connection_state.rs
+++ b/nitrogen/src/iwlwifi/connection_state.rs
@@ -192,6 +192,17 @@ pub fn wifi_init_completed() -> bool {
     WIFI_INIT_COMPLETED.load(core::sync::atomic::Ordering::Acquire)
 }
 
+/// Whether the most recent initialization attempt ended in the terminal
+/// failed state.
+///
+/// `wifi_init_completed()` intentionally covers both success and failure so
+/// callers can stop polling.  UI code needs the distinction to avoid showing
+/// a successful scan request after initialization was disabled.
+pub fn wifi_init_failed() -> bool {
+    WIFI_INIT_COMPLETED.load(core::sync::atomic::Ordering::Acquire)
+        && get_init_phase() == WifiInitPhase::Failed
+}
+
 /// Whether the hardware-facing driver object was successfully installed.
 ///
 /// `wifi_init_completed()` also becomes true after a failed initialization so
@@ -1196,8 +1207,16 @@ pub fn process_wifi_submission_queue(budget: usize) {
 
 /// Move Wi-Fi SQ entries through the executor until either budget is reached.
 pub fn process_wifi_submission_queue_until(budget: usize, deadline_tsc: u64) {
+    let mut processed_any = false;
     for _ in 0..budget {
-        if unsafe { core::arch::x86_64::_rdtsc() } >= deadline_tsc {
+        // A short scheduler budget must not turn the SQ into a starvation
+        // point. This is particularly important for InitStep: if the
+        // deadline has already elapsed by the time this phase runs, leaving
+        // the request queued makes Solvent eventually report an outer timeout
+        // even though the hardware state machine never got one step.
+        // Process one request unconditionally, then enforce the deadline for
+        // the remaining batch. The request itself has per-device watchdogs.
+        if processed_any && unsafe { core::arch::x86_64::_rdtsc() } >= deadline_tsc {
             break;
         }
         if !reserve_wifi_completion() {
@@ -1230,6 +1249,7 @@ pub fn process_wifi_submission_queue_until(budget: usize, deadline_tsc: u64) {
             .lock()
             .push_back(WifiCompletion { request_id, kind });
         release_wifi_completion();
+        processed_any = true;
     }
 }
 

--- a/nitrogen/src/iwlwifi/connection_state.rs
+++ b/nitrogen/src/iwlwifi/connection_state.rs
@@ -1219,11 +1219,31 @@ pub fn process_wifi_submission_queue_until(budget: usize, deadline_tsc: u64) {
         if processed_any && unsafe { core::arch::x86_64::_rdtsc() } >= deadline_tsc {
             break;
         }
-        if !reserve_wifi_completion() {
+
+        // InitStep and Tick are level-triggered housekeeping requests. Their
+        // completion records are intentionally ignored by the consumer, so
+        // they must not be blocked by a full CQ. In particular, a backlog of
+        // stale Tick records must not prevent the first InitStep from ever
+        // reaching the hardware state machine and make the UI-side timeout
+        // fire while the phase is still Idle.
+        let periodic = {
+            let queue = WIFI_SQ.lock();
+            matches!(
+                queue.front().map(|(_, request)| request),
+                Some(WifiRequest::InitStep | WifiRequest::Tick)
+            )
+        };
+        let completion_reserved = if periodic {
+            false
+        } else if reserve_wifi_completion() {
+            true
+        } else {
             break;
-        }
+        };
         let Some((request_id, request)) = WIFI_SQ.lock().pop_front() else {
-            release_wifi_completion();
+            if completion_reserved {
+                release_wifi_completion();
+            }
             break;
         };
         let kind = match request {
@@ -1245,10 +1265,12 @@ pub fn process_wifi_submission_queue_until(budget: usize, deadline_tsc: u64) {
                 accepted: perform_send_data_frame(&frame),
             },
         };
-        WIFI_CQ
-            .lock()
-            .push_back(WifiCompletion { request_id, kind });
-        release_wifi_completion();
+        if completion_reserved {
+            WIFI_CQ
+                .lock()
+                .push_back(WifiCompletion { request_id, kind });
+            release_wifi_completion();
+        }
         processed_any = true;
     }
 }

--- a/nitrogen/src/iwlwifi/mod.rs
+++ b/nitrogen/src/iwlwifi/mod.rs
@@ -44,7 +44,7 @@ pub use connection_state::{
     enqueue_data_frame, force_init_failed, init_wifi_manager, process_wifi_submission_queue,
     process_wifi_submission_queue_until, retry_wifi_initialization, set_wifi_driver_context,
     start_scan_if_idle, tick_wifi_device, try_init_wifi_device, try_init_wifi_device_step,
-    wifi_device_ready, wifi_init_completed, wifi_state_snapshot,
+    wifi_device_ready, wifi_init_completed, wifi_init_failed, wifi_state_snapshot,
 };
 pub use device::IwlWifiDevice;
 pub use device::try_create_iwl;

--- a/nitrogen/src/iwlwifi/registers.rs
+++ b/nitrogen/src/iwlwifi/registers.rs
@@ -105,11 +105,10 @@ pub const FH_RCSR_RX_RB_TIMEOUT: u32 = 0x11;
 /// layout; using it for HCMDs can appear to work for simple commands but
 /// corrupts the scheduler state when ADD_STA configures the AUX station.
 pub const IWL_CMD_QUEUE: u32 = 9;
-/// Auxiliary/off-channel queue used by the firmware scan station in the
-/// non-DQA transport used by the 7265. Linux v4.9 names this
-/// `IWL_MVM_OFFCHANNEL_QUEUE` and assigns it queue 8; queue 11 belongs to a
-/// different queue layout and must not be used here.
-pub const IWL_AUX_QUEUE: u32 = 8;
+/// Auxiliary queue used by the firmware scan station in the 7265's 16-queue
+/// non-DQA layout. Linux selects q11 for `mvm->aux_queue` in this layout;
+/// q8 is the separate off-channel reservation, not the station's TX queue.
+pub const IWL_AUX_QUEUE: u32 = 11;
 pub const FH_MEM_CBBC_0_15_LOWER_BOUND: u32 = (0x1000 + 0x9D0) / 4;
 pub const FH_MEM_CBBC_CMD_QUEUE: u32 = FH_MEM_CBBC_0_15_LOWER_BOUND + IWL_CMD_QUEUE;
 pub const FH_MEM_CBBC_AUX_QUEUE: u32 = FH_MEM_CBBC_0_15_LOWER_BOUND + IWL_AUX_QUEUE;
@@ -154,7 +153,7 @@ pub const SCD_GP_CTRL_AUTO_ACTIVE_MODE: u32 = 1 << 18;
 pub const TX_TFD_RING_BYTES: usize = 128 * TX_QUEUE_SIZE;
 /// The auxiliary station has its own TFD ring even though the host does not
 /// submit scan frames directly. Linux allocates one ring per scheduler queue;
-/// keeping q8 separate prevents firmware from interpreting q4 descriptors as
+/// keeping q11 separate prevents firmware from interpreting q9 descriptors as
 /// scan traffic.
 pub const TX_AUX_TFD_RING_OFFSET: usize = TX_TFD_RING_BYTES;
 pub const TX_KEEP_WARM_OFFSET: usize = TX_AUX_TFD_RING_OFFSET + TX_TFD_RING_BYTES;

--- a/nitrogen/src/iwlwifi/tx.rs
+++ b/nitrogen/src/iwlwifi/tx.rs
@@ -485,6 +485,22 @@ impl IwlWifiDevice {
 
         // Firmware API 17 uses the pre-v12 station API. The scan engine
         // requires its auxiliary station before accepting an offload request.
+        // In non-DQA mode Linux first sends SCD_QUEUE_CFG. The transport
+        // registers above configure DMA, while this command tells firmware
+        // that q11 is enabled and initially owned by station 0.
+        let aux_scd = ScdTxqCfgCmdV1::aux();
+        let aux_scd_bytes = unsafe { super::as_bytes(&aux_scd) };
+        self.send_init_hcmd(
+            "SCD_QUEUE_CFG_AUX",
+            LegacyCmd::ScdQueueCfg as u8,
+            GroupId::Legacy as u8,
+            aux_scd_bytes,
+        )?;
+        log::info!(
+            "iwlwifi: init.config name=aux_queue queue={} owner_sta=0 fifo=mcast action=enable",
+            IWL_AUX_QUEUE,
+        );
+
         // ADD_STA is a legacy-group command and uses the four-byte header.
         const MAC_INDEX_AUX: u8 = 4;
         // The first internal station allocation reserves station 0 for the
@@ -492,8 +508,7 @@ impl IwlWifiDevice {
         const AUX_STA_ID: u8 = 1;
         // In Linux's non-DQA path the scheduler queue is initially owned by
         // station 0; ADD_STA then binds the auxiliary station (sta 1) to the
-        // queue through tfd_queue_msk. Sending sta 1 here makes API-v17
-        // firmware reject SCD_QUEUE_CFG before it can consume ADD_STA.
+        // queue through tfd_queue_msk.
         let aux_sta = AddStaCmdV7::aux(MAC_INDEX_AUX, AUX_STA_ID);
         let aux_sta_bytes = unsafe { super::as_bytes(&aux_sta) };
         self.send_init_hcmd(

--- a/nitrogen/src/iwlwifi/tx.rs
+++ b/nitrogen/src/iwlwifi/tx.rs
@@ -57,7 +57,7 @@ impl IwlWifiDevice {
             self.write_prph(SCD_CHAINEXT_EN, 0);
             self.write_mem32(scd_base + SCD_CONTEXT_QUEUE_CMD, 0);
             self.write_mem32(scd_base + SCD_CONTEXT_QUEUE_CMD + 4, 64 | (64 << 16));
-            // The scan engine uses the internal station's q8. Configure it
+            // The scan engine uses the internal station's q11. Configure it
             // before ADD_STA_AUX, just as Linux does; the firmware validates
             // the station's tfd_queue_msk against this scheduler entry.
             self.write_mem32(scd_base + SCD_CONTEXT_QUEUE_AUX, 0);
@@ -118,7 +118,10 @@ impl IwlWifiDevice {
                 (aux_ring_phys >> 8) as u32,
             );
             core::ptr::write_volatile(self.mmio.add(HBUS_TARG_WRPTR as usize), IWL_CMD_QUEUE << 8);
-            for channel in 0..=IWL_CMD_QUEUE {
+            // The 7265 exposes 16 legacy TX channels. The AUX station is q11,
+            // so enabling only through the command q9 leaves its scheduler
+            // channel disabled even though host commands still work.
+            for channel in 0..=IWL_AUX_QUEUE {
                 core::ptr::write_volatile(
                     self.mmio
                         .add((FH_TCSR_CHNL_TX_CONFIG_BASE + channel * (0x20 / 4)) as usize),

--- a/nitrogen/src/iwlwifi/tx.rs
+++ b/nitrogen/src/iwlwifi/tx.rs
@@ -485,10 +485,13 @@ impl IwlWifiDevice {
 
         // Firmware API 17 uses the pre-v12 station API. The scan engine
         // requires its auxiliary station before accepting an offload request.
-        // In non-DQA mode Linux first sends SCD_QUEUE_CFG. The transport
-        // registers above configure DMA, while this command tells firmware
-        // that q11 is enabled and initially owned by station 0.
-        let aux_scd = ScdTxqCfgCmdV1::aux();
+        // In non-DQA mode Linux allocates the AUX station first, then sends
+        // SCD_QUEUE_CFG naming that station, and only then sends ADD_STA.
+        // The transport registers above configure DMA; this command tells
+        // firmware that q11 is enabled for the already allocated station.
+        const MAC_INDEX_AUX: u8 = 4;
+        const AUX_STA_ID: u8 = 1;
+        let aux_scd = ScdTxqCfgCmdV1::aux(AUX_STA_ID);
         let aux_scd_bytes = unsafe { super::as_bytes(&aux_scd) };
         self.send_init_hcmd(
             "SCD_QUEUE_CFG_AUX",
@@ -497,18 +500,15 @@ impl IwlWifiDevice {
             aux_scd_bytes,
         )?;
         log::info!(
-            "iwlwifi: init.config name=aux_queue queue={} owner_sta=0 fifo=mcast action=enable",
+            "iwlwifi: init.config name=aux_queue queue={} owner_sta={} fifo=mcast action=enable",
             IWL_AUX_QUEUE,
+            AUX_STA_ID,
         );
 
         // ADD_STA is a legacy-group command and uses the four-byte header.
-        const MAC_INDEX_AUX: u8 = 4;
-        // The first internal station allocation reserves station 0 for the
-        // BSS/AP path, so the AUX station receives station-table ID 1.
-        const AUX_STA_ID: u8 = 1;
         // In Linux's non-DQA path the scheduler queue is initially owned by
-        // station 0; ADD_STA then binds the auxiliary station (sta 1) to the
-        // queue through tfd_queue_msk.
+        // the auxiliary station; ADD_STA publishes the same station ID and
+        // queue mask to firmware.
         let aux_sta = AddStaCmdV7::aux(MAC_INDEX_AUX, AUX_STA_ID);
         let aux_sta_bytes = unsafe { super::as_bytes(&aux_sta) };
         self.send_init_hcmd(

--- a/nitrogen/src/iwlwifi/types.rs
+++ b/nitrogen/src/iwlwifi/types.rs
@@ -381,7 +381,7 @@ pub struct AddStaCmdV7 {
 
 impl AddStaCmdV7 {
     pub fn aux(mac_index: u8, sta_id: u8) -> Self {
-        // The 7265 non-DQA layout reserves queue 8 for the auxiliary
+        // The 7265 non-DQA layout reserves queue 11 for the auxiliary
         // station.  Linux advertises that queue in tfd_queue_msk even when
         // the first scan is passive; leaving it zero makes API-v17 firmware
         // reject the station command before it can return ADD_STA status.

--- a/nitrogen/src/iwlwifi/types.rs
+++ b/nitrogen/src/iwlwifi/types.rs
@@ -852,6 +852,22 @@ impl WifiInitPhase {
             Self::Failed => "failed",
         }
     }
+
+    /// Short labels suitable for the boot-screen Hint area.
+    pub const fn screen_label(self) -> &'static [u8] {
+        match self {
+            Self::Idle => b"WIFI WAIT",
+            Self::PciProbe => b"WIFI PCI",
+            Self::MmioInit => b"WIFI MMIO",
+            Self::MmioPollMacClock => b"WIFI CLOCK",
+            Self::DmaAlloc => b"WIFI DMA",
+            Self::FwUpload => b"WIFI FW LOAD",
+            Self::FwWaitAlive => b"WIFI FW ALIVE",
+            Self::FwInitCmds => b"WIFI COMMANDS",
+            Self::Done => b"WIFI READY",
+            Self::Failed => b"WIFI FAILED",
+        }
+    }
 }
 
 impl From<u8> for WifiInitPhase {

--- a/nitrogen/src/iwlwifi/types.rs
+++ b/nitrogen/src/iwlwifi/types.rs
@@ -211,9 +211,9 @@ pub struct PhyConfigurationCmd {
 
 /// SCD_QUEUE_CFG_CMD_API_S_VER_1, used by the legacy non-DQA scheduler.
 ///
-/// Linux sends this before ADD_STA for the auxiliary queue. The queue is
-/// initially owned by station 0; ADD_STA then advertises the real internal
-/// station (ID 1) through its `tfd_queue_msk`.
+/// Linux sends this before ADD_STA for the auxiliary queue. The auxiliary
+/// station is allocated first and its real internal station ID is already
+/// used here; the following ADD_STA publishes the same queue mask.
 #[repr(C, packed)]
 #[derive(Clone, Copy)]
 pub struct ScdTxqCfgCmdV1 {
@@ -230,13 +230,13 @@ pub struct ScdTxqCfgCmdV1 {
 }
 
 impl ScdTxqCfgCmdV1 {
-    pub fn aux() -> Self {
+    pub fn aux(sta_id: u8) -> Self {
         use super::registers::IWL_AUX_QUEUE;
         Self {
             token: 0,
-            // Non-DQA config happens before the station is added. Linux uses
-            // the default station-0 owner here and binds sta 1 in ADD_STA.
-            sta_id: 0,
+            // Linux allocates the AUX station-table entry before enabling its
+            // queue, so SCD_QUEUE_CFG must name that station (normally 1).
+            sta_id,
             tid: 15, // IWL_MAX_TID_COUNT
             scd_queue: IWL_AUX_QUEUE as u8,
             action: 1,    // SCD_CFG_ENABLE_QUEUE

--- a/nitrogen/src/iwlwifi/types.rs
+++ b/nitrogen/src/iwlwifi/types.rs
@@ -79,6 +79,9 @@ pub enum LegacyCmd {
     /// firmware API 17 transports it through the long-command group.
     ScanConfig = 0x0c,
     AddStaKey = 0x17,
+    /// Legacy scheduler queue configuration used before ADD_STA in non-DQA
+    /// mode. The firmware initially associates the queue with station 0.
+    ScdQueueCfg = 0x1d,
     /// LMAC scan request for the 7265 firmware API (SCAN_OFFLOAD_REQUEST_CMD).
     /// 0x18 is ADD_STA, not a scan request.
     ScanRequest = 0x51,
@@ -87,7 +90,6 @@ pub enum LegacyCmd {
     Auth = 0x1A,
     Assoc = 0x1B,
     Disassoc = 0x1C,
-    Deauth = 0x1D,
     AddSta = 0x18,
     MacContext = 0x28,
     TxAntConfig = 0x98,
@@ -205,6 +207,46 @@ pub struct PhyConfigurationCmd {
     pub phy_config: u32,
     pub calib_flow_trigger: u32,
     pub calib_event_trigger: u32,
+}
+
+/// SCD_QUEUE_CFG_CMD_API_S_VER_1, used by the legacy non-DQA scheduler.
+///
+/// Linux sends this before ADD_STA for the auxiliary queue. The queue is
+/// initially owned by station 0; ADD_STA then advertises the real internal
+/// station (ID 1) through its `tfd_queue_msk`.
+#[repr(C, packed)]
+#[derive(Clone, Copy)]
+pub struct ScdTxqCfgCmdV1 {
+    pub token: u8,
+    pub sta_id: u8,
+    pub tid: u8,
+    pub scd_queue: u8,
+    pub action: u8,
+    pub aggregate: u8,
+    pub tx_fifo: u8,
+    pub window: u8,
+    pub ssn: u16,
+    pub reserved: u16,
+}
+
+impl ScdTxqCfgCmdV1 {
+    pub fn aux() -> Self {
+        use super::registers::IWL_AUX_QUEUE;
+        Self {
+            token: 0,
+            // Non-DQA config happens before the station is added. Linux uses
+            // the default station-0 owner here and binds sta 1 in ADD_STA.
+            sta_id: 0,
+            tid: 15, // IWL_MAX_TID_COUNT
+            scd_queue: IWL_AUX_QUEUE as u8,
+            action: 1,    // SCD_CFG_ENABLE_QUEUE
+            aggregate: 0, // non-aggregated auxiliary queue
+            tx_fifo: 5,   // IWL_MVM_TX_FIFO_MCAST
+            window: 64,
+            ssn: 0,
+            reserved: 0,
+        }
+    }
 }
 
 /// One AC entry in the API-v1 MAC context QoS array.

--- a/nitrogen/src/pci.rs
+++ b/nitrogen/src/pci.rs
@@ -57,6 +57,17 @@ static PHYS_OFFSET: AtomicU64 = AtomicU64::new(0);
 static ECAM_START_BUS: core::sync::atomic::AtomicU8 = core::sync::atomic::AtomicU8::new(0);
 static ECAM_END_BUS: core::sync::atomic::AtomicU8 = core::sync::atomic::AtomicU8::new(0);
 
+/// Errors returned while preparing an upstream bridge's L1 Substates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum L1SubstateError {
+    /// ECAM is not configured for this bus, so extended config access is unsafe.
+    EcamUnavailable,
+    /// The bridge disappeared from the PCI bus while it was being prepared.
+    DeviceNotPresent,
+    /// The supplied BDF is not an upstream PCIe bridge.
+    NotBridge,
+}
+
 /// Store the ECAM MMIO base (physical), the phys→virt offset, and the
 /// bus range covered by the ECAM segment.
 ///
@@ -68,6 +79,13 @@ pub fn set_ecam_info(ecam_base: u64, phys_offset: u64, start_bus: u8, end_bus: u
     PHYS_OFFSET.store(phys_offset, core::sync::atomic::Ordering::Relaxed);
     ECAM_START_BUS.store(start_bus, core::sync::atomic::Ordering::Relaxed);
     ECAM_END_BUS.store(end_bus, core::sync::atomic::Ordering::Relaxed);
+}
+
+/// Whether ECAM has been configured for at least one PCI bus.
+pub fn ecam_initialized() -> bool {
+    ECAM_BASE.load(core::sync::atomic::Ordering::Acquire) != 0
+        && ECAM_START_BUS.load(core::sync::atomic::Ordering::Acquire)
+            <= ECAM_END_BUS.load(core::sync::atomic::Ordering::Acquire)
 }
 
 /// Convert a physical address to a virtual pointer using the stored offset.
@@ -622,13 +640,33 @@ impl PciDevice {
     /// it on the bridge alone is sufficient to prevent the link from
     /// entering L1.1/L1.2.  There is no need to call this on the endpoint.
     ///
-    /// Note: The WiFi/RTSX/PciHealth recovery paths intentionally leave
-    /// L1Sub enabled, as Linux tolerates ASPM L1 + L1Sub on the same
-    /// chipset without hangs. This function is provided for explicit
-    /// bridge-side L1Sub control when needed.
+    /// WiFi and PciHealth call this for bridge-side L1Sub control before
+    /// endpoint MMIO or link retraining. Endpoint L1Sub remains untouched
+    /// because ECAM access to an endpoint may hang while the link is in L1.
     ///
-    /// Silently no-ops if ECAM has not been configured by the kernel.
-    pub fn disable_l1_substates(bus: u8, device: u8, function: u8) {
+    /// Returns an error when ECAM is unavailable or the bridge disappeared.
+    /// A bridge without an L1Sub capability is treated as successfully
+    /// prepared because there is no L1Sub state to disable.
+    pub fn disable_l1_substates(
+        bus: u8,
+        device: u8,
+        function: u8,
+    ) -> Result<(), crate::pci::L1SubstateError> {
+        if !ecam_initialized()
+            || bus < ECAM_START_BUS.load(core::sync::atomic::Ordering::Acquire)
+            || bus > ECAM_END_BUS.load(core::sync::atomic::Ordering::Acquire)
+        {
+            return Err(crate::pci::L1SubstateError::EcamUnavailable);
+        }
+        let vendor = PciConfigSpace::read_config_word(bus, device, function, 0);
+        if vendor == 0xFFFF || vendor == 0x0000 {
+            return Err(crate::pci::L1SubstateError::DeviceNotPresent);
+        }
+        let class_rev = PciConfigSpace::read_config_dword(bus, device, function, 8);
+        if (class_rev >> 24) as u8 != 0x06 || (class_rev >> 16) as u8 != 0x04 {
+            return Err(crate::pci::L1SubstateError::NotBridge);
+        }
+
         let mut off: u16 = 0x100;
         let mut iterations = 0;
         const MAX_ITERATIONS: u8 = 48;
@@ -637,8 +675,11 @@ impl PciDevice {
             // Extended capabilities live at offsets ≥ 0x100 — must use ECAM.
             let cap_hdr = read_ext_dword(bus, device, function, off);
             if cap_hdr == 0xFFFF_FFFF {
-                // ECAM not configured or device absent — skip
-                return;
+                // The pre-flight checks above already established that ECAM
+                // and the bridge are available. Treat an all-ones capability
+                // header as an absent L1Sub capability, not as permission to
+                // continue with an unsafe endpoint MMIO access.
+                return Ok(());
             }
             let cap_id = (cap_hdr & 0xFFFF) as u16;
             let next_off = ((cap_hdr >> 20) & 0xFFF) as u16;
@@ -647,8 +688,13 @@ impl PciDevice {
                 // L1 PM Substates Capability
                 // L1SubCtl1 is at offset cap+0x08 (2 dwords in).
                 let ctl1 = read_ext_dword(bus, device, function, off + 8);
-                // Bits [2:1]: ASPM L1.2 Enable (bit 2), ASPM L1.1 Enable (bit 1)
-                let l1sub_enabled = ctl1 & 0x6;
+                if ctl1 == 0xFFFF_FFFF {
+                    return Err(crate::pci::L1SubstateError::DeviceNotPresent);
+                }
+                // PCI_L1SS_CTL1_ASPM_L1_2 (bit 2) and
+                // PCI_L1SS_CTL1_ASPM_L1_1 (bit 3). The adjacent bits 0/1
+                // control PCI-PM L1.2/L1.1 and are intentionally preserved.
+                let l1sub_enabled = ctl1 & 0xC;
                 if l1sub_enabled != 0 {
                     log::info!(
                         "PCI: disabling L1Sub on {:02x}:{:02x}.{} (was {:#x})",
@@ -657,13 +703,14 @@ impl PciDevice {
                         function,
                         l1sub_enabled,
                     );
-                    write_ext_dword(bus, device, function, off + 8, ctl1 & !0x6u32);
+                    write_ext_dword(bus, device, function, off + 8, ctl1 & !0xCu32);
                 }
-                return;
+                return Ok(());
             }
 
             off = next_off;
         }
+        Ok(())
     }
 
     pub fn detect_bar_size(&self, bar_index: u8) -> u32 {

--- a/nitrogen/src/pci_health.rs
+++ b/nitrogen/src/pci_health.rs
@@ -147,25 +147,21 @@ impl PciHealth {
     ///
     /// # ⚠️ Hang-proof design
     ///
-    /// All operations use port I/O (CF8/CFC) exclusively. Bridge and endpoint
-    /// ECAM reads are **never** performed — port I/O is used for standard
-    /// config space access only. L1 PM Substates are not modified and are
-    /// intentionally left enabled (see below).
+    /// Standard config-space operations use port I/O (CF8/CFC). The one
+    /// extended-config operation is the bridge-side L1Sub clear; the bridge
+    /// is upstream of the endpoint and remains safe to access through ECAM.
     ///
     /// # Ordering
     ///
     /// 1. `ensure_d0()` on endpoint and bridge (port I/O, safe)
-    /// 2. **Link retrain** on upstream bridge (port I/O, safe)
-    /// 3. `disable_pcie_aspm()` on bridge — standard ASPM only (port I/O, safe)
-    /// 4. `disable_pcie_aspm()` on endpoint — standard ASPM only (port I/O, safe)
-    /// 5. `check()` — full health verification via port I/O (safe)
+    /// 2. Disable bridge-side L1 Substates through ECAM (safe)
+    /// 3. **Link retrain** on upstream bridge (port I/O, safe)
+    /// 4. `disable_pcie_aspm()` on bridge — standard ASPM only (port I/O, safe)
+    /// 5. `disable_pcie_aspm()` on endpoint — standard ASPM only (port I/O, safe)
+    /// 6. `check()` — full health verification via port I/O (safe)
     ///
-    /// L1 PM Substates (L1.1/L1.2) are not modified during recovery. While
-    /// bridge-side ECAM access would be permissible for L1Sub configuration
-    /// (bridges are never in L1 relative to the CPU), recovery paths do not
-    /// disable L1Sub since it is disabled once during WiFi init on the bridge.
-    /// Endpoint L1Sub cannot be safely disabled here (ECAM MMIO hangs if the
-    /// link is in L1).
+    /// Endpoint L1Sub is intentionally not touched: ECAM access to an
+    /// endpoint may hang while the link is in L1.
     pub fn recover(&mut self) -> Result<(), PciHealthError> {
         // Step 1: Re-assert D0 on the device and bridge (port I/O, safe)
         self.ensure_d0();
@@ -175,22 +171,29 @@ impl PciHealth {
             bridge.ensure_d0();
         }
 
-        // Step 2: Retrain the upstream link (port I/O, safe)
+        // Step 2: Disable L1.1/L1.2 on the bridge before retraining or
+        // touching the endpoint. This closes the power-management path that
+        // can make a live 7265 look like a vanished PCIe device.
+        if let Some((b, d, f)) = self.upstream_bridge {
+            PciDevice::disable_l1_substates(b, d, f);
+        }
+
+        // Step 3: Retrain the upstream link (port I/O, safe)
         self.retrain_upstream_link();
 
-        // Step 3: Disable standard ASPM on the bridge (port I/O, safe)
+        // Step 4: Disable standard ASPM on the bridge (port I/O, safe)
         if let Some((b, d, f)) = self.upstream_bridge
             && let Some(bridge) = PciDevice::new(b, d, f)
         {
             bridge.disable_pcie_aspm();
         }
 
-        // Step 4: Disable standard ASPM on the endpoint (port I/O, safe).
+        // Step 5: Disable standard ASPM on the endpoint (port I/O, safe).
         // L1Sub is not touched here — endpoint ECAM access is unsafe when
-        // the link may be in L1. Bridge-side L1Sub is disabled during WiFi init.
+        // the link may be in L1.
         self.disable_aspm();
 
-        // Step 5: Re-verify (port I/O, safe)
+        // Step 6: Re-verify (port I/O, safe)
         self.check()
     }
 

--- a/nitrogen/src/pci_health.rs
+++ b/nitrogen/src/pci_health.rs
@@ -10,14 +10,15 @@
 //! | Non-posted read hang | Read to unresponsive device | Config space probe | Skip MMIO, use PIO fallback |
 //! | Surprise link down | Transient electrical noise | Config retry | Retry with backoff |
 
-use crate::pci::{PciConfigSpace, PciDevice};
+use crate::pci::{L1SubstateError, PciConfigSpace, PciDevice};
 
 /// Error type for PCI health operations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PciHealthError {
-    DeviceGone, // vendor=0xFFFF
-    NotD0,      // power state is D1-D3hot
-    LinkDown,   // PCIe link status shows speed=0
+    DeviceGone,      // vendor=0xFFFF
+    NotD0,           // power state is D1-D3hot
+    LinkDown,        // PCIe link status shows speed=0
+    EcamUnavailable, // bridge L1Substate configuration could not be verified
 }
 
 impl core::fmt::Display for PciHealthError {
@@ -26,6 +27,12 @@ impl core::fmt::Display for PciHealthError {
             PciHealthError::DeviceGone => write!(f, "device not on PCI bus"),
             PciHealthError::NotD0 => write!(f, "device not in D0"),
             PciHealthError::LinkDown => write!(f, "PCIe link down"),
+            PciHealthError::EcamUnavailable => {
+                write!(
+                    f,
+                    "PCI ECAM unavailable for bridge L1Substate configuration"
+                )
+            }
         }
     }
 }
@@ -175,7 +182,18 @@ impl PciHealth {
         // touching the endpoint. This closes the power-management path that
         // can make a live 7265 look like a vanished PCIe device.
         if let Some((b, d, f)) = self.upstream_bridge {
-            PciDevice::disable_l1_substates(b, d, f);
+            match PciDevice::disable_l1_substates(b, d, f) {
+                Ok(()) => {}
+                Err(L1SubstateError::EcamUnavailable) => {
+                    return Err(PciHealthError::EcamUnavailable);
+                }
+                Err(L1SubstateError::DeviceNotPresent) => {
+                    return Err(PciHealthError::DeviceGone);
+                }
+                Err(L1SubstateError::NotBridge) => {
+                    return Err(PciHealthError::DeviceGone);
+                }
+            }
         }
 
         // Step 3: Retrain the upstream link (port I/O, safe)

--- a/nitrogen/src/wifi.rs
+++ b/nitrogen/src/wifi.rs
@@ -340,6 +340,12 @@ pub fn probe_pci_only(ctx: &'static dyn DriverContext) -> Option<RawPciProbeResu
             dev,
             func
         );
+
+        // Clearing ordinary ASPM bits is not enough to prevent the endpoint
+        // from entering L1.1/L1.2 once firmware starts changing power state.
+        // The upstream bridge is safe to access through ECAM, so disable the
+        // negotiated L1 Substates before the first endpoint MMIO transaction.
+        crate::pci::PciDevice::disable_l1_substates(bus, dev, func);
     }
 
     // ── Minimal endpoint configuration ─────────────────────

--- a/nitrogen/src/wifi.rs
+++ b/nitrogen/src/wifi.rs
@@ -320,6 +320,13 @@ pub struct RawPciProbeResult {
 /// Returns raw state that can be used by subsequent init phases.
 pub fn probe_pci_only(ctx: &'static dyn DriverContext) -> Option<RawPciProbeResult> {
     crate::debug::print("wifi", "start_pci_probe");
+    // WifiRegistry::probe() only uses port I/O, but its result is immediately
+    // followed by bridge ECAM access before the endpoint's first MMIO read.
+    // Do not discover a candidate that cannot be safely prepared.
+    if !crate::pci::ecam_initialized() {
+        log::warn!("WiFi: PCI ECAM is unavailable; refusing probe before endpoint MMIO");
+        return None;
+    }
     let Some((entry, info)) = WifiRegistry::probe() else {
         log::warn!("WiFi: no supported Intel wireless PCI device found");
         return None;
@@ -345,7 +352,26 @@ pub fn probe_pci_only(ctx: &'static dyn DriverContext) -> Option<RawPciProbeResu
         // from entering L1.1/L1.2 once firmware starts changing power state.
         // The upstream bridge is safe to access through ECAM, so disable the
         // negotiated L1 Substates before the first endpoint MMIO transaction.
-        crate::pci::PciDevice::disable_l1_substates(bus, dev, func);
+        match crate::pci::PciDevice::disable_l1_substates(bus, dev, func) {
+            Ok(()) => {}
+            Err(crate::pci::L1SubstateError::EcamUnavailable) => {
+                log::warn!(
+                    "WiFi: refusing endpoint MMIO because bridge ECAM is unavailable at {:02x}:{:02x}.{}",
+                    bus,
+                    dev,
+                    func,
+                );
+                return None;
+            }
+            Err(crate::pci::L1SubstateError::DeviceNotPresent) => {
+                log::warn!("WiFi: upstream bridge disappeared during PCI probe");
+                return None;
+            }
+            Err(crate::pci::L1SubstateError::NotBridge) => {
+                log::warn!("WiFi: refusing probe because upstream BDF is not a PCIe bridge");
+                return None;
+            }
+        }
     }
 
     // ── Minimal endpoint configuration ─────────────────────

--- a/nitrogen/tests/linux_protocol_compat.rs
+++ b/nitrogen/tests/linux_protocol_compat.rs
@@ -12,7 +12,9 @@ use nitrogen::iwlwifi::registers::{
     TX_KEEP_WARM_BYTES, TX_KEEP_WARM_OFFSET, TX_QUEUE_SIZE, TX_SCD_BC_BYTES, TX_SCD_BC_OFFSET,
     TX_TFD_RING_BYTES,
 };
-use nitrogen::iwlwifi::types::{AddStaCmdV7, MacContextCmd, ScanConfigV1, ScanRequestCmd};
+use nitrogen::iwlwifi::types::{
+    AddStaCmdV7, MacContextCmd, ScanConfigV1, ScanRequestCmd, ScdTxqCfgCmdV1,
+};
 use nitrogen::usb::UsbSetupPacket;
 use nitrogen::usb::xhci::ring::{trb_flag, trb_type};
 use nitrogen::usb::xhci::transfer::linux_control_transfer_trbs;
@@ -38,6 +40,16 @@ fn linux_v49_aux_station_payload_is_wire_compatible() {
     expected[16] = 1;
     expected[40..44].copy_from_slice(&(1u32 << 11).to_le_bytes());
     assert_eq!(actual, expected);
+}
+
+#[test]
+fn linux_v49_aux_queue_config_is_sent_before_station_add() {
+    assert_eq!(size_of::<ScdTxqCfgCmdV1>(), 12);
+    let payload = ScdTxqCfgCmdV1::aux();
+    let actual = bytes(&payload);
+    // token=0, owner sta=0, tid=15, q11, enable, non-aggregate,
+    // multicast FIFO=5, window=64, ssn=0, reserved=0.
+    assert_eq!(actual, &[0, 0, 15, 11, 1, 0, 5, 64, 0, 0, 0, 0]);
 }
 
 #[test]

--- a/nitrogen/tests/linux_protocol_compat.rs
+++ b/nitrogen/tests/linux_protocol_compat.rs
@@ -24,19 +24,19 @@ fn bytes<T>(value: &T) -> &[u8] {
 #[test]
 fn linux_v49_aux_station_payload_is_wire_compatible() {
     assert_eq!(IWL_CMD_QUEUE, 9);
-    assert_eq!(IWL_AUX_QUEUE, 8);
+    assert_eq!(IWL_AUX_QUEUE, 11);
     assert_eq!(size_of::<AddStaCmdV7>(), 44);
 
     // Linux v4.9 iwl_mvm_add_aux_sta(): MAC_INDEX_AUX is 4, while the
     // internal station-table entry is allocated as sta_id 1. The queue mask
-    // must advertise q8 before ADD_STA is sent.
+    // must advertise q11 before ADD_STA is sent.
     let payload = AddStaCmdV7::aux(4, 1);
     let actual = bytes(&payload);
     let mut expected = [0u8; 44];
     expected[2..4].copy_from_slice(&0xffffu16.to_le_bytes());
     expected[4..8].copy_from_slice(&4u32.to_le_bytes());
     expected[16] = 1;
-    expected[40..44].copy_from_slice(&(1u32 << 8).to_le_bytes());
+    expected[40..44].copy_from_slice(&(1u32 << 11).to_le_bytes());
     assert_eq!(actual, expected);
 }
 

--- a/nitrogen/tests/linux_protocol_compat.rs
+++ b/nitrogen/tests/linux_protocol_compat.rs
@@ -45,11 +45,11 @@ fn linux_v49_aux_station_payload_is_wire_compatible() {
 #[test]
 fn linux_v49_aux_queue_config_is_sent_before_station_add() {
     assert_eq!(size_of::<ScdTxqCfgCmdV1>(), 12);
-    let payload = ScdTxqCfgCmdV1::aux();
+    let payload = ScdTxqCfgCmdV1::aux(1);
     let actual = bytes(&payload);
-    // token=0, owner sta=0, tid=15, q11, enable, non-aggregate,
+    // token=0, owner sta=1, tid=15, q11, enable, non-aggregate,
     // multicast FIFO=5, window=64, ssn=0, reserved=0.
-    assert_eq!(actual, &[0, 0, 15, 11, 1, 0, 5, 64, 0, 0, 0, 0]);
+    assert_eq!(actual, &[0, 1, 15, 11, 1, 0, 5, 64, 0, 0, 0, 0]);
 }
 
 #[test]

--- a/solvent/src/network_manager.rs
+++ b/solvent/src/network_manager.rs
@@ -43,6 +43,7 @@ impl WifiService {
         let started = *self.init_started.get_or_insert(now);
         if nitrogen::iwlwifi::wifi_init_completed() {
             self.init_pending = false;
+            self.init_started = None;
         } else if now.wrapping_sub(started) >= WIFI_INIT_TIMEOUT_TICKS {
             log::warn!(
                 "iwlwifi: deferred initialization timed out after {} scheduler ticks",
@@ -50,6 +51,7 @@ impl WifiService {
             );
             nitrogen::iwlwifi::force_init_failed();
             self.init_pending = false;
+            self.init_started = None;
         } else {
             nitrogen::iwlwifi::try_init_wifi_device_step();
         }
@@ -86,7 +88,11 @@ impl WifiService {
         *crate::NETWORK_SNAPSHOT.lock() = crate::NetworkSnapshot {
             aps,
             status: if !state.device_available {
-                NetStatus::NoDevice
+                if nitrogen::iwlwifi::wifi_init_failed() {
+                    NetStatus::Error("Wi-Fi initialization failed".into())
+                } else {
+                    NetStatus::NoDevice
+                }
             } else {
                 match state.status {
                     WifiStatus::Connected => NetStatus::Connected(
@@ -112,6 +118,9 @@ impl crate::Service for WifiService {
         #[cfg(not(nitrogen_no_iwlwifi))]
         if !self.init_pending && WIFI_INIT_REQUESTED.swap(false, Ordering::Acquire) {
             self.init_pending = true;
+            // A retry starts a new timeout window. Keeping the old start
+            // tick made every retry fail immediately after the first timeout.
+            self.init_started = Some(now);
             log::info!("iwlwifi: deferred initialization requested by network menu");
         }
         #[cfg(not(nitrogen_no_iwlwifi))]
@@ -129,10 +138,16 @@ impl crate::Service for WifiService {
         }
         #[cfg(not(nitrogen_no_iwlwifi))]
         if nitrogen::iwlwifi::wifi_init_completed()
+            && nitrogen::iwlwifi::wifi_device_ready()
             && WIFI_SCAN_REQUESTED.swap(false, Ordering::Acquire)
         {
             log::info!("iwlwifi: scan requested by network menu");
             nitrogen::iwlwifi::start_scan_if_idle();
+        } else if nitrogen::iwlwifi::wifi_init_failed() {
+            // The menu action and initialization request are independent
+            // atomics. Do not issue a misleading scan request after the
+            // initialization state has been disabled.
+            WIFI_SCAN_REQUESTED.store(false, Ordering::Release);
         }
         for action in core::mem::take(&mut *crate::WIFI_ACTION_QUEUE.lock()) {
             let crate::WifiAction::Connect(ssid, password) = action;

--- a/solvent/src/network_manager.rs
+++ b/solvent/src/network_manager.rs
@@ -15,10 +15,10 @@ use lattice::desktop::DesktopAction;
 // aborted the state machine before its own alive timeout could run.
 const WIFI_INIT_TIMEOUT_TICKS: u64 = 12_000;
 
-// iwlwifi firmware/MMIO probing is not safe to run unconditionally from the
-// desktop tick: a missing or wedged PCIe endpoint can stall that tick.  Keep
-// the service registered for the network UI, but only start hardware probing
-// after the user explicitly opens the network menu.
+// iwlwifi firmware/MMIO probing is owned by the scheduler-facing Wi-Fi
+// service. It is queued when the service is registered, rather than from a
+// desktop/UI event, so boot can make progress even when no network menu is
+// ever opened.
 static WIFI_INIT_REQUESTED: AtomicBool = AtomicBool::new(false);
 static WIFI_SCAN_REQUESTED: AtomicBool = AtomicBool::new(false);
 
@@ -121,14 +121,13 @@ impl crate::Service for WifiService {
             // A retry starts a new timeout window. Keeping the old start
             // tick made every retry fail immediately after the first timeout.
             self.init_started = Some(now);
-            log::info!("iwlwifi: deferred initialization requested by network menu");
+            log::info!("iwlwifi: deferred initialization requested");
         }
         #[cfg(not(nitrogen_no_iwlwifi))]
         if self.init_pending {
             self.advance_init(now);
         }
         #[cfg(not(nitrogen_no_iwlwifi))]
-        // There is no device to poll before the user requests initialization.
         // After a failed attempt wifi_init_completed() is also true, but the
         // driver object is absent. Use the stronger readiness predicate so we
         // do not keep producing no-op Tick requests that can starve later
@@ -167,7 +166,8 @@ impl crate::Service for WifiService {
 pub fn register_wifi_service() {
     use alloc::boxed::Box;
     nitrogen::iwlwifi::init_wifi_manager();
-    log::info!("iwlwifi: service registered; initialization deferred until network menu");
+    request_wifi_initialization();
+    log::info!("iwlwifi: service registered; automatic initialization queued");
     crate::register_service(Box::new(WifiService::new()));
 }
 
@@ -175,6 +175,10 @@ pub fn register_wifi_service() {
 fn request_wifi_initialization() {
     let _ = nitrogen::iwlwifi::retry_wifi_initialization();
     WIFI_INIT_REQUESTED.store(true, Ordering::Release);
+}
+
+#[cfg(not(nitrogen_no_iwlwifi))]
+fn request_wifi_scan() {
     WIFI_SCAN_REQUESTED.store(true, Ordering::Release);
 }
 
@@ -185,7 +189,10 @@ pub fn handle_network_action(rt: &mut crate::RuntimeState, action: &DesktopActio
     match action {
         DesktopAction::ShowNetworkMenu => {
             #[cfg(not(nitrogen_no_iwlwifi))]
-            request_wifi_initialization();
+            {
+                request_wifi_initialization();
+                request_wifi_scan();
+            }
             let (fw, fh, _) = *crate::FB_DIMS.lock();
             rt.desktop.show_network_menu(fw, fh);
             rt.frame_due = true;

--- a/solvent/src/network_manager.rs
+++ b/solvent/src/network_manager.rs
@@ -116,12 +116,30 @@ impl crate::Service for WifiService {
         #[cfg(nitrogen_no_iwlwifi)]
         let _ = now;
         #[cfg(not(nitrogen_no_iwlwifi))]
-        if !self.init_pending && WIFI_INIT_REQUESTED.swap(false, Ordering::Acquire) {
-            self.init_pending = true;
-            // A retry starts a new timeout window. Keeping the old start
-            // tick made every retry fail immediately after the first timeout.
-            self.init_started = Some(now);
-            log::info!("iwlwifi: deferred initialization requested");
+        if !self.init_pending && WIFI_INIT_REQUESTED.load(Ordering::Acquire) {
+            // A failed initialization is terminal until its resources can be
+            // reset. Keep the request published when try_lock() is busy and
+            // consume it only after retry_wifi_initialization() succeeds.
+            let can_start = if nitrogen::iwlwifi::wifi_init_failed() {
+                nitrogen::iwlwifi::retry_wifi_initialization()
+            } else {
+                !nitrogen::iwlwifi::wifi_init_completed()
+            };
+            if can_start {
+                WIFI_INIT_REQUESTED.store(false, Ordering::Release);
+                self.init_pending = true;
+                // A retry starts a new timeout window. Keeping the old start
+                // tick made every retry fail immediately after the first timeout.
+                self.init_started = Some(now);
+                log::info!("iwlwifi: deferred initialization requested");
+            } else if nitrogen::iwlwifi::wifi_init_completed()
+                && !nitrogen::iwlwifi::wifi_init_failed()
+            {
+                // A menu action may arrive while an existing attempt is
+                // finishing. Do not leave that level-triggered request stuck
+                // forever after a successful initialization.
+                WIFI_INIT_REQUESTED.store(false, Ordering::Release);
+            }
         }
         #[cfg(not(nitrogen_no_iwlwifi))]
         if self.init_pending {
@@ -173,8 +191,12 @@ pub fn register_wifi_service() {
 
 #[cfg(not(nitrogen_no_iwlwifi))]
 fn request_wifi_initialization() {
-    let _ = nitrogen::iwlwifi::retry_wifi_initialization();
-    WIFI_INIT_REQUESTED.store(true, Ordering::Release);
+    // Initial startup and a failed startup are both level-triggered. In the
+    // failed case WifiService::tick retries the reset and leaves this request
+    // pending if WIFI_INIT_CTX is temporarily locked.
+    if !nitrogen::iwlwifi::wifi_init_completed() || nitrogen::iwlwifi::wifi_init_failed() {
+        WIFI_INIT_REQUESTED.store(true, Ordering::Release);
+    }
 }
 
 #[cfg(not(nitrogen_no_iwlwifi))]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Wi‑Fi initialization now starts automatically when network services become available.
  - Network status distinguishes initialization failures from missing Wi‑Fi hardware.
  - Initialization screens now show clearer progress labels.

- **Bug Fixes**
  - Wi‑Fi initialization retries receive a fresh timeout window.
  - Network scans are prevented until the device is ready and are cleared after initialization failure.
  - Opening the network menu independently triggers initialization and scanning.
  - Improved PCIe recovery helps restore connectivity after hardware link issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->