### PR TITLE
Wifi debug

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -76,16 +76,16 @@ For legacy iwlwifi, the authentication exchange follows Linux gen1's DQA
 ordering: publish the CBBC and initial zero write pointer before
 `SCD_QUEUE_CFG`, attach the station queue after that command, and make the
 first post-configuration doorbell the TFD's actual write pointer. The affected
-API-29 7265D firmware still needs a narrowly scoped q5 `SCD_EN_CTRL` gate
-restored after queue ownership is accepted; this compatibility write does not
-emit a second zero-pointer doorbell. The driver records firmware TX results for
-management frames, advances the bounded queue plan after an explicit failure,
-and no longer discards association-frame transmission errors. The DQA
-management queue follows Linux's gen1 scheduler frame limit of 64; Linux's
-separate 16-entry management allocation is a host software queue capacity, not
-the SCD command window. Host replay/unit tests cover the state machine; the AP
-authentication result on the affected physical adapter remains the final
-hardware validation step.
+The API-29 q5 `SCD_EN_CTRL` write is retained only as a disabled diagnostic A/B
+switch because Linux leaves firmware-owned DQA queue activation to firmware;
+the default path does not modify q5 after queue ownership is accepted. The
+driver records firmware TX results for management frames, advances the bounded
+queue plan after an explicit failure, and no longer discards association-frame
+transmission errors. The DQA management queue follows Linux's gen1 scheduler
+frame limit of 64; Linux's separate 16-entry management allocation is a host
+software queue capacity, not the SCD command window. Host replay/unit tests
+cover the state machine; the AP authentication result on the affected physical
+adapter remains the final hardware validation step.
 
 A 2026-07-30 redundancy and correctness audit reduced logic LOC without
 changing runtime contracts: repetitive command-serialisation and font/colour

--- a/docs/BUG_JOURNAL.md
+++ b/docs/BUG_JOURNAL.md
@@ -303,6 +303,60 @@ timeout path is nevertheless valuable: the next fix should preserve the
 initial q5 evidence, prevent a stalled q5 fallback from blocking the command
 queue, and make the gate-cleared experiment independently observable.
 
+## Entry 026 — 2026-08-16 API-29 firmware TLV alignment audit
+
+### Linux comparison
+
+Linux's `iwl_parse_tlv_firmware()` advances every record by
+`sizeof(struct iwl_ucode_tlv) + ALIGN(tlv_len, 4)`. Fullerene already used
+that boundary for the normal path, but the `SEC_INIT`/`SEC_RT` skip and
+separator paths advanced only to the unpadded payload end. That is a real
+parser discrepancy for a non-word-sized TLV preceding a section record.
+
+The API-29 image in the new hardware log is otherwise parsed consistently:
+API 29/build, `TLV_ENABLED_CAPABILITIES` index 0 bit 12 (DQA), PHY_SKU,
+runtime calibration, and all three selected sections are observed before
+ALIVE. `SCD_QUEUE_CFG` also returns the expected q5 response. Therefore this
+TLV issue is fixed as a correctness hole, but the current q5 `RDPTR=0`
+failure is not proven to originate in the firmware-file TLV stream.
+
+### Change
+
+The legacy parser now computes and validates one aligned `next_tlv` boundary,
+uses it on every skip path, and rejects truncated/overflowing records instead
+of silently continuing. It also logs the Linux API-change bitmap (including
+bit 29, without changing key-command selection) so the physical run can
+confirm that the selected firmware's API flags were read at the same offset.
+
+The q5 SCD gate, authentication frame, WPA path, and RX parser were not
+changed by this audit.
+
+## Entry 025 — 2026-08-16 API-29 DQA gate A/B matches Linux ownership
+
+### Linux comparison
+
+Linux gen1 `iwl_trans_pcie_txq_enable()` receives `cfg == NULL` for a DQA
+queue. In that branch it initializes the queue pointers and publishes the
+initial `HBUS_TARG_WRPTR`, but it does not write `SCD_EN_CTRL`, queue status,
+queuechain, aggregation, context, or the RA/TID translation entry. The only
+`SCD_EN_CTRL` update in the function is for the command queue. `ADD_STA`
+publishes the station's `tfd_queue_msk` separately through the MVM path.
+
+### Change
+
+`ensure_api29_dqa_scheduler_gate()` now defaults to observation-only. The
+former q5 `SCD_EN_CTRL` write remains behind
+`API29_DQA_HOST_SCD_GATE_DIAGNOSTIC = false`, and logs before/after values and
+the q5 bit so a physical run is an unambiguous A/B result. The direct-SCD
+fallback remains separate. Authentication/WPA/RX parsing and the auth frame
+layout were not changed.
+
+The submit log now includes q5 CBBC, station queue mask, SCD control bits,
+context words, translation/TX-status words, and FH state in the same record as
+the post-doorbell pointers. The first hardware validation for this build is
+`qbit=CLEAR` followed by `hw_wrptr=1` and `hw_rdptr=1` (or a TX completion).
+No physical result is claimed by this entry yet.
+
 ## Entry 009 — 2026-07-30 workspace audit fixes
 
 A full-workspace bug and redundancy sweep produced the following fixes. Each

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -23,6 +23,16 @@ git -C bonder/iwlwifi sparse-checkout set intel/iwlwifi
 The UEFI build requires the matching firmware files to be present in that
 directory.
 
+For a local 7265D firmware experiment, keep the replacement outside the
+submodule and override it only for that build:
+
+```bash
+FULLERENE_IWLWIFI_7265D_FW=/path/to/iwlwifi-7265D-29.ucode \
+  cargo run -p flasks --bin flasks -- --iso-only
+```
+
+Without the environment variable, the tracked submodule firmware is used.
+
 The repository includes third‑party application port definitions that are
 automatically built from submodule sources and embedded into the kernel
 via a CPIO initramfs archive.

--- a/nitrogen/build.rs
+++ b/nitrogen/build.rs
@@ -17,7 +17,7 @@
 
 use std::env;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 fn main() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
@@ -98,4 +98,25 @@ fn main() {
     println!("cargo:rerun-if-changed={}", ignore_path.display());
     println!("cargo:rerun-if-env-changed=NITROGEN_DRIVERIGNORE");
     println!("cargo:rerun-if-changed=build.rs");
+
+    // Keep tracked firmware as the default, while allowing local hardware
+    // tests to use an external blob without modifying the submodule pointer.
+    let default_fw =
+        PathBuf::from(&manifest_dir).join("../bonder/iwlwifi/intel/iwlwifi/iwlwifi-7265D-29.ucode");
+    let configured_fw = env::var_os("FULLERENE_IWLWIFI_7265D_FW")
+        .map(PathBuf::from)
+        .map(|path| {
+            if path.is_absolute() {
+                path
+            } else {
+                PathBuf::from(&manifest_dir).join(path)
+            }
+        })
+        .unwrap_or(default_fw);
+    println!("cargo:rerun-if-env-changed=FULLERENE_IWLWIFI_7265D_FW");
+    println!("cargo:rerun-if-changed={}", configured_fw.display());
+    println!(
+        "cargo:rustc-env=FULLERENE_IWLWIFI_7265D_FW={}",
+        configured_fw.display()
+    );
 }

--- a/nitrogen/src/iwlwifi/connection_state.rs
+++ b/nitrogen/src/iwlwifi/connection_state.rs
@@ -2322,12 +2322,18 @@ impl IwlWifiDevice {
             let q5_cbbc = self
                 .safe_read32(fh_mem_cbbc_queue(IWL_MGMT_QUEUE))
                 .unwrap_or(!0);
-            let q5_ctx0 = self
-                .read_mem32(self.alive_scd_base_addr + scd_context_queue(IWL_MGMT_QUEUE))
-                .unwrap_or(!0);
-            let q5_ctx1 = self
-                .read_mem32(self.alive_scd_base_addr + scd_context_queue(IWL_MGMT_QUEUE) + 4)
-                .unwrap_or(!0);
+            let (q5_ctx0, q5_ctx1) = if self.alive_scd_base_addr != 0 {
+                (
+                    self.read_mem32(self.alive_scd_base_addr + scd_context_queue(IWL_MGMT_QUEUE))
+                        .unwrap_or(!0),
+                    self.read_mem32(
+                        self.alive_scd_base_addr + scd_context_queue(IWL_MGMT_QUEUE) + 4,
+                    )
+                    .unwrap_or(!0),
+                )
+            } else {
+                (!0, !0)
+            };
             let q0_status = self
                 .read_prph(scd_queue_status(self.command_queue()))
                 .unwrap_or(!0);

--- a/nitrogen/src/iwlwifi/connection_state.rs
+++ b/nitrogen/src/iwlwifi/connection_state.rs
@@ -2271,6 +2271,13 @@ impl IwlWifiDevice {
                 aux_tx_stts,
             );
             let queue_update = AddStaCmdV7::peer_queue_update(0, 0, ap.bssid);
+            let queue_update_mask = queue_update.tfd_queue_msk;
+            log::info!(
+                "iwlwifi: CONNECT_ADD_STA_QUEUE owner sta_id={} queue={} tfd_queue_msk={:#010x}",
+                queue_update.sta_id,
+                IWL_MGMT_QUEUE,
+                queue_update_mask,
+            );
             if let Err(error) = self.send_hcmd_and_wait(
                 "CONNECT_ADD_STA_QUEUE",
                 LegacyCmd::AddSta as u8,
@@ -2312,6 +2319,15 @@ impl IwlWifiDevice {
             let q5_rdptr = self
                 .read_prph(scd_queue_rdptr(IWL_MGMT_QUEUE))
                 .unwrap_or(!0);
+            let q5_cbbc = self
+                .safe_read32(fh_mem_cbbc_queue(IWL_MGMT_QUEUE))
+                .unwrap_or(!0);
+            let q5_ctx0 = self
+                .read_mem32(self.alive_scd_base_addr + scd_context_queue(IWL_MGMT_QUEUE))
+                .unwrap_or(!0);
+            let q5_ctx1 = self
+                .read_mem32(self.alive_scd_base_addr + scd_context_queue(IWL_MGMT_QUEUE) + 4)
+                .unwrap_or(!0);
             let q0_status = self
                 .read_prph(scd_queue_status(self.command_queue()))
                 .unwrap_or(!0);
@@ -2328,13 +2344,17 @@ impl IwlWifiDevice {
             let aggr_sel = self.read_prph(SCD_AGGR_SEL).unwrap_or(!0);
             let scd_dram = self.read_prph(SCD_DRAM_BASE_ADDR).unwrap_or(!0);
             log::info!(
-                "iwlwifi: SCD pre-auth q0 status={:#010x} wrptr={:#010x} rdptr={:#010x} | q5 status={:#010x} wrptr={:#010x} rdptr={:#010x} | scd_en={:#010x} scd_gp={:#010x} txfact={:#010x} qchain={:#010x} aggr={:#010x} dram={:#010x}",
+                "iwlwifi: SCD pre-auth q0 status={:#010x} wrptr={:#010x} rdptr={:#010x} | q5 status={:#010x} wrptr={:#010x} rdptr={:#010x} cbbc={:#010x} ctx0={:#010x} ctx1={:#010x} sta_queue_mask={:#010x} | scd_en={:#010x} scd_gp={:#010x} txfact={:#010x} qchain={:#010x} aggr={:#010x} dram={:#010x}",
                 q0_status,
                 q0_wrptr,
                 q0_rdptr,
                 q5_status,
                 q5_wrptr,
                 q5_rdptr,
+                q5_cbbc,
+                q5_ctx0,
+                q5_ctx1,
+                1u32 << IWL_MGMT_QUEUE,
                 scd_en,
                 scd_gp,
                 scd_txfact,

--- a/nitrogen/src/iwlwifi/device.rs
+++ b/nitrogen/src/iwlwifi/device.rs
@@ -1196,11 +1196,24 @@ impl IwlWifiDevice {
             let tlv_data_off = off + 8;
             let tlv_end = match tlv_data_off.checked_add(tlv_len as usize) {
                 Some(end) => end,
-                None => break,
+                None => return Err(crate::DriverError::Protocol),
             };
 
             if tlv_end > fw_data.len() {
-                break;
+                return Err(crate::DriverError::Protocol);
+            }
+
+            // Linux advances by ALIGN(tlv_len, 4), not merely by the
+            // unpadded payload end.  This matters when an image contains a
+            // non-word-sized metadata TLV before the SEC_* records: otherwise
+            // a SEC record for the other image can make the next header start
+            // in its padding bytes and shift the whole parse.
+            let next_tlv = tlv_end
+                .checked_add(3)
+                .map(|end| end & !3)
+                .ok_or(crate::DriverError::Protocol)?;
+            if next_tlv > fw_data.len() {
+                return Err(crate::DriverError::Protocol);
             }
 
             match tlv_type {
@@ -1232,6 +1245,22 @@ impl IwlWifiDevice {
                             core::ptr::read_unaligned(fw_ptr.add(tlv_data_off) as *const u32)
                         };
                         log::info!("iwlwifi: firmware.phy_sku config={:#010x}", self.phy_config,);
+                    }
+                }
+                TLV_API_CHANGES_SET => {
+                    if tlv_len == 8 {
+                        let api_index: u32 = unsafe {
+                            core::ptr::read_unaligned(fw_ptr.add(tlv_data_off) as *const u32)
+                        };
+                        let api_flags: u32 = unsafe {
+                            core::ptr::read_unaligned(fw_ptr.add(tlv_data_off + 4) as *const u32)
+                        };
+                        log::info!(
+                            "iwlwifi: firmware.api_changes api_index={} bitmap={:#010x} tkip_mic_keys={}",
+                            api_index,
+                            api_flags,
+                            api_index == 0 && api_flags & (1 << 29) != 0,
+                        );
                     }
                 }
                 TLV_ENABLED_CAPABILITIES => {
@@ -1290,11 +1319,11 @@ impl IwlWifiDevice {
                         FirmwareImage::Runtime => TLV_SEC_RT,
                     };
                     if tlv_type != wanted {
-                        off = tlv_end;
+                        off = next_tlv;
                         continue;
                     }
                     if tlv_len < 4 {
-                        off = tlv_end;
+                        off = next_tlv;
                         continue;
                     }
                     let target: u32 = unsafe {
@@ -1303,7 +1332,7 @@ impl IwlWifiDevice {
                     if target == FW_CPU1_CPU2_SEPARATOR_SECTION
                         || target == FW_PAGING_SEPARATOR_SECTION
                     {
-                        off = tlv_end;
+                        off = next_tlv;
                         continue;
                     }
                     let data_size = tlv_len - 4;
@@ -1343,7 +1372,7 @@ impl IwlWifiDevice {
                 }
                 _ => {}
             }
-            off = tlv_end.saturating_add(3) & !3;
+            off = next_tlv;
         }
 
         if section_count == 0 {

--- a/nitrogen/src/iwlwifi/device.rs
+++ b/nitrogen/src/iwlwifi/device.rs
@@ -1248,10 +1248,16 @@ impl IwlWifiDevice {
                     }
                 }
                 TLV_API_CHANGES_SET => {
-                    if tlv_len == 8 {
-                        let api_index: u32 = unsafe {
-                            core::ptr::read_unaligned(fw_ptr.add(tlv_data_off) as *const u32)
-                        };
+                    if tlv_len != 8 {
+                        return Err(crate::DriverError::Protocol);
+                    }
+                    let api_index: u32 = unsafe {
+                        core::ptr::read_unaligned(fw_ptr.add(tlv_data_off) as *const u32)
+                    };
+                    // Linux exposes 69 API bits, represented as three u32
+                    // entries in the firmware bitmap.
+                    const API_BITMAP_ENTRIES: u32 = 3;
+                    if api_index < API_BITMAP_ENTRIES {
                         let api_flags: u32 = unsafe {
                             core::ptr::read_unaligned(fw_ptr.add(tlv_data_off + 4) as *const u32)
                         };

--- a/nitrogen/src/iwlwifi/firmware.rs
+++ b/nitrogen/src/iwlwifi/firmware.rs
@@ -4,14 +4,14 @@ use super::device::IwlWifiDevice;
 use super::registers::*;
 use super::types::{FirmwareBlob, FirmwareProfile};
 
-// Keep the firmware source aligned with Linux's canonical linux-firmware
-// repository.  The repository stores Intel firmware below intel/iwlwifi/.
+// Keep the default firmware source aligned with the tracked linux-firmware
+// submodule. A build-time override is available for hardware experiments so
+// replacing a local firmware blob does not dirty or advance the submodule.
 const FW_7260_17: &[u8] =
     include_bytes!("../../../bonder/iwlwifi/intel/iwlwifi/iwlwifi-7260-17.ucode");
 const FW_7265_17: &[u8] =
     include_bytes!("../../../bonder/iwlwifi/intel/iwlwifi/iwlwifi-7265-17.ucode");
-const FW_7265D_29: &[u8] =
-    include_bytes!("../../../bonder/iwlwifi/intel/iwlwifi/iwlwifi-7265D-29.ucode");
+const FW_7265D_29: &[u8] = include_bytes!(env!("FULLERENE_IWLWIFI_7265D_FW"));
 
 /// Select firmware using the raw CSR_HW_REV value, before the type field is
 /// shifted for display.  The 7265 and 7265D share PCI IDs, so this distinction

--- a/nitrogen/src/iwlwifi/registers.rs
+++ b/nitrogen/src/iwlwifi/registers.rs
@@ -404,6 +404,8 @@ pub const TLV_SEC_INIT: u32 = 20;
 pub const TLV_SEC_WOWLAN: u32 = 21;
 pub const TLV_DEF_CALIB: u32 = 22;
 pub const TLV_PHY_SKU: u32 = 23;
+/// Firmware API-change bitmap entries (`api_index`, `api_flags`).
+pub const TLV_API_CHANGES_SET: u32 = 29;
 /// Firmware capability bitmap entries (`api_index`, `api_capa`).
 pub const TLV_ENABLED_CAPABILITIES: u32 = 30;
 /// Firmware TLVs containing the runtime/init error-log SRAM addresses.

--- a/nitrogen/src/iwlwifi/tx.rs
+++ b/nitrogen/src/iwlwifi/tx.rs
@@ -22,6 +22,12 @@ const IWL_FIRST_TB_SIZE: usize = 20;
 // and SCD_QUEUE_CFG lets firmware configure the dynamic queue.
 const DQA_HOST_DIRECT_SCD_DIAGNOSTIC: bool = false;
 
+// Linux's gen1 DQA path does not set SCD_EN_CTRL for a dynamically allocated
+// data queue. The old API-29 workaround did not move q5's read pointer on the
+// affected 7265D and prevented a clean upstream-equivalent A/B run. Keep the
+// switch explicit so the old behavior can be re-enabled for one hardware run.
+const API29_DQA_HOST_SCD_GATE_DIAGNOSTIC: bool = false;
+
 // Legacy 7265 management/data frames use the API-v6 TX command.  A 1 Mbps
 // CCK rate is valid for the 2.4 GHz management exchange used by this driver;
 // the firmware command wrapper is the important part here, since placing the
@@ -516,28 +522,43 @@ impl IwlWifiDevice {
         Ok(())
     }
 
-    /// Restore the API-29 DQA scheduler gate after firmware has configured a
-    /// queue through SCD_QUEUE_CFG and ADD_STA_QUEUE.
+    /// Optionally restore the old API-29 DQA scheduler gate after firmware has
+    /// configured a queue through SCD_QUEUE_CFG and ADD_STA_QUEUE.
     ///
     /// Linux does not issue a second zero-pointer doorbell at this point: the
     /// first post-configuration doorbell is the TFD's actual write pointer.
-    /// The API-29 7265D image still needs q5 in SCD_EN_CTRL, however; without
-    /// that bit its FH TRB remains zero even though SCD_QUEUE_STATUS is active.
-    /// Keep this firmware quirk separate from the doorbell so the normal DQA
-    /// pointer sequence remains Linux-compatible.
+    /// This is intentionally disabled for the Linux-compatible A/B experiment:
+    /// upstream leaves activation of firmware-owned DQA queues to firmware.
+    /// Keep the diagnostic switch separate from the doorbell so either result
+    /// can be identified without changing the pointer sequence.
     pub(super) fn ensure_api29_dqa_scheduler_gate(&mut self, queue: u32) {
         if self.fw_dqa_supported && self.fw_api_ver == IWL_FW_API29_MAX {
-            let scd_en = self.read_prph(SCD_EN_CTRL).unwrap_or(0);
-            self.write_prph(SCD_EN_CTRL, scd_en | (1 << queue));
+            let before = self.read_prph(SCD_EN_CTRL).unwrap_or(!0);
+            if API29_DQA_HOST_SCD_GATE_DIAGNOSTIC {
+                self.write_prph(SCD_EN_CTRL, before | (1 << queue));
+            }
+            let after = self.read_prph(SCD_EN_CTRL).unwrap_or(!0);
+            log::info!(
+                "iwlwifi: API29 DQA host SCD gate queue={} enabled={} scd_en_before={:#010x} scd_en_after={:#010x} qbit={}",
+                queue,
+                API29_DQA_HOST_SCD_GATE_DIAGNOSTIC,
+                before,
+                after,
+                if after & (1 << queue) != 0 {
+                    "SET"
+                } else {
+                    "CLEAR"
+                },
+            );
         }
     }
 
     /// Abandon a stalled traffic queue before switching to another queue.
     /// This is only called after the watchdog observed no scheduler progress;
     /// clearing the queue prevents its old TFD from racing the fallback.
-    /// API-29 DQA normally adds the traffic queue to SCD_EN_CTRL as a local
-    /// compatibility workaround, so release that extra gate here. The rest
-    /// of the queue teardown follows Linux's gen1 txq_disable sequence:
+    /// A diagnostic run may have added the traffic queue to SCD_EN_CTRL as a
+    /// local compatibility workaround, so release that extra gate here. The
+    /// rest of the queue teardown follows Linux's gen1 txq_disable sequence:
     /// deactivate the queue and clear its scheduler status entry. In
     /// particular, do not ring a zero write pointer while disabling a queue;
     /// that is a new doorbell, not a teardown operation, and can race the
@@ -2252,6 +2273,31 @@ impl IwlWifiDevice {
                     .read_prph(scd_queue_status(traffic_queue))
                     .unwrap_or(!0);
                 let fifo = scd_status & 0x7;
+                let scd_en = self.read_prph(SCD_EN_CTRL).unwrap_or(!0);
+                let scd_gp = self.read_prph(SCD_GP_CTRL).unwrap_or(!0);
+                let scd_chain = self.read_prph(SCD_QUEUECHAIN_SEL).unwrap_or(!0);
+                let scd_aggr = self.read_prph(SCD_AGGR_SEL).unwrap_or(!0);
+                let scd_base = self.alive_scd_base_addr;
+                let ctx0 = self
+                    .read_mem32(scd_base + scd_context_queue(traffic_queue))
+                    .unwrap_or(!0);
+                let ctx1 = self
+                    .read_mem32(scd_base + scd_context_queue(traffic_queue) + 4)
+                    .unwrap_or(!0);
+                let trans_tbl = self
+                    .read_mem32(scd_base + scd_trans_tbl_offset_queue(traffic_queue))
+                    .unwrap_or(!0);
+                let tx_stts = self
+                    .read_mem32(scd_base + scd_tx_stts_queue_offset(traffic_queue))
+                    .unwrap_or(!0);
+                let cbbc = self
+                    .safe_read32(fh_mem_cbbc_queue(traffic_queue))
+                    .unwrap_or(!0);
+                let station_queue_mask = if self.fw_dqa_supported {
+                    1u32 << traffic_queue
+                } else {
+                    1u32 << IWL_DATA_QUEUE
+                };
                 let byte_count_addr = self.tx_dma_ring.dma_iova()
                     + TX_SCD_BC_OFFSET as u64
                     + traffic_queue as u64 * (256 + 64) * 2
@@ -2280,7 +2326,7 @@ impl IwlWifiDevice {
                     + (256 + desc_idx) * 2) as *const u16;
                 let bc_duplicate = unsafe { core::ptr::read_volatile(bc_dup_ptr) };
                 log::info!(
-                    "iwlwifi: TX management submitted queue={} slot={} frame={} wire={} bc_dwords={} bc_addr={:#018x} tbs={} tb0={} tb1={} tb2={} scratch={:#018x} sw_wrptr={} hw_wrptr={:#010x} rptr={:#010x} status={:#010x} fifo={} fifo_cfg={:#010x} fifo_credit={:#010x} fifo_buf={:#010x} scd_dram={:#010x} scd_txfact={:#010x} fh_tx_trb={:#010x} tx_status={:#010x} tx_error={:#010x} gp_cntrl={:#010x} gp1={:#010x}",
+                    "iwlwifi: TX management submitted queue={} slot={} frame={} wire={} bc_dwords={} bc_addr={:#018x} tbs={} tb0={} tb1={} tb2={} scratch={:#018x} sta_queue_mask={:#010x} cbbc={:#010x} sw_wrptr={} hw_wrptr={:#010x} rptr={:#010x} status={:#010x} fifo={} fifo_cfg={:#010x} fifo_credit={:#010x} fifo_buf={:#010x} scd_en={:#010x} scd_gp={:#010x} qchain={:#010x} aggr={:#010x} ctx0={:#010x} ctx1={:#010x} trans_tbl={:#010x} tx_stts={:#010x} scd_dram={:#010x} scd_txfact={:#010x} fh_tx_trb={:#010x} tx_status={:#010x} tx_error={:#010x} gp_cntrl={:#010x} gp1={:#010x}",
                     traffic_queue,
                     desc_idx,
                     tx_frame.len(),
@@ -2292,6 +2338,8 @@ impl IwlWifiDevice {
                     tb1_len,
                     tb2_len,
                     scratch_dma,
+                    station_queue_mask,
+                    cbbc,
                     self.tx_data_head & 0xff,
                     scd_wrptr & 0xff,
                     scd_rptr,
@@ -2303,6 +2351,14 @@ impl IwlWifiDevice {
                         .unwrap_or(!0),
                     self.safe_read32(FH_TCSR_CHNL_TX_BUF_STS_BASE + fifo * (0x20 / 4))
                         .unwrap_or(!0),
+                    scd_en,
+                    scd_gp,
+                    scd_chain,
+                    scd_aggr,
+                    ctx0,
+                    ctx1,
+                    trans_tbl,
+                    tx_stts,
                     self.read_prph(SCD_DRAM_BASE_ADDR).unwrap_or(!0),
                     self.read_prph(SCD_TXFACT).unwrap_or(!0),
                     self.safe_read32(fh_tx_trb_channel(fifo)).unwrap_or(!0),
@@ -2765,7 +2821,7 @@ mod tests {
     }
 
     #[test]
-    fn api29_dqa_gate_does_not_issue_a_zero_pointer_doorbell() {
+    fn api29_dqa_gate_is_linux_owned_by_default() {
         let mut device = IwlWifiDevice::new_for_test([0x02, 0, 0, 0, 0, 1]);
         device.fw_dqa_supported = true;
         device.fw_api_ver = IWL_FW_API29_MAX;
@@ -2774,10 +2830,7 @@ mod tests {
 
         device.ensure_api29_dqa_scheduler_gate(IWL_MGMT_QUEUE);
 
-        assert_eq!(
-            device.safe_read32(HBUS_TARG_PRPH_WDAT),
-            Some((1 << IWL_DQA_CMD_QUEUE) | (1 << IWL_MGMT_QUEUE))
-        );
+        assert_eq!(device.safe_read32(HBUS_TARG_PRPH_WDAT), Some(0));
         assert_eq!(device.safe_read32(HBUS_TARG_WRPTR), Some(0x1234_5678));
     }
 

--- a/nitrogen/src/iwlwifi/tx.rs
+++ b/nitrogen/src/iwlwifi/tx.rs
@@ -2296,18 +2296,20 @@ impl IwlWifiDevice {
                 let scd_gp = self.read_prph(SCD_GP_CTRL).unwrap_or(!0);
                 let scd_chain = self.read_prph(SCD_QUEUECHAIN_SEL).unwrap_or(!0);
                 let scd_base = self.alive_scd_base_addr;
-                let ctx0 = self
-                    .read_mem32(scd_base + scd_context_queue(traffic_queue))
-                    .unwrap_or(!0);
-                let ctx1 = self
-                    .read_mem32(scd_base + scd_context_queue(traffic_queue) + 4)
-                    .unwrap_or(!0);
-                let trans_tbl = self
-                    .read_mem32(scd_base + scd_trans_tbl_offset_queue(traffic_queue))
-                    .unwrap_or(!0);
-                let tx_stts = self
-                    .read_mem32(scd_base + scd_tx_stts_queue_offset(traffic_queue))
-                    .unwrap_or(!0);
+                let (ctx0, ctx1, trans_tbl, tx_stts) = if scd_base != 0 {
+                    (
+                        self.read_mem32(scd_base + scd_context_queue(traffic_queue))
+                            .unwrap_or(!0),
+                        self.read_mem32(scd_base + scd_context_queue(traffic_queue) + 4)
+                            .unwrap_or(!0),
+                        self.read_mem32(scd_base + scd_trans_tbl_offset_queue(traffic_queue))
+                            .unwrap_or(!0),
+                        self.read_mem32(scd_base + scd_tx_stts_queue_offset(traffic_queue))
+                            .unwrap_or(!0),
+                    )
+                } else {
+                    (!0, !0, !0, !0)
+                };
                 let cbbc = self
                     .safe_read32(fh_mem_cbbc_queue(traffic_queue))
                     .unwrap_or(!0);

--- a/nitrogen/src/iwlwifi/tx.rs
+++ b/nitrogen/src/iwlwifi/tx.rs
@@ -1028,6 +1028,19 @@ impl IwlWifiDevice {
         }
         let command_queue = self.command_queue();
         let sequence = ((command_queue as u16) << 8) | (self.tx_head as u16 & 0xff);
+        if matches!(
+            label,
+            "CONNECT_ADD_STA" | "CONNECT_SCD_QUEUE_CFG" | "CONNECT_ADD_STA_QUEUE"
+        ) {
+            log::info!(
+                "iwlwifi: hcmd.sync.submit name={} opcode=0x{:02x} group=0x{:02x} payload_len={} payload_hex={}",
+                label,
+                opcode,
+                group,
+                data.len(),
+                HexBytes(data),
+            );
+        }
         self.send_hcmd(opcode, group, data)?;
         let target = self.tx_head;
         let consumed = crate::timing::poll_timeout_us(100_000, || {
@@ -2239,21 +2252,27 @@ impl IwlWifiDevice {
             }
             mmio::cache_flush(desc as *const TxDmaDesc as usize);
 
-            // The legacy SCD does not derive an MPDU's airtime length from
-            // the TFD. Linux publishes a separate byte-count entry before
-            // ringing the queue doorbell; a zero entry leaves a valid TFD
-            // permanently unfetched. The 7265 is a pre-9000 gen1 device and
-            // Gen1's SCD table records the 802.11 payload plus CRC/delimiter
-            // and, for CCMP, the firmware-appended MIC in DWORDs on the
-            // 7000-series transport used by the 7265.
+            // The legacy SCD uses the byte-count table only for
+            // Scheduler-ACK/aggregate queues. Linux configures the 7265
+            // management queue as FIFO/non-aggregate, so Q5 must not be
+            // treated as a Scheduler-ACK queue merely because a byte-count
+            // table exists in the shared TX DMA allocation. Keep the table
+            // writer available for aggregate data queues, but make this
+            // distinction explicit for the Q5 A/B experiment.
             let sec_ctl = wire[TX_COMMAND_HEADER_LEN + 17];
-            let byte_count_entry = self.update_scd_byte_count(
-                traffic_queue,
-                desc_idx,
-                tx_frame.len() as u16,
-                0,
-                sec_ctl,
-            );
+            let scd_aggr = self.read_prph(SCD_AGGR_SEL).unwrap_or(!0);
+            let scheduler_ack = (scd_aggr & (1 << traffic_queue)) != 0;
+            let byte_count_entry = if scheduler_ack {
+                self.update_scd_byte_count(
+                    traffic_queue,
+                    desc_idx,
+                    tx_frame.len() as u16,
+                    0,
+                    sec_ctl,
+                )
+            } else {
+                0
+            };
 
             self.tx_data_head = self.tx_data_head.wrapping_add(1);
             let handshake_frame = tx_frame.len() >= 2 && matches!(tx_frame[0] & 0xfc, 0xb0 | 0x00);
@@ -2276,7 +2295,6 @@ impl IwlWifiDevice {
                 let scd_en = self.read_prph(SCD_EN_CTRL).unwrap_or(!0);
                 let scd_gp = self.read_prph(SCD_GP_CTRL).unwrap_or(!0);
                 let scd_chain = self.read_prph(SCD_QUEUECHAIN_SEL).unwrap_or(!0);
-                let scd_aggr = self.read_prph(SCD_AGGR_SEL).unwrap_or(!0);
                 let scd_base = self.alive_scd_base_addr;
                 let ctx0 = self
                     .read_mem32(scd_base + scd_context_queue(traffic_queue))
@@ -2325,12 +2343,34 @@ impl IwlWifiDevice {
                     + traffic_queue as usize * (256 + 64) * 2
                     + (256 + desc_idx) * 2) as *const u16;
                 let bc_duplicate = unsafe { core::ptr::read_volatile(bc_dup_ptr) };
+                // Linux derives the initial DQA SSN from the 802.11 header
+                // before calling iwl_trans_txq_enable_cfg().  Fullerene
+                // currently sends SSN=0 in SCD_QUEUE_CFG and lets the TX
+                // command firmware assign the management sequence; expose
+                // both values before considering an SSN change.
+                let frame_seq_ctrl = if tx_frame.len() >= 24 {
+                    u16::from_le_bytes([tx_frame[22], tx_frame[23]])
+                } else {
+                    u16::MAX
+                };
+                let frame_ssn = if frame_seq_ctrl == u16::MAX {
+                    u16::MAX
+                } else {
+                    (frame_seq_ctrl >> 4) & 0x0fff
+                };
                 log::info!(
-                    "iwlwifi: TX management submitted queue={} slot={} frame={} wire={} bc_dwords={} bc_addr={:#018x} tbs={} tb0={} tb1={} tb2={} scratch={:#018x} sta_queue_mask={:#010x} cbbc={:#010x} sw_wrptr={} hw_wrptr={:#010x} rptr={:#010x} status={:#010x} fifo={} fifo_cfg={:#010x} fifo_credit={:#010x} fifo_buf={:#010x} scd_en={:#010x} scd_gp={:#010x} qchain={:#010x} aggr={:#010x} ctx0={:#010x} ctx1={:#010x} trans_tbl={:#010x} tx_stts={:#010x} scd_dram={:#010x} scd_txfact={:#010x} fh_tx_trb={:#010x} tx_status={:#010x} tx_error={:#010x} gp_cntrl={:#010x} gp1={:#010x}",
+                    "iwlwifi: TX management submitted queue={} slot={} frame={} wire={} frame_seq_ctrl={:#06x} frame_ssn={} bc_mode={} bc_dwords={} bc_addr={:#018x} tbs={} tb0={} tb1={} tb2={} scratch={:#018x} sta_queue_mask={:#010x} cbbc={:#010x} sw_wrptr={} hw_wrptr={:#010x} rptr={:#010x} status={:#010x} fifo={} fifo_cfg={:#010x} fifo_credit={:#010x} fifo_buf={:#010x} scd_en={:#010x} scd_gp={:#010x} qchain={:#010x} aggr={:#010x} ctx0={:#010x} ctx1={:#010x} trans_tbl={:#010x} tx_stts={:#010x} scd_dram={:#010x} scd_txfact={:#010x} fh_tx_trb={:#010x} tx_status={:#010x} tx_error={:#010x} gp_cntrl={:#010x} gp1={:#010x}",
                     traffic_queue,
                     desc_idx,
                     tx_frame.len(),
                     wire.len(),
+                    frame_seq_ctrl,
+                    frame_ssn,
+                    if scheduler_ack {
+                        "scheduler-ack"
+                    } else {
+                        "fifo"
+                    },
                     byte_count_entry & 0x0fff,
                     byte_count_addr,
                     desc.num_tbs,
@@ -2776,10 +2816,12 @@ mod tests {
         let primary = unsafe { core::ptr::read_unaligned(byte_count_base as *const u16) };
         let duplicate =
             unsafe { core::ptr::read_unaligned((byte_count_base + 256 * 2) as *const u16) };
-        // 7265's 7000-series gen1 table stores DWORDs: ceil((30 + CRC +
-        // delimiter) / 4) = 10.
-        assert_eq!(u16::from_le(primary), 10);
-        assert_eq!(u16::from_le(duplicate), 10);
+        // Q5 is Linux's FIFO/non-aggregate management queue, so the
+        // Scheduler-ACK byte-count table is intentionally untouched by the
+        // submit path. The table writer itself is covered below for the
+        // aggregate/Scheduler-ACK path.
+        assert_eq!(u16::from_le(primary), 0);
+        assert_eq!(u16::from_le(duplicate), 0);
     }
 
     #[test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting a local Intel Wi-Fi 7265D firmware file during ISO-only builds.
  * Added clearer firmware API-change reporting and expanded Wi-Fi connection and transmission diagnostics.
* **Bug Fixes**
  * Improved firmware metadata parsing by detecting truncated, misaligned, or overflowing records.
  * Corrected queue byte-count handling for management traffic.
  * Disabled the API-29 scheduler-control write by default while retaining optional diagnostic support.
* **Documentation**
  * Documented local firmware overrides, architecture behavior, and troubleshooting findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->